### PR TITLE
fix: harden Windows CI build for VS Code 1.109.5

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -52,11 +52,8 @@ jobs:
         shell: bash
         working-directory: r/vscode
         env:
-          npm_config_disturl: https://electronjs.org/headers
-          npm_config_target: 30.5.1
-          npm_config_runtime: electron
-          npm_config_build_from_source: true
           ELECTRON_SKIP_BINARY_DOWNLOAD: 1
+          PLAYWRIGHT_SKIP_BROWSER_DOWNLOAD: 1
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           success=0
@@ -93,6 +90,13 @@ jobs:
             echo "Kept only: $(ls $SDK_VENDOR/ripgrep/)"
           fi
 
+      - name: Remove conflicting files before patching
+        shell: bash
+        working-directory: r/vscode
+        run: |
+          # gettingStartedGuide.css exists in VS Code 1.109.5 but patch 001 creates it from scratch
+          rm -f src/vs/workbench/contrib/welcomeGettingStarted/browser/media/gettingStartedGuide.css 2>/dev/null || true
+
       - name: Apply patches
         shell: bash
         working-directory: r
@@ -103,14 +107,24 @@ jobs:
         working-directory: r/vscode/extensions/ritemark
         run: npm run compile
 
+      - name: Clean webview dev files before build
+        shell: bash
+        working-directory: r/vscode/extensions/ritemark
+        run: |
+          rm -rf webview/node_modules 2>/dev/null || true
+          rm -rf webview/src 2>/dev/null || true
+          echo "Cleaned webview dev files (prevents EMFILE during bundling)"
+
       - name: Build VS Code (win32-x64-min)
         shell: bash
         working-directory: r/vscode
+        env:
+          NODE_OPTIONS: --max-old-space-size=8192
         run: |
           LOG_FILE="../windows-build.log"
           : > "$LOG_FILE"
           echo "Starting Windows build at $(date)" | tee -a "$LOG_FILE"
-          npm run gulp vscode-win32-x64-min \
+          npx gulp vscode-win32-x64-min \
             > >(tee -a "$LOG_FILE") \
             2> >(tee -a "$LOG_FILE" >&2) &
           BUILD_PID=$!

--- a/branding/product.json
+++ b/branding/product.json
@@ -26,6 +26,10 @@
   "licenseFileName": "LICENSE",
   "reportIssueUrl": "https://github.com/jarmo-productory/ritemark-native/issues/new",
   "urlProtocol": "ritemark",
+  "win32ContextMenu": {
+    "x64": { "clsid": "{633A4994-E129-4F03-ABF3-97D6595BACD5}" },
+    "arm64": { "clsid": "{AD4E33B5-32F9-4C02-A8E4-CAD8AE146101}" }
+  },
   "quality": "stable",
   "extensionsGallery": {
     "serviceUrl": "https://marketplace.visualstudio.com/_apis/public/gallery",


### PR DESCRIPTION
## Summary
- Add `win32ContextMenu` CLSIDs to product.json (required by 1.109.5 packaging)
- Remove `gettingStartedGuide.css` before patching (file now ships with VS Code)
- Clean webview dev files before build (prevents EMFILE) and set 8GB heap limit
- Remove stale Electron target env vars (`.npmrc` handles this)

Discovered during local Windows build testing.

## Test plan
- [ ] Trigger `workflow_dispatch` on main after merge
- [ ] Verify CI build completes and produces `ritemark-windows-x64` artifact