### PR TITLE
fix: add patches 012 and 013 with correct line numbers

### DIFF
--- a/patches/vscode/012-hide-vscode-walkthroughs.patch
+++ b/patches/vscode/012-hide-vscode-walkthroughs.patch
@@ -1,0 +1,36 @@
+diff --git a/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts b/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
+--- a/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
++++ b/src/vs/workbench/contrib/welcomeGettingStarted/common/gettingStartedContent.ts
+@@ -208,12 +208,13 @@ type GettingStartedWalkthroughContent = GettingStartedWalkthrough[];
+
+ const Button = (title: string, href: string) => `[${title}](${href})`;
+
++// RiteMark: Hide VS Code default walkthroughs - only show extension walkthroughs
+ export const walkthroughs: GettingStartedWalkthroughContent = [
+ 	{
+ 		id: 'Setup',
+ 		title: localize('gettingStarted.setup.title', "Get Started with VS Code"),
+ 		description: localize('gettingStarted.setup.description', "Customize your editor, learn the basics, and start coding"),
+-		isFeatured: true,
++		isFeatured: false, // RiteMark: changed from true
+ 		icon: setupIcon,
+ 		when: '!isWeb',
+ 		next: 'Beginner',
+@@ -313,7 +314,7 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
+ 		id: 'SetupWeb',
+ 		title: localize('gettingStarted.setupWeb.title', "Get Started with VS Code for the Web"),
+ 		description: localize('gettingStarted.setupWeb.description', "Customize your editor, learn the basics, and start coding"),
+-		isFeatured: true,
++		isFeatured: false, // RiteMark: changed from true
+ 		icon: setupIcon,
+ 		when: 'isWeb',
+ 		next: 'Beginner',
+@@ -398,7 +399,7 @@ export const walkthroughs: GettingStartedWalkthroughContent = [
+ 		id: 'SetupAccessibility',
+ 		title: localize('gettingStarted.setupAccessibility.title', "Get Started with Accessibility Features"),
+ 		description: localize('gettingStarted.setupAccessibility.description', "Learn the tools and shortcuts that make VS Code accessible. Note that some actions are not actionable from within the context of the walkthrough."),
+-		isFeatured: true,
++		isFeatured: false, // RiteMark: changed from true
+ 		icon: setupIcon,
+ 		when: CONTEXT_ACCESSIBILITY_MODE_ENABLED.key,
+ 		next: 'Setup',

--- a/patches/vscode/013-default-light-theme.patch
+++ b/patches/vscode/013-default-light-theme.patch
@@ -1,0 +1,18 @@
+diff --git a/src/vs/workbench/services/themes/common/themeConfiguration.ts b/src/vs/workbench/services/themes/common/themeConfiguration.ts
+--- a/src/vs/workbench/services/themes/common/themeConfiguration.ts
++++ b/src/vs/workbench/services/themes/common/themeConfiguration.ts
+@@ -15,7 +15,6 @@ import { ThemeSettings, IWorkbenchColorTheme, IWorkbenchFileIconTheme, IColorCus
+ import { IConfigurationService, ConfigurationTarget } from '../../../../platform/configuration/common/configuration.js';
+-import { isWeb } from '../../../../base/common/platform.js';
+ import { ColorScheme } from '../../../../platform/theme/common/theme.js';
+ import { IHostColorSchemeService } from './hostColorSchemeService.js';
+
+@@ -36,7 +35,7 @@ const colorThemeSettingEnumDescriptions: string[] = [];
+ const colorThemeSettingSchema: IConfigurationPropertySchema = {
+ 	type: 'string',
+ 	markdownDescription: nls.localize({ key: 'colorTheme', comment: ['{0} will become a link to another setting.'] }, "Specifies the color theme used in the workbench when {0} is not enabled.", formatSettingAsLink(ThemeSettings.DETECT_COLOR_SCHEME)),
+-	default: isWeb ? ThemeSettingDefaults.COLOR_THEME_LIGHT : ThemeSettingDefaults.COLOR_THEME_DARK,
++	default: ThemeSettingDefaults.COLOR_THEME_LIGHT, // RiteMark: Always default to light theme
+ 	tags: [COLOR_THEME_CONFIGURATION_SETTINGS_TAG],
+ 	enum: colorThemeSettingEnum,
+ 	enumDescriptions: colorThemeSettingEnumDescriptions,


### PR DESCRIPTION
Adds two VS Code patches from fix/windows-minor-issues branch:

1. 012-hide-vscode-walkthroughs.patch
   - Hides VS Code default walkthroughs (show RiteMark first)
   - Sets isFeatured: false for Setup, SetupWeb, SetupAccessibility

2. 013-default-light-theme.patch
   - Removes unused isWeb import (fixes build error: '$r' declared but never read)
   - Always defaults to light theme instead of platform-dependent
   - Corrected line numbers for VS Code 1.94.0

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

https://claude.ai/code/session_017f5aaQbHtTbmdDkKZFt7mg