### PR TITLE
ci: fix Inno Setup 6 compatibility - remove UseLongPathNames

### DIFF
--- a/installer/windows/ritemark.iss
+++ b/installer/windows/ritemark.iss
@@ -39,7 +39,7 @@ MinVersion=10.0
 ArchitecturesAllowed=x64compatible
 ArchitecturesInstallIn64BitMode=x64compatible
 ; Handle long paths (node_modules has deeply nested paths >260 chars)
-UseLongPathNames=yes
+; UseLongPathNames=yes  ; Requires Inno Setup 7, windows-latest has IS6
 ; Mutex to prevent running during install
 AppMutex={#AppMutex}
 ; Don't require admin by default (user install)


### PR DESCRIPTION
Comment out UseLongPathNames=yes directive which requires Inno Setup 7.
GitHub Actions windows-latest runners have Inno Setup 6.

https://claude.ai/code/session_01AqV7Y1FUG5oKCh4GbwEwQK