### PR TITLE
Sprint 45: harden Claude and Codex agent lifecycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,6 +14,16 @@ This file configures Codex behavior for `ritemark-native`. It is additive to the
 - For release work, also use the `release-process` skill and run `./scripts/release-preflight.sh` before version bumps, tags, or build/distribution steps.
 - Keep sprint documentation under `docs/development/sprints/` aligned with implementation when the task is part of an explicit sprint.
 
+### Hard Gates
+
+- Do not develop on `main`. `main` is not a development branch.
+- If the current branch is `main`, do not write implementation code until a dedicated feature branch exists for the sprint.
+- Do not start implementation work before there is an explicit sprint.
+- Use the `sprint-workflow` skill to create or update the sprint before writing code.
+- A sprint may require an audit or research pass before implementation starts. Do that first when the scope is unclear, cross-cutting, or recovery/debugging heavy.
+- Treat each sprint as one feature branch. Do not mix multiple sprint implementations on the same branch.
+- If no sprint exists yet, stop at sprint setup, audit, and planning. Do not proceed into code changes in the same step as if the sprint already existed.
+
 ### Skill Routing
 
 - Use `vscode-development` for VS Code OSS builds, extension activation/loading, patch application, upstream updates, Node/toolchain issues, and `scripts/code.sh` or production build problems.

--- a/docs/development/analysis/2026-03-17-agent-lifecycle-planmode-analysis.md
+++ b/docs/development/analysis/2026-03-17-agent-lifecycle-planmode-analysis.md
@@ -1,0 +1,398 @@
+# Agent Lifecycle Analysis: AskUserQuestion, Plan Mode, Dev Mode
+
+Date: 2026-03-17
+Repo: `ritemark-native`
+Scope: Claude agent sidebar, Codex sidebar, extension <-> webview interaction lifecycle
+
+## Goal
+
+Make the full agent lifecycle reliable:
+
+1. normal execution in dev mode
+2. enter plan mode
+3. ask clarifying questions while planning
+4. update/render plan state clearly
+5. approve or reject the plan
+6. exit plan mode correctly
+7. continue execution in the same turn
+
+This document is intentionally written before the final fix is completed, so the target lifecycle is explicit and reviewable first.
+
+## Executive Summary
+
+There are two different problems, not one:
+
+1. Claude support is mostly present in the SDK and partly present in our UI, but our integration breaks the lifecycle in the middle.
+2. Codex capability is split between what the current CLI can expose and what Ritemark currently consumes. Our checked-in app-server protocol layer is a simplified, outdated subset, so the current "capability gap" is partly an integration gap, not purely a dependency limitation.
+
+The current Claude integration has three architectural mistakes:
+
+1. `AskUserQuestion` UI exists in the webview, but nothing emits the event that would render it.
+2. Plan approval is modeled as "send a new follow-up prompt", but Claude plan approval is actually a response to a pending `ExitPlanMode` tool call.
+3. Plan text is inferred from generic `thinking` snippets instead of being tracked as explicit plan-mode state.
+
+The practical consequence is the bug seen in the sidebar:
+
+- the agent can show a plan-like result
+- the user can click `Approve plan`
+- but Claude may still remain in plan mode because we answered with a new prompt instead of resolving the pending `ExitPlanMode` transition
+
+## What The Current Code Does
+
+### Claude
+
+Relevant files:
+
+- `extensions/ritemark/src/agent/AgentRunner.ts`
+- `extensions/ritemark/src/agent/types.ts`
+- `extensions/ritemark/src/views/UnifiedViewProvider.ts`
+- `extensions/ritemark/webview/src/components/ai-sidebar/store.ts`
+- `extensions/ritemark/webview/src/components/ai-sidebar/AgentView.tsx`
+- `extensions/ritemark/webview/src/components/ai-sidebar/AgentResponse.tsx`
+- `extensions/ritemark/webview/src/components/ai-sidebar/AgentQuestion.tsx`
+
+Observed behavior before the final fix:
+
+1. Claude assistant messages are streamed and reduced to generic `agent-progress`.
+2. `EnterPlanMode` and `ExitPlanMode` are only recognized as progress markers.
+3. `AgentQuestion.tsx` exists but is effectively dead code because no extension message renders it.
+4. Plan review UI appears after a turn result and is handled by sending a new prompt like `Plan approved. Proceed with implementation.`
+
+This is the wrong lifecycle for Claude plan mode.
+
+### Codex
+
+Relevant files:
+
+- `extensions/ritemark/src/codex/codexProtocol.ts`
+- `extensions/ritemark/src/codex/codexAppServer.ts`
+- `extensions/ritemark/src/views/UnifiedViewProvider.ts`
+- `extensions/ritemark/webview/src/components/ai-sidebar/CodexView.tsx`
+
+Observed behavior in the checked-in Ritemark integration:
+
+1. Our local `codexProtocol.ts` only models turn start/completion, streamed deltas, item start/completion, and approvals.
+2. We already surface command/file approvals correctly.
+3. The current integration uses `experimentalRawEvents: false`.
+4. We do not currently consume typed Codex events for question input or plan updates anywhere in Ritemark.
+
+Important correction from a fresh audit on 2026-03-18:
+
+1. The installed Codex CLI is `0.114.0`, while `codexProtocol.ts` in this repo is labeled as a simplified snapshot generated from `v0.106.0`.
+2. Running `codex app-server generate-ts --out <tmpdir>` on the local CLI produced richer types than Ritemark currently checks in.
+3. The generated protocol includes:
+   - server request `item/tool/requestUserInput`
+   - notification `turn/plan/updated`
+   - notification `item/plan/delta`
+   - MCP-related notifications and requests
+4. This means the current Codex limitation in Ritemark is not "the dependency definitely cannot do it". It is "our checked-in protocol/client layer does not yet consume the richer surface exposed by the current dependency".
+
+## External Findings
+
+### Anthropic / Claude
+
+Primary sources checked:
+
+- Anthropic Claude Code SDK docs: <https://docs.anthropic.com/en/docs/claude-code/sdk/sdk-typescript>
+- Anthropic SDK package page: <https://www.npmjs.com/package/@anthropic-ai/claude-agent-sdk>
+- local installed SDK types under `extensions/ritemark/node_modules/@anthropic-ai/claude-agent-sdk/`
+
+Important findings:
+
+1. The SDK exposes `canUseTool`, which is the intended control point for handling tool execution.
+2. `AskUserQuestion` is a built-in tool and is explicitly present in the SDK tool schemas.
+3. The SDK control path supports returning `behavior: 'allow'` with `updatedInput`.
+4. The local SDK source strongly suggests that `AskUserQuestion` is resolved by returning `updatedInput` that includes `answers`.
+5. `SDKUserMessage` also contains `parent_tool_use_id` and `tool_use_result`, which confirms the SDK is built for interactive tool flows.
+
+Most important design implication:
+
+- `AskUserQuestion` should not be modeled as a normal text turn.
+- it is a pending tool interaction that pauses execution until the host app answers it
+
+### OpenAI / Codex
+
+Primary sources checked:
+
+- official OpenAI Codex docs: <https://developers.openai.com/codex/>
+- official OpenAI Codex CLI repository: <https://github.com/openai/codex>
+- local installed Codex CLI and generated protocol types
+
+Important findings:
+
+1. Our local Codex CLI version is `0.114.0`.
+2. The checked-in Ritemark protocol file is a simplified subset generated from `v0.106.0`.
+3. A fresh `codex app-server generate-ts --out <tmpdir>` run from the installed CLI shows server request `item/tool/requestUserInput` and server notifications including `turn/plan/updated` and `item/plan/delta`.
+4. Official Codex materials confirm MCP support is configured through `~/.codex/config.toml`, and an open issue shows project-specific MCP config is still a gap in Codex CLI today.
+
+Inference note:
+
+- the older "Codex does not expose question/plan events" conclusion is no longer strong enough. The more precise conclusion is that Ritemark currently does not consume the richer app-server surface from the newer Codex CLI.
+
+Most important design implication:
+
+- we still must not pretend Claude SDK and Codex app-server are identical
+- but we also should not artificially cap Codex to the older subset if the installed dependency now exposes typed question and plan events
+- the next Codex phase should start by refreshing `codexProtocol.ts` from the current CLI and updating `codexAppServer` / `UnifiedViewProvider` to consume the richer event surface
+
+## MCP Access Findings
+
+### Claude SDK MCP loading
+
+The Claude MCP problem had a concrete root cause in our integration.
+
+Observed local setup:
+
+- user-scope MCP server `pencil` exists in `~/.claude.json`
+- there is no project `.mcp.json` in this repo
+- `AgentRunner` was launching the SDK with `settingSources: ['project']`
+
+Observed runtime result:
+
+- with `settingSources: ['project']`, the SDK init event only showed Claude.ai connectors and did not include `pencil`
+- with `settingSources: ['user', 'project', 'local']`, the same init event showed `pencil` as `connected`
+
+Design implication:
+
+- if Ritemark wants Claude sessions to see the same user/project/local MCP configuration as Claude Code, the SDK session must load all three setting sources by default
+- project-only loading is too narrow for normal interactive usage
+
+Implementation status:
+
+- `AgentRunner` now defaults to `['user', 'project', 'local']`
+- custom overrides are still possible through explicit `settingSources`
+
+Additional nuance:
+
+- loading an MCP server is not sufficient on its own
+- Anthropic's SDK docs also require explicit MCP tool permission in `allowedTools`, using names like `mcp__server__*`, or direct `mcpServers` passed in code
+
+### Codex MCP loading
+
+Codex uses a different configuration model.
+
+Observed local/official behavior:
+
+- Codex CLI supports MCP servers via `mcp_servers` in `~/.codex/config.toml`
+- the official repo issue tracker still has an open feature gap around project-specific MCP config
+
+Design implication:
+
+- Claude and Codex should not share one assumption about MCP scope resolution
+- Claude supports user/project/local scope distinctions
+- Codex currently appears centered on user config, with project-specific MCP support still not established in the official CLI flow
+
+## Root Cause Breakdown
+
+### Root Cause 1: AskUserQuestion is disconnected
+
+The webview has a real UI for agent questions:
+
+- `extensions/ritemark/webview/src/components/ai-sidebar/AgentQuestion.tsx`
+
+But the extension never emits a typed question event, and the store never holds pending question state for a turn.
+
+Result:
+
+- Claude asks
+- the SDK waits
+- Ritemark never renders the UI needed to answer
+
+### Root Cause 2: Plan approval is modeled as a new prompt
+
+Current behavior in the sidebar:
+
+- user clicks `Approve plan`
+- store sends a new agent prompt
+- a new turn is created
+
+That is semantically wrong.
+
+For Claude, plan approval is not a new user turn. It is the answer to a pending `ExitPlanMode` tool call. If we send a new prompt instead, the model may still be in plan mode and the lifecycle drifts out of sync.
+
+This matches the bug seen in the screenshot:
+
+- the UI says the plan was approved
+- Claude still says it first needs to exit plan mode
+
+### Root Cause 3: Plan state is inferred from generic text
+
+Current plan rendering uses generic `thinking` activity text as the plan preview source.
+
+That is fragile because:
+
+1. not every `thinking` chunk is plan content
+2. plan text can span multiple assistant messages
+3. the state change is actually semantic:
+   - entered plan mode
+   - produced plan content
+   - requested exit from plan mode
+   - received approval or rejection
+   - resumed execution
+
+This should be tracked as lifecycle state, not reconstructed from snippets after the fact.
+
+## Correct Claude Lifecycle
+
+The correct turn lifecycle should be:
+
+1. user sends a prompt
+2. agent starts in normal execution mode
+3. agent may call `EnterPlanMode`
+4. host marks the turn as `plan mode active`
+5. assistant text emitted while plan mode is active is accumulated into `planText`
+6. agent may call `AskUserQuestion`
+7. host renders a typed question card and pauses until the user answers
+8. host returns the answer as `updatedInput.answers`
+9. agent continues in the same turn
+10. agent calls `ExitPlanMode`
+11. host renders a plan approval card tied to that pending tool call
+12. user approves or rejects the pending plan request
+13. if approved, host allows the tool call and Claude exits plan mode
+14. if rejected, host denies the tool call with feedback and Claude remains in plan mode
+15. Claude continues execution in the same turn
+16. final result arrives after actual implementation or final response
+
+Critical point:
+
+- `Approve plan` must not create a new turn
+- it must resolve the pending `ExitPlanMode` tool call inside the current turn
+
+## Correct UI State Model
+
+Each Claude turn needs explicit interactive state:
+
+- `isRunning`
+- `planModeActive`
+- `planText`
+- `pendingQuestion`
+- `pendingPlanApproval`
+- `result`
+
+This is better than treating everything as generic activities because interactive states are mutually exclusive in important ways:
+
+- a running turn with a pending question should not show a generic spinner as the primary action
+- a running turn with pending plan approval should show approve/reject controls tied to the pending tool request
+- a completed turn should show result state, not interactive state
+
+## Recommended Implementation Model
+
+### Claude
+
+Implement three typed extension -> webview events:
+
+1. `agent-question`
+2. `agent-plan-approval`
+3. `agent-progress` with explicit `plan_text`
+
+Implement two typed webview -> extension responses:
+
+1. `agent-answer-question`
+2. `agent-answer-plan`
+
+In `AgentSession`, keep two pending promises:
+
+1. pending ask-user-question response
+2. pending exit-plan-mode approval response
+
+When `canUseTool` receives:
+
+- `AskUserQuestion`
+  - emit `agent-question`
+  - wait for UI response
+  - return `allow` with `updatedInput.answers`
+
+- `ExitPlanMode`
+  - emit `agent-plan-approval`
+  - wait for UI response
+  - if approved: return `allow`
+  - if rejected: return `deny` with feedback
+
+Implementation status as of 2026-03-17:
+
+- Claude `AskUserQuestion` is now wired as a pending tool interaction end-to-end.
+- Claude `ExitPlanMode` is now modeled as a pending approval in the same turn, not a synthetic follow-up prompt.
+- The remaining work is validation-heavy: dev smoke tests for approve/reject/cancel behavior and ensuring no stale UI state remains after interruption.
+
+### Codex
+
+Do not fake universal support.
+
+Instead:
+
+1. keep the internal turn model conceptually aligned with Claude
+2. only populate interactive fields when Codex app-server actually emits them
+3. if the protocol does not expose a feature, surface that as unsupported rather than emulating it from prose
+
+That avoids building a misleading abstraction where Claude is event-driven and Codex is text-scraped.
+
+## Why A Shared "Universal" Abstraction Still Makes Sense
+
+It is still worth having one internal model for the UI, but the model must be capability-based.
+
+Example shared UI concepts:
+
+- `pendingQuestion`
+- `pendingPlanApproval`
+- `approval`
+- `streamingText`
+- `activities`
+
+But each provider advertises what it can actually produce:
+
+- Claude:
+  - question: yes
+  - plan approval: yes
+  - plan text: yes
+  - command/file approval: no in this integration
+
+- Codex app-server `0.114.0`:
+  - question: not exposed
+  - plan approval: not exposed
+  - plan text: not exposed as typed event
+  - command/file approval: yes
+
+## Minimal Safe Rollout
+
+Recommended implementation order:
+
+1. Fix Claude `AskUserQuestion` end-to-end.
+2. Fix Claude `ExitPlanMode` approval as a pending tool response.
+3. Convert plan rendering to explicit `planText` lifecycle state.
+4. Leave Codex on its currently exposed event set.
+5. Add logging or diagnostics around unknown Codex notifications so future app-server versions are easy to adopt.
+
+## Validation Checklist
+
+Claude manual tests:
+
+1. agent asks a multiple-choice question and waits
+2. answering resumes the same turn
+3. agent enters plan mode
+4. plan text renders incrementally
+5. `Approve plan` exits plan mode and continues in the same turn
+6. `Reject` keeps the agent in plan mode and lets it revise
+7. cancelling during a pending question or plan approval does not leave stale UI
+
+Codex manual tests:
+
+1. command approval still renders
+2. file approval still renders
+3. no regression in streaming text
+4. no false promise of unsupported question/plan interaction
+
+Build validation:
+
+- `cd extensions/ritemark && npm run compile`
+- `cd extensions/ritemark/webview && npm run build`
+- `./scripts/validate-qa.sh`
+
+## Recommended Decision
+
+Proceed with this exact design:
+
+1. Claude gets a proper pending-tool lifecycle for `AskUserQuestion` and `ExitPlanMode`.
+2. Plan approval stops being a synthetic follow-up prompt.
+3. Codex remains capability-based until the app-server protocol exposes richer interactive events.
+
+This is the smallest design that is both technically correct and durable.

--- a/docs/development/sprints/sprint-45-agent-lifecycle-hardening/README.md
+++ b/docs/development/sprints/sprint-45-agent-lifecycle-hardening/README.md
@@ -1,0 +1,13 @@
+# Sprint 45: Agent Lifecycle Hardening
+
+This sprint hardens the interactive lifecycle for agent-driven work in the AI sidebar.
+
+Focus areas:
+
+- Claude `AskUserQuestion` rendering and response flow
+- Claude plan mode lifecycle
+- correct `ExitPlanMode` approval handling
+- extension <-> webview state synchronization
+- Codex capability audit for equivalent lifecycle support
+
+This sprint starts with an audit phase before implementation continues.

--- a/docs/development/sprints/sprint-45-agent-lifecycle-hardening/notes/dependency-drift-upkeep-plan.md
+++ b/docs/development/sprints/sprint-45-agent-lifecycle-hardening/notes/dependency-drift-upkeep-plan.md
@@ -1,0 +1,157 @@
+# Dependency Drift Upkeep Plan
+
+Date: 2026-03-18
+Scope: Claude SDK, Codex CLI app-server protocol, MCP configuration behavior, sidebar lifecycle adapters
+
+## Problem
+
+The failure mode in this sprint was not just a bug in one handler.
+
+It was protocol drift:
+
+- Claude SDK behavior was newer/richer than our assumptions about MCP loading
+- Codex CLI `0.114.0` exposed a richer app-server surface than the simplified protocol snapshot checked into Ritemark
+- the UI kept relying on local adapter assumptions instead of verifying current dependency behavior
+
+Fast-moving agent dependencies will keep changing. We need a repeatable process that catches drift before it becomes a user-visible lifecycle failure.
+
+## Operating Model
+
+Treat agent providers as external protocols with adapters, not as stable internals.
+
+That means:
+
+1. keep provider-specific capabilities explicit
+2. verify current behavior from the installed dependency, not memory
+3. snapshot the protocol boundary we actually consume
+4. run a small smoke suite after each dependency bump or CLI reinstall
+
+## Concrete Upkeep Routine
+
+### 1. Add a scheduled protocol audit
+
+Trigger:
+
+- every Codex CLI version bump
+- every Claude SDK version bump
+- any unexplained lifecycle regression in the sidebar
+
+Checklist:
+
+- run `codex app-server generate-ts --out <tmpdir>`
+- diff the generated types against `extensions/ritemark/src/codex/codexProtocol.ts`
+- note new server requests, new notifications, and changed enum values
+- inspect the local Claude SDK types under `extensions/ritemark/node_modules/@anthropic-ai/claude-agent-sdk/`
+- confirm `settingSources`, MCP config behavior, and tool permission expectations still match our adapter
+
+Output:
+
+- one short audit note in the active sprint or maintenance sprint
+- a decision: no changes, adapter update, or UI capability update
+
+### 2. Keep a checked-in capability matrix
+
+Maintain a small source-of-truth table for each provider:
+
+- supports question requests
+- supports plan updates
+- supports plan approval
+- supports MCP startup state
+- supports MCP tool progress
+- config scope model
+
+This should live next to the adapter code or in sprint-maintenance docs and must be updated whenever a provider bump changes the answer.
+
+### 3. Add protocol snapshot tests
+
+Add small tests that fail loudly when our local assumptions drift:
+
+- Codex:
+  - expected request method names
+  - expected notification names we consume
+  - current approval decision enum values
+- Claude:
+  - default `settingSources`
+  - synchronous question/plan-answer lifecycle
+
+These do not need to be end-to-end. They only need to guard the adapter boundary.
+
+### 4. Add one dev smoke flow per provider
+
+After any provider bump or adapter change, manually verify:
+
+- Claude:
+  - AskUserQuestion
+  - plan approve
+  - plan reject
+  - return from plan mode into same turn
+  - user-scope MCP appears when expected
+- Codex:
+  - command approval
+  - file approval
+  - requestUserInput
+  - plan update rendering
+
+Record pass/fail in sprint notes. Do not rely only on compile success.
+
+### 5. Separate dependency bumps from feature work
+
+Do not combine:
+
+- provider version bump
+- protocol adapter rewrite
+- UI redesign
+
+Preferred sequence:
+
+1. bump dependency on a dedicated branch
+2. regenerate or audit protocol
+3. adapt the Ritemark bridge
+4. run smoke checks
+5. only then resume feature work
+
+This keeps regressions attributable.
+
+### 6. Create a maintenance sprint lane
+
+Use a recurring maintenance sprint or maintenance issue bucket for:
+
+- CLI/SDK refreshes
+- protocol diff review
+- MCP behavior changes
+- auth/config flow changes
+
+This prevents "silent drift" from piling up until a feature sprint breaks unexpectedly.
+
+## Near-Term Follow-Up
+
+1. Refresh `extensions/ritemark/src/codex/codexProtocol.ts` more fully from the current Codex CLI instead of extending it ad hoc.
+2. Add Codex-side snapshot tests for the new request/notification methods we now rely on.
+3. Add a short provider capability matrix document referenced from the sidebar adapter.
+4. Consider a small script that generates a temporary Codex protocol snapshot and reports newly added methods in CI or pre-release checks.
+
+## Implemented In Sprint 45
+
+The first production guardrail is now in place for Codex:
+
+- Ritemark inspects the active `codex` binary at runtime and records both version-range compatibility and observed protocol capabilities.
+- Settings now surfaces whether Codex is fully compatible, runnable with limits, or outside the audited range.
+- The Codex chat view now shows a dismissable notice when the current CLI is limited or untested, instead of silently pretending every lifecycle feature is available.
+
+This is the baseline for future upkeep. It does not replace protocol audits or smoke tests after provider changes.
+
+## Reference Commands
+
+```bash
+codex --version
+codex app-server generate-ts --out /tmp/codex-protocol
+cd extensions/ritemark && npm run compile
+cd extensions/ritemark/webview && npm run build
+./scripts/validate-qa.sh
+```
+
+## External References
+
+- Anthropic Claude Code settings: https://docs.anthropic.com/en/docs/claude-code/settings
+- Anthropic Claude Code MCP: https://docs.anthropic.com/en/docs/claude-code/mcp
+- OpenAI Codex repo: https://github.com/openai/codex

--- a/docs/development/sprints/sprint-45-agent-lifecycle-hardening/notes/user-flow-lifecycle-contract.md
+++ b/docs/development/sprints/sprint-45-agent-lifecycle-hardening/notes/user-flow-lifecycle-contract.md
@@ -1,0 +1,398 @@
+# Agent Lifecycle User Flow Contract
+
+## Purpose
+
+This document defines the user-facing lifecycle for plan mode, questions, approvals, and execution in the AI sidebar.
+
+It is intended to be implementation-ready:
+
+- one shared UX contract
+- provider-specific adapters underneath
+- explicit state entry/exit rules
+- pseudocode for the core transitions
+
+## Product Goal
+
+The user should experience only 3 clear phases:
+
+1. Clarify
+2. Review plan
+3. Execute
+
+The UI must not bounce back into plan review after execution has started unless the plan materially changes.
+
+## Jarmo's Vision
+
+1. User starts chatting.
+2. User asks to enter Plan mode, optionally with guidance about what the plan is for.
+3. Plan mode is activated.
+4. The agent reviews the context and starts a clarification phase.
+5. If needed, the agent uses `AskUserQuestion` or `request_user_input` to ask concise multiple-choice questions.
+6. User answers the questions.
+7. The agent shows one clear plan card as a compact to-do list with 3 actions:
+   - Approve
+   - Revise
+   - Cancel
+8. Approve:
+   - Exit Plan mode
+   - Enter Edit mode
+   - Start implementing the approved to-do list
+   - Continue until the work is complete or a real blocker requires user input
+9. Revise:
+   - Stay in Plan mode
+   - Update the current draft plan based on feedback
+   - Show the revised plan again for review
+10. Cancel:
+   - Exit Plan mode
+   - End the plan flow cleanly
+   - Say something simple like: “Plan cancelled. Is there anything else I can help with?”
+11. In Edit mode:
+   - Collapse the inline plan card
+   - Pin a compact plan widget above the chat input
+   - Show item status visually:
+     - Pending: empty checkbox
+     - In progress: hourglass
+     - Done: filled checkbox
+   - Update statuses as work progresses
+12. When all items are done, finish with a short summary of what was completed.
+
+## Shared UX Contract
+
+### Phase 1: Clarify
+
+- The agent may inspect context.
+- If required input is missing, the agent asks one or more interactive questions.
+- The user answers inside the same logical turn/session.
+- The agent resumes from that answer without creating a fake follow-up conversation turn.
+
+### Phase 2: Review Plan
+
+- The agent produces one explicit plan.
+- The UI shows one review card.
+- The user can:
+  - Approve
+  - Revise
+  - Cancel
+
+### Phase 3: Execute
+
+- After approval, the agent starts execution.
+- The review card disappears.
+- The UI shows a compact sticky tasklist widget above the input.
+- That widget tracks:
+  - current item
+  - completed items
+  - pending items
+- The tasklist remains visible while execution is active and should shrink to a compact summary when no longer useful.
+
+## What Must Never Happen
+
+- The agent asks for plan approval repeatedly after every micro-step.
+- The same plan is reviewed multiple times without a material scope change.
+- Approve only changes local UI state but does not actually continue execution.
+- The user sees duplicate plan boxes for the same plan.
+- The user cannot tell whether the agent is planning or executing.
+- The user cannot tell whether items are pending, active, or done.
+
+## Shared State Model
+
+The webview should normalize both Claude and Codex into one shared lifecycle model.
+
+```ts
+type AgentPhase = 'clarify' | 'review' | 'execute' | 'done' | 'cancelled' | 'error'
+
+type TaskItemStatus = 'pending' | 'inProgress' | 'done'
+
+interface TaskItem {
+  id: string
+  label: string
+  status: TaskItemStatus
+}
+
+interface ActivePlan {
+  summary: string
+  items: TaskItem[]
+  approved: boolean
+  visibleInStickyWidget: boolean
+}
+
+interface LifecycleState {
+  provider: 'claude' | 'codex'
+  phase: AgentPhase
+  pendingQuestion?: QuestionCard
+  pendingPlanReview?: PlanDraft
+  activePlan?: ActivePlan
+}
+```
+
+## State Entry and Exit Rules
+
+### Clarify
+
+- Enter when:
+  - the task starts and required input is missing
+  - the provider explicitly requests user input
+- Exit when:
+  - the user answers the required questions
+  - the agent has enough information to produce a plan
+
+### Review Plan
+
+- Enter when:
+  - the agent has produced a draft plan for user confirmation
+- Exit when:
+  - user clicks `Approve` -> go to `Execute`
+  - user clicks `Revise` -> stay in `Review Plan` and regenerate the draft
+  - user clicks `Cancel` -> go to `Cancelled`
+
+### Execute
+
+- Enter when:
+  - the user approves the plan
+  - the provider has crossed from planning into real work
+- Exit when:
+  - all task items are done -> go to `Done`
+  - execution is cancelled -> go to `Cancelled`
+  - a real blocker requires fresh user input -> temporarily enter `Clarify`
+  - the plan materially changes -> temporarily re-enter `Review Plan`
+
+### Done
+
+- Enter when:
+  - the approved task items are completed
+- Exit when:
+  - a new user message starts a new task
+
+### Cancelled
+
+- Enter when:
+  - the user cancels plan review
+  - the user cancels execution
+- Exit when:
+  - a new user message starts a new task
+
+## Task Item State Rules
+
+### Pending
+
+- Enter when:
+  - the plan is first created
+  - a new item is added during execution
+  - an item is reopened because the plan materially changed
+- Exit when:
+  - the agent chooses it as the current working item
+
+### In Progress
+
+- Enter when:
+  - the agent or a sub-agent starts actively working on that item
+- Exit when:
+  - the item is completed
+  - the item is explicitly moved back to `Pending` because the plan changed
+
+### Done
+
+- Enter when:
+  - the intended outcome of that item has been achieved
+- Exit when:
+  - the plan is materially revised and the item must be reopened
+
+## UI Contract
+
+### Question Card
+
+- One question card per clarification checkpoint
+- Must be interactive
+- Must resume the same logical task after answer
+
+### Plan Review Card
+
+- One review card per draft plan
+- Buttons:
+  - `Approve`
+  - `Revise`
+  - `Cancel`
+- After `Approve`, the review card disappears
+
+### Sticky Tasklist Widget
+
+- Shown only after plan approval
+- Compact by default
+- Placed above the chat input
+- Shows:
+  - summary line
+  - current active item
+  - pending items
+  - done items, visually de-emphasized
+- Must not be a plain markdown dump
+
+## Provider Contract
+
+### Claude
+
+Claude has a real planning lifecycle.
+
+- Clarification uses `AskUserQuestion`
+- Review uses `ExitPlanMode`
+- Approve/reject resolves the pending tool interaction
+- Execution continues in the same logical turn
+
+Claude should not require a synthetic continuation prompt after approval.
+
+### Codex
+
+Codex does not expose the same lifecycle primitives as Claude.
+
+Therefore the adapter must emulate the same user-facing contract:
+
+- clarification via `request_user_input`
+- one plan review checkpoint
+- explicit transition from review into execution
+- no repeated plan-review loop unless scope materially changes
+
+If Codex only provides plan text and step updates, the adapter must still preserve the same UX contract.
+
+## Adapter Boundary
+
+Provider-specific:
+
+- protocol events
+- tool payloads
+- mode switching
+- continuation mechanics
+
+Shared:
+
+- question card
+- plan review card
+- sticky tasklist widget
+- phase semantics
+- success / error / cancel behavior
+
+## Current Known Failure
+
+The current Codex lifecycle is still wrong:
+
+- after approval, continuation can drift back into plan review
+- the model can treat the approved plan as a fresh planning request instead of entering execution
+- step status updates are not yet trustworthy enough to represent real tool-driven execution
+
+This is a phase-boundary bug between:
+
+- `plan approved`
+- `execution started`
+
+## Required Next Fix
+
+After plan approval, Codex must enter a strict execution-oriented continuation mode:
+
+- do not re-plan by default
+- do not ask for approval again
+- start tools/work immediately if the task requires them
+- update task item status as work progresses
+- only return to plan review if scope materially changes and that change is explained to the user
+
+## Pseudocode
+
+### Shared Webview Reducer
+
+```ts
+function onQuestionRequested(state, question) {
+  state.phase = 'clarify'
+  state.pendingQuestion = question
+}
+
+function onQuestionAnswered(state) {
+  state.pendingQuestion = undefined
+}
+
+function onPlanDraftReady(state, draftPlan) {
+  state.phase = 'review'
+  state.pendingPlanReview = draftPlan
+}
+
+function onPlanApproved(state, approvedPlan) {
+  state.phase = 'execute'
+  state.pendingPlanReview = undefined
+  state.activePlan = {
+    summary: approvedPlan.summary,
+    items: approvedPlan.items,
+    approved: true,
+    visibleInStickyWidget: true,
+  }
+}
+
+function onPlanRevised(state, revisedDraft) {
+  state.phase = 'review'
+  state.pendingPlanReview = revisedDraft
+}
+
+function onPlanCancelled(state) {
+  state.phase = 'cancelled'
+  state.pendingPlanReview = undefined
+  state.activePlan = undefined
+}
+
+function onTaskItemStarted(state, itemId) {
+  for (const item of state.activePlan.items) {
+    if (item.id === itemId) item.status = 'inProgress'
+  }
+}
+
+function onTaskItemCompleted(state, itemId) {
+  for (const item of state.activePlan.items) {
+    if (item.id === itemId) item.status = 'done'
+  }
+}
+
+function onExecutionCompleted(state) {
+  state.phase = 'done'
+}
+```
+
+### Claude Adapter
+
+```ts
+onClaudeAskUserQuestion(toolCall) -> onQuestionRequested(...)
+onClaudeExitPlanMode(planDraft) -> onPlanDraftReady(...)
+onClaudeApproveExitPlanMode() -> onPlanApproved(...)
+onClaudeRejectExitPlanMode(feedback) -> onPlanRevised(...)
+onClaudeExecutionProgress(stepUpdate) -> onTaskItemStarted/onTaskItemCompleted(...)
+```
+
+### Codex Adapter
+
+```ts
+onCodexRequestUserInput(request) -> onQuestionRequested(...)
+onCodexPlanUpdate(planDraft) -> onPlanDraftReady(...)
+
+onCodexApprovePlan() {
+  onPlanApproved(...)
+  startExecutionContinuation({
+    mode: 'execute',
+    instructions: 'Do not re-plan unless scope materially changes'
+  })
+}
+
+onCodexExecutionProgress(stepUpdate) -> onTaskItemStarted/onTaskItemCompleted(...)
+
+onCodexUnexpectedPlanReviewDuringExecution() {
+  if (!scopeMateriallyChanged) suppressReplanAndContinueExecution()
+  else onPlanDraftReady(newDraftPlan)
+}
+```
+
+## Acceptance Test
+
+Given a task that requires edits:
+
+1. User asks for the task.
+2. Agent asks one clarification question if needed.
+3. Agent shows one plan review card.
+4. User clicks `Approve`.
+5. Agent starts working.
+6. Sticky tasklist shows progress.
+7. Agent uses tools / edits files.
+8. Agent does not ask for plan approval again unless scope changed materially.
+
+If step 8 fails, the lifecycle is still broken.

--- a/docs/development/sprints/sprint-45-agent-lifecycle-hardening/research/lifecycle-audit.md
+++ b/docs/development/sprints/sprint-45-agent-lifecycle-hardening/research/lifecycle-audit.md
@@ -1,0 +1,58 @@
+# Lifecycle Audit
+
+## Summary
+
+The sprint begins with an audit because the bug is not isolated to one component.
+
+Affected layers:
+
+- Claude SDK integration
+- extension-side session lifecycle
+- webview store and rendering
+- plan approval semantics
+- Codex protocol capability mapping
+
+## Audit Outcome
+
+### Claude
+
+- `AskUserQuestion` support exists in the SDK, but Ritemark was not surfacing it to the sidebar.
+- `ExitPlanMode` approval must be handled as a pending tool interaction, not as a new user prompt.
+- Plan content should be tracked as explicit lifecycle state.
+- Implementation now follows that model in the sidebar bridge and store; remaining risk is runtime validation of approve/reject/cancel transitions.
+- Reproduced runtime bug: `onPlanApproval` and `onQuestion` were emitted before the pending resolver state was registered, so immediate answers could be dropped.
+- Reproduced SDK integration detail: approved `ExitPlanMode` should return `updatedInput: input`; omitting it is risky because the SDK docs show the original input should be forwarded on allow decisions.
+
+### Codex
+
+- Current `codex app-server` protocol in this repo exposes approvals and turn events.
+- Fresh audit correction: the installed Codex CLI `0.114.0` can generate a richer app-server protocol than the simplified subset checked into this repo.
+- A local `codex app-server generate-ts --out <tmpdir>` run includes `item/tool/requestUserInput`, `turn/plan/updated`, and `item/plan/delta`.
+- So the current Codex lifecycle gap is partly in Ritemark's stale protocol/client layer, not purely in the dependency.
+- Ritemark should not pretend the providers are identical, but it also should not keep assuming Codex lacks lifecycle features that the current CLI may already expose.
+
+### MCP
+
+- Claude MCP loading was blocked by our own SDK launch options: `settingSources: ['project']` excluded user/local MCP config, so user-scope servers like `pencil` never appeared in the session.
+- Fix direction is to load `user`, `project`, and `local` by default, while still allowing overrides.
+- Codex MCP configuration follows a different model: official materials point to `~/.codex/config.toml`, and project-specific MCP support is still an open gap in the Codex repo.
+
+## Mandatory Rule For This Sprint
+
+No more lifecycle implementation should be treated as ad hoc patching.
+
+Every change must be checked against the target lifecycle:
+
+1. enter running turn
+2. optionally enter plan mode
+3. optionally ask questions
+4. optionally request plan approval
+5. exit plan mode correctly
+6. continue in the same turn
+7. finish with a stable final result
+
+## Reference
+
+Use the main analysis doc as the source of truth:
+
+- `/Users/jarmotuisk/Projects/ritemark-native/docs/development/analysis/2026-03-17-agent-lifecycle-planmode-analysis.md`

--- a/docs/development/sprints/sprint-45-agent-lifecycle-hardening/sprint-plan.md
+++ b/docs/development/sprints/sprint-45-agent-lifecycle-hardening/sprint-plan.md
@@ -1,0 +1,134 @@
+# Sprint 45: Agent Lifecycle Hardening
+
+## Goal
+
+Make the Claude and Codex agent lifecycle in the AI sidebar predictable and reviewable, with Claude fully supporting question/plan interactions and Codex explicitly modeled by actual protocol capabilities.
+
+## Why This Sprint Exists
+
+The current agent UX shows lifecycle drift:
+
+- `AskUserQuestion` does not render or resume correctly
+- plan approval is treated like a new prompt instead of a pending tool response
+- the UI can say a plan is approved while Claude remains in plan mode
+- Codex and Claude are currently mixed together as if they expose the same interaction primitives
+
+This is a cross-cutting state-machine problem, so the sprint starts with an audit before more implementation continues.
+
+## Feature Flag Check
+
+- [x] Does this sprint need a feature flag? NO.
+  This is lifecycle hardening for existing agent behavior, not a new user-facing experiment.
+
+## Success Criteria
+
+- [ ] Claude `AskUserQuestion` renders as an interactive card in the sidebar
+- [ ] Answering a Claude question resumes the same running turn
+- [ ] Claude plan text is tracked explicitly as plan state, not reconstructed from generic activity snippets
+- [ ] `Approve plan` resolves the pending `ExitPlanMode` transition instead of sending a new prompt
+- [ ] `Reject plan` keeps Claude in plan mode with usable feedback
+- [ ] Cancelling during pending question or plan approval does not leave stale UI state
+- [ ] Codex UI only claims lifecycle features that are actually exposed by the current app-server protocol
+- [ ] Dev-mode validation covers question flow, plan flow, and return-to-execution flow
+
+## Deliverables
+
+| Deliverable | Description | Status |
+| --- | --- | --- |
+| Lifecycle audit | Root-cause and target-state analysis for Claude/Codex lifecycle | Done |
+| Claude question flow | Typed question event and answer roundtrip | Done |
+| Claude plan flow | Explicit plan-mode state and correct `ExitPlanMode` handling | In progress |
+| Shared sidebar state model | Clear pending question / pending plan approval state in webview store | Done |
+| Shared lifecycle UI primitives | Reuse the same plan review and active-plan UI building blocks across Claude and Codex | In progress |
+| Codex capability alignment | Refresh understanding of actual app-server support and keep UI aligned to what we truly consume | Done |
+| MCP configuration alignment | Make Claude SDK sessions load expected MCP scopes and document Codex MCP differences | Done |
+| Validation notes | TDD-style lifecycle regression coverage plus build and QA validation for lifecycle transitions | In progress |
+
+## Scope
+
+### In Scope
+
+- `extensions/ritemark/src/agent/`
+- `extensions/ritemark/src/views/UnifiedViewProvider.ts`
+- `extensions/ritemark/webview/src/components/ai-sidebar/`
+- Codex protocol audit for lifecycle capability mapping
+- sprint docs and validation notes
+
+### Out of Scope
+
+- changing `.claude/**`
+- inventing unsupported Codex lifecycle features
+- shipping a generic cross-provider abstraction that hides protocol differences
+
+## Implementation Checklist
+
+### Phase 1: Audit
+
+- [x] Inspect current Claude lifecycle in extension and webview layers
+- [x] Verify Anthropic SDK support for `AskUserQuestion` and plan-related tool flow
+- [x] Inspect current Codex app-server protocol surface in the local dependency version
+- [x] Write lifecycle analysis document with target design
+
+### Phase 2: Claude State Model
+
+- [x] Add explicit sidebar state for pending question, pending plan approval, and plan text
+- [x] Stop relying on generic `thinking` snippets as the only plan representation
+- [x] Ensure one running turn can pause and resume without synthetic extra turns
+
+### Phase 3: Claude Tool Interaction Flow
+
+- [x] Wire `AskUserQuestion` through the SDK callback path
+- [x] Render the interactive question card and return answers to the pending tool call
+- [x] Wire `ExitPlanMode` approval as a pending tool interaction
+- [x] Ensure approval/rejection updates the active turn instead of creating fake follow-up turns
+
+### Phase 4: Codex Capability Alignment
+
+- [x] Keep approvals working as-is
+- [x] Audit the actual current Codex CLI protocol surface, not only the checked-in simplified subset
+- [x] Refresh checked-in Codex protocol/client modeling to match the current dependency where safe
+- [x] Avoid UI promises for unsupported or still-unconsumed Codex interactions
+
+### Phase 4A: MCP Configuration Alignment
+
+- [x] Reproduce Claude MCP loading gap with project-only settings
+- [x] Change Claude SDK default setting sources to `user`, `project`, `local`
+- [x] Add regression coverage for default setting sources
+- [x] Document Codex MCP configuration differences versus Claude
+
+### Phase 5: Validation
+
+- [x] `cd extensions/ritemark && npm run compile`
+- [x] `cd extensions/ritemark/webview && npm run build`
+- [x] `./scripts/validate-qa.sh`
+- [x] Add targeted lifecycle tests to the repo QA path
+- [x] Sanity-check Claude SDK MCP loading with `project` vs `user+project+local`
+- [ ] Dev smoke test: Claude question flow
+- [x] Dev smoke test: Claude plan approve flow
+- [ ] Dev smoke test: Claude plan reject flow
+- [ ] Dev smoke test: return from plan mode into implementation in same turn
+- [ ] Dev smoke test: Codex approvals still render
+
+## Key Research
+
+- [Agent lifecycle analysis](/Users/jarmotuisk/Projects/ritemark-native/docs/development/analysis/2026-03-17-agent-lifecycle-planmode-analysis.md)
+- [Sprint audit](/Users/jarmotuisk/Projects/ritemark-native/docs/development/sprints/sprint-45-agent-lifecycle-hardening/research/lifecycle-audit.md)
+- [User flow lifecycle contract](/Users/jarmotuisk/Projects/ritemark-native/docs/development/sprints/sprint-45-agent-lifecycle-hardening/notes/user-flow-lifecycle-contract.md)
+
+## Key Files
+
+| File | Purpose |
+| --- | --- |
+| `extensions/ritemark/src/agent/AgentRunner.ts` | Claude SDK lifecycle and pending tool interactions |
+| `extensions/ritemark/src/agent/types.ts` | Shared extension-side lifecycle types |
+| `extensions/ritemark/src/views/UnifiedViewProvider.ts` | Extension <-> webview event bridge |
+| `extensions/ritemark/webview/src/components/ai-sidebar/store.ts` | Sidebar state machine |
+| `extensions/ritemark/webview/src/components/ai-sidebar/AgentView.tsx` | Turn rendering and interactive cards |
+| `extensions/ritemark/webview/src/components/ai-sidebar/AgentResponse.tsx` | Plan rendering and approval UI |
+| `extensions/ritemark/src/codex/codexProtocol.ts` | Current Codex app-server protocol surface |
+
+## Status
+
+**Current Phase:** TDD lifecycle coverage added for helper/store seams, next fixes should be test-driven from failing lifecycle scenarios  
+**Current Branch:** `feature/sprint-45-agent-lifecycle-hardening`  
+**Next Gate:** Add failing tests for the remaining Codex post-approval re-planning bug, then fix the execution-mode transition against those tests

--- a/extensions/ritemark/package.json
+++ b/extensions/ritemark/package.json
@@ -436,7 +436,7 @@
   "scripts": {
     "compile": "tsc -p ./",
     "watch": "tsc -watch -p ./",
-    "test": "npx tsx src/features/featureGate.test.ts && npx tsx src/flows/flowTypes.test.ts && npx tsx src/flows/FlowExecutor.test.ts && npx tsx src/flows/nodes/ClaudeCodeNodeExecutor.test.ts && npx tsx src/update/updateResolver.test.ts && npx tsx src/flows/FlowIntegration.test.ts && npx tsx src/flows/nodes/SaveFileNodeExecutor.integration.test.ts && npx tsx src/flows/nodes/ClaudeCodeNodeExecutor.integration.test.ts",
+    "test": "npx tsx src/features/featureGate.test.ts && npx tsx src/agent/AgentRunner.test.ts && npx tsx src/codex/codexApproval.test.ts && npx tsx webview/src/components/ai-sidebar/lifecycle.test.ts && npx tsx webview/src/components/ai-sidebar/conversationReset.test.ts && npx tsx src/flows/flowTypes.test.ts && npx tsx src/flows/FlowExecutor.test.ts && npx tsx src/flows/nodes/ClaudeCodeNodeExecutor.test.ts && npx tsx src/update/updateResolver.test.ts && npx tsx src/flows/FlowIntegration.test.ts && npx tsx src/flows/nodes/SaveFileNodeExecutor.integration.test.ts && npx tsx src/flows/nodes/ClaudeCodeNodeExecutor.integration.test.ts",
     "test:integration": "npx tsx src/flows/nodes/SaveFileNodeExecutor.integration.test.ts && npx tsx src/flows/nodes/LLMNodeExecutor.integration.test.ts && npx tsx src/flows/nodes/ClaudeCodeNodeExecutor.integration.test.ts",
     "test:integration:free": "npx tsx src/flows/nodes/SaveFileNodeExecutor.integration.test.ts",
     "test:all": "npm run test && npm run test:integration",

--- a/extensions/ritemark/src/agent/AgentRunner.test.ts
+++ b/extensions/ritemark/src/agent/AgentRunner.test.ts
@@ -1,5 +1,10 @@
 import assert from 'node:assert/strict';
-import { AgentSession, DEFAULT_SETTING_SOURCES } from './AgentRunner';
+import {
+  AgentSession,
+  buildClaudeSystemAppend,
+  buildClaudeTurnPrompt,
+  DEFAULT_SETTING_SOURCES,
+} from './AgentRunner';
 
 async function testSynchronousPlanApprovalAnswer() {
   const session = new AgentSession({
@@ -88,8 +93,35 @@ function testDefaultSettingSources() {
   );
 }
 
+function testDefaultToolsIncludePlanAndQuestionLifecycle() {
+  const session = new AgentSession({
+    workspacePath: process.cwd(),
+  }) as AgentSession & Record<string, unknown>;
+
+  assert.ok(
+    Array.isArray(session._allowedTools) && session._allowedTools.includes('AskUserQuestion'),
+    'default tools should include AskUserQuestion'
+  );
+  assert.ok(
+    Array.isArray(session._allowedTools) && session._allowedTools.includes('ExitPlanMode'),
+    'default tools should include ExitPlanMode'
+  );
+}
+
+function testClaudeLifecycleInstructionsAreIncluded() {
+  const systemAppend = buildClaudeSystemAppend('/tmp/workspace', ['node_modules']);
+  assert.match(systemAppend, /AskUserQuestion/, 'system append should mention AskUserQuestion');
+  assert.match(systemAppend, /ExitPlanMode/, 'system append should mention ExitPlanMode');
+
+  const turnPrompt = buildClaudeTurnPrompt('User prompt');
+  assert.match(turnPrompt, /Ritemark lifecycle contract/, 'turn prompt should include lifecycle reminder');
+  assert.match(turnPrompt, /User prompt$/, 'turn prompt should preserve original prompt');
+}
+
 async function main() {
   testDefaultSettingSources();
+  testDefaultToolsIncludePlanAndQuestionLifecycle();
+  testClaudeLifecycleInstructionsAreIncluded();
   await testSynchronousPlanApprovalAnswer();
   await testSynchronousQuestionAnswer();
   console.log('AgentRunner lifecycle tests passed.');

--- a/extensions/ritemark/src/agent/AgentRunner.test.ts
+++ b/extensions/ritemark/src/agent/AgentRunner.test.ts
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict';
+import { AgentSession, DEFAULT_SETTING_SOURCES } from './AgentRunner';
+
+async function testSynchronousPlanApprovalAnswer() {
+  const session = new AgentSession({
+    workspacePath: process.cwd(),
+  }) as AgentSession & Record<string, unknown>;
+
+  session._emitPlanApproval = (request: { toolUseId: string }) => {
+    const answered = session.answerPlanApproval(request.toolUseId, true);
+    assert.equal(answered, true, 'synchronous plan approval answer should be accepted');
+  };
+
+  const result = await session._handleCanUseTool(
+    'ExitPlanMode',
+    { allowedPrompts: [] },
+    { signal: new AbortController().signal, toolUseID: 'plan-tool-1' }
+  );
+
+  assert.equal(result.behavior, 'allow');
+  if (result.behavior === 'allow') {
+    assert.deepEqual(result.updatedInput, { allowedPrompts: [] });
+  }
+}
+
+async function testSynchronousQuestionAnswer() {
+  const session = new AgentSession({
+    workspacePath: process.cwd(),
+  }) as AgentSession & Record<string, unknown>;
+
+  const questionInput = {
+    questions: [
+      {
+        header: 'Choice',
+        question: 'Pick one',
+        options: [
+          { label: 'A', description: 'first' },
+          { label: 'B', description: 'second' },
+        ],
+      },
+    ],
+  };
+
+  session._emitQuestion = (question: { toolUseId: string; questions: Array<{ question: string }> }) => {
+    const answered = session.answerQuestion(question.toolUseId, {
+      [question.questions[0].question]: 'A',
+    });
+    assert.equal(answered, true, 'synchronous question answer should be accepted');
+  };
+
+  const result = await session._handleCanUseTool(
+    'AskUserQuestion',
+    questionInput,
+    { signal: new AbortController().signal, toolUseID: 'question-tool-1' }
+  );
+
+  assert.equal(result.behavior, 'allow');
+  if (result.behavior === 'allow') {
+    assert.deepEqual(result.updatedInput, {
+      ...questionInput,
+      answers: {
+        'Pick one': 'A',
+      },
+    });
+  }
+}
+
+function testDefaultSettingSources() {
+  const session = new AgentSession({
+    workspacePath: process.cwd(),
+  }) as AgentSession & Record<string, unknown>;
+
+  assert.deepEqual(
+    session._settingSources,
+    DEFAULT_SETTING_SOURCES,
+    'default setting sources should load user, project, and local Claude settings'
+  );
+
+  const customSession = new AgentSession({
+    workspacePath: process.cwd(),
+    settingSources: ['project'],
+  }) as AgentSession & Record<string, unknown>;
+
+  assert.deepEqual(
+    customSession._settingSources,
+    ['project'],
+    'custom setting sources should be preserved'
+  );
+}
+
+async function main() {
+  testDefaultSettingSources();
+  await testSynchronousPlanApprovalAnswer();
+  await testSynchronousQuestionAnswer();
+  console.log('AgentRunner lifecycle tests passed.');
+}
+
+void main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/extensions/ritemark/src/agent/AgentRunner.ts
+++ b/extensions/ritemark/src/agent/AgentRunner.ts
@@ -13,6 +13,9 @@
 
 import type {
   AgentExecutionOptions,
+  AgentPlanApprovalRequest,
+  AgentQuestion,
+  AgentSettingSource,
   AgentSessionConfig,
   AgentTurnOptions,
   AgentProgress,
@@ -116,7 +119,8 @@ function isContextOverflowError(str: string): boolean {
 
 // ── Constants ────────────────────────────────────────────────────────
 
-const DEFAULT_TOOLS = ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep'];
+const DEFAULT_TOOLS = ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep', 'AskUserQuestion'];
+export const DEFAULT_SETTING_SOURCES: AgentSettingSource[] = ['user', 'project', 'local'];
 const DEFAULT_TIMEOUT_MINUTES = 15;
 
 const DEFAULT_EXCLUDED_FOLDERS = [
@@ -144,6 +148,60 @@ ${exclusions}
 If a user asks you to operate on these paths, explain that they are excluded for safety.\n\n`;
 }
 
+function normalizeAgentQuestion(input: Record<string, unknown>, toolUseId: string): AgentQuestion | null {
+  const rawQuestions = input.questions;
+  if (!Array.isArray(rawQuestions) || rawQuestions.length === 0) {
+    return null;
+  }
+
+  const questions = rawQuestions.flatMap((rawQuestion) => {
+    if (!rawQuestion || typeof rawQuestion !== 'object') {
+      return [];
+    }
+
+    const question = typeof rawQuestion.question === 'string' ? rawQuestion.question.trim() : '';
+    const header = typeof rawQuestion.header === 'string' ? rawQuestion.header.trim() : '';
+    const rawOptions = Array.isArray(rawQuestion.options) ? rawQuestion.options : [];
+    const options = rawOptions.flatMap((rawOption: unknown) => {
+      if (!rawOption || typeof rawOption !== 'object') {
+        return [];
+      }
+      const option = rawOption as { label?: unknown; description?: unknown };
+      const label = typeof option.label === 'string' ? option.label.trim() : '';
+      if (!label) {
+        return [];
+      }
+      return [{
+        label,
+        description: typeof option.description === 'string' ? option.description.trim() : '',
+      }];
+    });
+
+    if (!question || !header || options.length < 2) {
+      return [];
+    }
+
+    return [{
+      header,
+      question,
+      options,
+      multiSelect: rawQuestion.multiSelect === true,
+    }];
+  });
+
+  if (questions.length === 0) {
+    return null;
+  }
+
+  return { toolUseId, questions };
+}
+
+function resolveSettingSources(settingSources?: AgentSettingSource[]): AgentSettingSource[] {
+  return settingSources && settingSources.length > 0
+    ? settingSources
+    : DEFAULT_SETTING_SOURCES;
+}
+
 // ── One-shot execution (for Flows) ──────────────────────────────────
 
 /**
@@ -156,6 +214,7 @@ export async function runAgent(options: AgentExecutionOptions): Promise<AgentRes
     workspacePath,
     attachments,
     allowedTools = DEFAULT_TOOLS,
+    settingSources,
     excludedFolders = DEFAULT_EXCLUDED_FOLDERS,
     timeoutMinutes = DEFAULT_TIMEOUT_MINUTES,
     abortSignal,
@@ -226,10 +285,19 @@ export async function runAgent(options: AgentExecutionOptions): Promise<AgentRes
       options: {
         cwd: workspacePath,
         ...(pathToClaudeCodeExecutable ? { pathToClaudeCodeExecutable } : {}),
-        settingSources: ['project'],
+        settingSources: resolveSettingSources(settingSources),
         permissionMode: 'bypassPermissions',
         allowDangerouslySkipPermissions: true,
         allowedTools,
+        canUseTool: async (toolName: string) => {
+          if (toolName === 'AskUserQuestion') {
+            return {
+              behavior: 'deny',
+              message: 'AskUserQuestion is not available during flow execution.',
+            };
+          }
+          return { behavior: 'allow' };
+        },
         abortController,
       },
     });
@@ -331,13 +399,27 @@ export class AgentSession {
   private _turnResolve: ((result: AgentResult) => void) | null = null;
   private _turnFilesModified: string[] = [];
   private _emitProgress: ExtendedProgressEmitter | null = null;
+  private _emitQuestion: ((question: AgentQuestion) => void) | null = null;
+  private _emitPlanApproval: ((request: AgentPlanApprovalRequest) => void) | null = null;
   private _turnTimeout: ReturnType<typeof setTimeout> | null = null;
   private _turnTimeoutMs = 0;  // Stored so we can reset on activity
+  private _planModeActive = false;
+  private _pendingQuestion: {
+    toolUseId: string;
+    resolve: (answers: Record<string, string>) => void;
+    reject: (error: Error) => void;
+  } | null = null;
+  private _pendingPlanApproval: {
+    toolUseId: string;
+    resolve: (decision: { approved: boolean; feedback?: string }) => void;
+    reject: (error: Error) => void;
+  } | null = null;
 
   // Config
   private readonly _workspacePath: string;
   private readonly _excludedFolders: string[];
   private readonly _allowedTools: string[];
+  private readonly _settingSources: AgentSettingSource[];
   private readonly _modelId: string | undefined;
   private readonly _anthropicApiKey: string | undefined;
   private readonly _pathToClaudeCodeExecutable: string | undefined;
@@ -349,6 +431,7 @@ export class AgentSession {
     this._workspacePath = config.workspacePath;
     this._excludedFolders = config.excludedFolders || DEFAULT_EXCLUDED_FOLDERS;
     this._allowedTools = config.allowedTools || DEFAULT_TOOLS;
+    this._settingSources = resolveSettingSources(config.settingSources);
     this._modelId = config.model;
     this._anthropicApiKey = config.anthropicApiKey;
     this._pathToClaudeCodeExecutable = config.pathToClaudeCodeExecutable;
@@ -363,7 +446,7 @@ export class AgentSession {
    * subsequent calls feed into the existing warm process (~2-3s).
    */
   async sendMessage(options: AgentTurnOptions): Promise<AgentResult> {
-    const { prompt, attachments, activeFile, timeoutMinutes = DEFAULT_TIMEOUT_MINUTES, onProgress } = options;
+    const { prompt, attachments, activeFile, timeoutMinutes = DEFAULT_TIMEOUT_MINUTES, onProgress, onQuestion, onPlanApproval } = options;
 
     if (!prompt || prompt.trim() === '') {
       throw new Error('Agent prompt is empty');
@@ -397,6 +480,9 @@ export class AgentSession {
 
     // Set per-turn state BEFORE starting/enqueueing
     this._turnFilesModified = [];
+    this._planModeActive = false;
+    this._clearPendingQuestion();
+    this._clearPendingPlanApproval();
     this._emitProgress = (type, message, tool?, file?, subagentInfo?) => {
       onProgress?.({
         type,
@@ -409,6 +495,8 @@ export class AgentSession {
         parentToolUseId: subagentInfo?.parentToolUseId,
       });
     };
+    this._emitQuestion = onQuestion || null;
+    this._emitPlanApproval = onPlanApproval || null;
 
     const resultPromise = new Promise<AgentResult>((resolve) => {
       this._turnResolve = resolve;
@@ -438,6 +526,8 @@ export class AgentSession {
   interrupt(): void {
     const turnId = this._turnId;
     this._queryStream?.interrupt().catch(() => {});
+    this._clearPendingQuestion('Execution cancelled');
+    this._clearPendingPlanApproval('Execution cancelled');
     this._forceResolveTurn(turnId, {
       text: '',
       filesModified: [],
@@ -454,6 +544,8 @@ export class AgentSession {
     try { this._queryStream?.close(); } catch {}
     this._queryStream = null;
     this._model = null;
+    this._clearPendingQuestion('Session closed');
+    this._clearPendingPlanApproval('Session closed');
     this._forceResolveTurn(this._turnId, {
       text: '',
       filesModified: [],
@@ -523,13 +615,38 @@ export class AgentSession {
       const resolve = this._turnResolve;
       this._turnResolve = null;
       this._emitProgress = null;
+      this._emitQuestion = null;
+      this._emitPlanApproval = null;
       this._turnFilesModified = [];
+      this._planModeActive = false;
       if (this._turnTimeout) {
         clearTimeout(this._turnTimeout);
         this._turnTimeout = null;
       }
       resolve(result);
     }
+  }
+
+  answerQuestion(toolUseId: string, answers: Record<string, string>): boolean {
+    if (!this._pendingQuestion || this._pendingQuestion.toolUseId !== toolUseId) {
+      return false;
+    }
+
+    const { resolve } = this._pendingQuestion;
+    this._pendingQuestion = null;
+    resolve(answers);
+    return true;
+  }
+
+  answerPlanApproval(toolUseId: string, approved: boolean, feedback?: string): boolean {
+    if (!this._pendingPlanApproval || this._pendingPlanApproval.toolUseId !== toolUseId) {
+      return false;
+    }
+
+    const { resolve } = this._pendingPlanApproval;
+    this._pendingPlanApproval = null;
+    resolve({ approved, feedback });
+    return true;
   }
 
   // ── Input channel ───────────────────────────────────────────────────
@@ -585,10 +702,11 @@ export class AgentSession {
         preset: 'claude_code',
         append: safetyAppend,
       },
-      settingSources: ['project'],
+      settingSources: this._settingSources,
       permissionMode: 'bypassPermissions',
       allowDangerouslySkipPermissions: true,
       allowedTools: this._allowedTools,
+      canUseTool: this._handleCanUseTool.bind(this),
     };
 
     if (this._modelId) {
@@ -642,8 +760,10 @@ export class AgentSession {
             message,
             this._turnFilesModified,
             this._emitProgress || (() => {}),
-            message.parent_tool_use_id
+            message.parent_tool_use_id,
+            this._planModeActive
           );
+          this._planModeActive = updatePlanModeState(message, this._planModeActive);
         } else if (message.type === 'tool_progress' || (message.type === 'system' && message.subtype === 'task_notification')) {
           processSystemMessage(message, this._emitProgress || (() => {}));
         } else if (message.type === 'result') {
@@ -700,6 +820,133 @@ export class AgentSession {
       }
     }
   }
+
+  private async _handleCanUseTool(
+    toolName: string,
+    input: Record<string, unknown>,
+    options: { signal: AbortSignal; toolUseID: string }
+  ): Promise<{ behavior: 'allow'; updatedInput?: Record<string, unknown> } | { behavior: 'deny'; message: string; interrupt?: boolean }> {
+    if (toolName === 'ExitPlanMode') {
+      if (!this._emitPlanApproval) {
+        return {
+          behavior: 'deny',
+          message: 'Plan approval UI is unavailable for this session.',
+          interrupt: true,
+        };
+      }
+
+      try {
+        const decision = await new Promise<{ approved: boolean; feedback?: string }>((resolve, reject) => {
+          this._pendingPlanApproval = {
+            toolUseId: options.toolUseID,
+            resolve,
+            reject,
+          };
+
+          this._emitPlanApproval?.({ toolUseId: options.toolUseID });
+
+          options.signal.addEventListener('abort', () => {
+            if (this._pendingPlanApproval?.toolUseId === options.toolUseID) {
+              this._pendingPlanApproval = null;
+            }
+            reject(new Error('Plan approval cancelled'));
+          }, { once: true });
+        });
+
+        if (decision.approved) {
+          this._planModeActive = false;
+          return {
+            behavior: 'allow',
+            updatedInput: input,
+          };
+        }
+
+        return {
+          behavior: 'deny',
+          message: decision.feedback?.trim() || 'Plan rejected by user.',
+        };
+      } catch (error) {
+        return {
+          behavior: 'deny',
+          message: error instanceof Error ? error.message : 'Plan approval failed',
+          interrupt: true,
+        };
+      }
+    }
+
+    if (toolName !== 'AskUserQuestion') {
+      return { behavior: 'allow' };
+    }
+
+    const question = normalizeAgentQuestion(input, options.toolUseID);
+    if (!question) {
+      return {
+        behavior: 'deny',
+        message: 'AskUserQuestion payload was invalid.',
+      };
+    }
+
+    if (!this._emitQuestion) {
+      return {
+        behavior: 'deny',
+        message: 'Question UI is unavailable for this session.',
+        interrupt: true,
+      };
+    }
+
+    try {
+      const answers = await new Promise<Record<string, string>>((resolve, reject) => {
+        this._pendingQuestion = {
+          toolUseId: options.toolUseID,
+          resolve,
+          reject,
+        };
+
+        this._emitQuestion?.(question);
+
+        options.signal.addEventListener('abort', () => {
+          if (this._pendingQuestion?.toolUseId === options.toolUseID) {
+            this._pendingQuestion = null;
+          }
+          reject(new Error('AskUserQuestion cancelled'));
+        }, { once: true });
+      });
+
+      return {
+        behavior: 'allow',
+        updatedInput: {
+          ...input,
+          answers,
+        },
+      };
+    } catch (error) {
+      return {
+        behavior: 'deny',
+        message: error instanceof Error ? error.message : 'AskUserQuestion failed',
+        interrupt: true,
+      };
+    }
+  }
+
+  private _clearPendingQuestion(message = 'Question cancelled') {
+    if (!this._pendingQuestion) {
+      return;
+    }
+
+    const { reject } = this._pendingQuestion;
+    this._pendingQuestion = null;
+    reject(new Error(message));
+  }
+
+  private _clearPendingPlanApproval(message = 'Plan approval cancelled') {
+    if (!this._pendingPlanApproval) {
+      return;
+    }
+
+    const { reject } = this._pendingPlanApproval;
+    this._pendingPlanApproval = null;
+    reject(new Error(message));
+  }
 }
 
 // ── Shared helpers ──────────────────────────────────────────────────
@@ -722,15 +969,20 @@ function processAssistantMessage(
   message: SDKMessage,
   filesModified: string[],
   emitProgress: ExtendedProgressEmitter,
-  parentToolUseId?: string | null
+  parentToolUseId?: string | null,
+  planModeActive = false
 ) {
   const content = message.message?.content;
   if (!Array.isArray(content)) return;
 
   for (const block of content) {
     if (block.type === 'text' && block.text) {
-      const snippet = block.text.substring(0, 150);
-      emitProgress('thinking', snippet.length < block.text.length ? snippet + '...' : snippet);
+      if (planModeActive && !parentToolUseId) {
+        emitProgress('plan_text', block.text);
+      } else {
+        const snippet = block.text.substring(0, 150);
+        emitProgress('thinking', snippet.length < block.text.length ? snippet + '...' : snippet);
+      }
     } else if (block.type === 'tool_use') {
       const input = block.input as {
         file_path?: string;
@@ -791,6 +1043,26 @@ function processAssistantMessage(
       }
     }
   }
+}
+
+function updatePlanModeState(message: SDKMessage, currentState: boolean): boolean {
+  const content = message.message?.content;
+  if (!Array.isArray(content)) {
+    return currentState;
+  }
+
+  let nextState = currentState;
+  for (const block of content) {
+    if (block.type !== 'tool_use') {
+      continue;
+    }
+
+    if (block.name === 'EnterPlanMode') {
+      nextState = true;
+    }
+  }
+
+  return nextState;
 }
 
 /**

--- a/extensions/ritemark/src/agent/AgentRunner.ts
+++ b/extensions/ritemark/src/agent/AgentRunner.ts
@@ -26,6 +26,7 @@ import type {
   SDKMessage,
   SubagentProgress,
 } from './types';
+import { traceClaude } from './agentTrace';
 
 // Dynamic import for ES Module SDK (VS Code extensions use CommonJS)
 // Using Function constructor to bypass TypeScript's import() → require() transformation
@@ -119,9 +120,22 @@ function isContextOverflowError(str: string): boolean {
 
 // ── Constants ────────────────────────────────────────────────────────
 
-const DEFAULT_TOOLS = ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep', 'AskUserQuestion'];
+const DEFAULT_TOOLS = ['Bash', 'Read', 'Write', 'Edit', 'Glob', 'Grep', 'AskUserQuestion', 'ExitPlanMode'];
 export const DEFAULT_SETTING_SOURCES: AgentSettingSource[] = ['user', 'project', 'local'];
 const DEFAULT_TIMEOUT_MINUTES = 15;
+const CLAUDE_LIFECYCLE_APPEND = [
+  'LIFECYCLE RULES:',
+  '- If the user asks to work in plan mode, enter plan mode before execution.',
+  '- If you need clarification from the user and AskUserQuestion can represent it, use AskUserQuestion instead of asking in normal assistant text.',
+  '- If the user explicitly asked for multiple-choice questions, use AskUserQuestion for them.',
+  '- When your draft plan is ready, use ExitPlanMode to request plan review instead of presenting the plan as a final answer.',
+  '- After AskUserQuestion or ExitPlanMode, wait for the user response instead of continuing as if the tool had not paused execution.',
+].join('\n');
+const CLAUDE_TURN_REMINDER = [
+  'Follow the Ritemark lifecycle contract for this turn.',
+  'Use AskUserQuestion for multiple-choice clarification when needed.',
+  'Use ExitPlanMode when a reviewable draft plan is ready.',
+].join(' ');
 
 const DEFAULT_EXCLUDED_FOLDERS = [
   '.git',
@@ -146,6 +160,14 @@ function buildSafetyPrefix(workspacePath: string, excludedFolders: string[]): st
 Do NOT read, write, edit, or delete files matching these patterns:
 ${exclusions}
 If a user asks you to operate on these paths, explain that they are excluded for safety.\n\n`;
+}
+
+export function buildClaudeSystemAppend(workspacePath: string, excludedFolders: string[]): string {
+  return buildSafetyPrefix(workspacePath, excludedFolders) + CLAUDE_LIFECYCLE_APPEND;
+}
+
+export function buildClaudeTurnPrompt(prompt: string): string {
+  return `${CLAUDE_TURN_REMINDER}\n\n${prompt}`;
 }
 
 function normalizeAgentQuestion(input: Record<string, unknown>, toolUseId: string): AgentQuestion | null {
@@ -245,8 +267,7 @@ export async function runAgent(options: AgentExecutionOptions): Promise<AgentRes
     throw new Error('Agent prompt is empty');
   }
 
-  const safetyPrefix = buildSafetyPrefix(workspacePath, excludedFolders);
-  const fullPrompt = safetyPrefix + prompt;
+  const fullPrompt = buildClaudeTurnPrompt(buildSafetyPrefix(workspacePath, excludedFolders) + prompt);
 
   const abortController = new AbortController();
   const timeoutMs = timeoutMinutes * 60 * 1000;
@@ -453,10 +474,10 @@ export class AgentSession {
     }
 
     // Build prompt with active file context (skip if already referenced in path chips)
-    let fullPrompt = prompt;
+    let fullPrompt = buildClaudeTurnPrompt(prompt);
     if (activeFile) {
-      const alreadyReferenced = prompt.includes(`[File: ${activeFile.path}]`) ||
-        prompt.match(new RegExp(`\\[File:.*/${activeFile.path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\]`));
+      const alreadyReferenced = fullPrompt.includes(`[File: ${activeFile.path}]`) ||
+        fullPrompt.match(new RegExp(`\\[File:.*/${activeFile.path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\]`));
       if (!alreadyReferenced) {
         let fileContext = `[Currently editing: ${activeFile.path}]`;
         if (activeFile.selection) {
@@ -465,18 +486,25 @@ export class AgentSession {
             : activeFile.selection;
           fileContext += `\n[Selected text: ${selSnippet}]`;
         }
-        fullPrompt = fileContext + '\n\n' + prompt;
+        fullPrompt = fileContext + '\n\n' + fullPrompt;
       } else if (activeFile.selection) {
         // File already referenced but selection still useful
         const selSnippet = activeFile.selection.length > 500
           ? activeFile.selection.substring(0, 500) + '...'
           : activeFile.selection;
-        fullPrompt = `[Selected text: ${selSnippet}]\n\n` + prompt;
+        fullPrompt = `[Selected text: ${selSnippet}]\n\n` + fullPrompt;
       }
     }
 
     const userMsg = buildUserMessage(fullPrompt, attachments);
     const turnId = ++this._turnId;
+    traceClaude('execution', 'sendMessage', {
+      turnId,
+      model: this._modelId ?? this._model,
+      promptPreview: prompt.slice(0, 200),
+      attachmentCount: attachments?.length ?? 0,
+      activeFile: activeFile?.path ?? null,
+    });
 
     // Set per-turn state BEFORE starting/enqueueing
     this._turnFilesModified = [];
@@ -525,6 +553,7 @@ export class AgentSession {
    */
   interrupt(): void {
     const turnId = this._turnId;
+    traceClaude('lifecycle', 'interrupt', { turnId });
     this._queryStream?.interrupt().catch(() => {});
     this._clearPendingQuestion('Execution cancelled');
     this._clearPendingPlanApproval('Execution cancelled');
@@ -540,6 +569,10 @@ export class AgentSession {
    * Close the session entirely. Kills the process and resets all state.
    */
   close(): void {
+    traceClaude('lifecycle', 'close', {
+      active: this.isActive,
+      currentTurnId: this._turnId,
+    });
     this._closed = true;
     try { this._queryStream?.close(); } catch {}
     this._queryStream = null;
@@ -628,7 +661,12 @@ export class AgentSession {
   }
 
   answerQuestion(toolUseId: string, answers: Record<string, string>): boolean {
+    traceClaude('lifecycle', 'answerQuestion', {
+      toolUseId,
+      answerKeys: Object.keys(answers),
+    });
     if (!this._pendingQuestion || this._pendingQuestion.toolUseId !== toolUseId) {
+      traceClaude('lifecycle', 'answerQuestion missed pending state', { toolUseId });
       return false;
     }
 
@@ -639,7 +677,13 @@ export class AgentSession {
   }
 
   answerPlanApproval(toolUseId: string, approved: boolean, feedback?: string): boolean {
+    traceClaude('lifecycle', 'answerPlanApproval', {
+      toolUseId,
+      approved,
+      hasFeedback: Boolean(feedback?.trim()),
+    });
     if (!this._pendingPlanApproval || this._pendingPlanApproval.toolUseId !== toolUseId) {
+      traceClaude('lifecycle', 'answerPlanApproval missed pending state', { toolUseId });
       return false;
     }
 
@@ -692,7 +736,7 @@ export class AgentSession {
 
   private async _startSession(firstMsg: Record<string, unknown>) {
     const query = await getQuery();
-    const safetyAppend = buildSafetyPrefix(this._workspacePath, this._excludedFolders);
+    const safetyAppend = buildClaudeSystemAppend(this._workspacePath, this._excludedFolders);
 
     const queryOptions: Record<string, unknown> = {
       cwd: this._workspacePath,
@@ -725,6 +769,12 @@ export class AgentSession {
       prompt: this._createMessageStream(firstMsg),
       options: queryOptions,
     }) as QueryHandle;
+    traceClaude('execution', 'session started', {
+      model: this._modelId ?? null,
+      settingSources: this._settingSources,
+      allowedTools: this._allowedTools,
+      workspacePath: this._workspacePath,
+    });
 
     // Start background consumer (runs for session lifetime)
     this._consumeLoop().catch(() => {});
@@ -747,15 +797,22 @@ export class AgentSession {
         }
 
         if (message.type === 'system' && message.subtype === 'init') {
+          traceClaude('sdk', 'system:init', {
+            model: message.model ?? null,
+            sessionId: message.session_id ?? null,
+          });
           this._model = message.model || null;
           this._emitProgress?.('init', `Starting Claude (${message.model || 'claude'})`);
           // Fetch supported models from the SDK session
           this._fetchSupportedModels();
         } else if (message.type === 'system' && message.subtype === 'status' && (message as any).status === 'compacting') {
+          traceClaude('sdk', 'system:status', { status: (message as any).status });
           this._emitProgress?.('compacting', 'Vestlus on pikaks läinud — teen varasemast kokkuvõtte...');
         } else if (message.type === 'system' && message.subtype === 'compact_boundary') {
+          traceClaude('sdk', 'system:compact_boundary');
           this._emitProgress?.('compacted', 'Varasem vestlus on kokku võetud. Kui midagi olulist puudu, maini seda uuesti.');
         } else if (message.type === 'assistant') {
+          traceClaude('sdk', 'assistant message', summarizeAssistantMessage(message));
           processAssistantMessage(
             message,
             this._turnFilesModified,
@@ -765,8 +822,19 @@ export class AgentSession {
           );
           this._planModeActive = updatePlanModeState(message, this._planModeActive);
         } else if (message.type === 'tool_progress' || (message.type === 'system' && message.subtype === 'task_notification')) {
+          traceClaude('sdk', 'tool/system progress', {
+            type: message.type,
+            subtype: message.subtype,
+            toolName: message.tool_name ?? null,
+            status: message.status ?? null,
+          });
           processSystemMessage(message, this._emitProgress || (() => {}));
         } else if (message.type === 'result') {
+          traceClaude('sdk', 'result', {
+            subtype: message.subtype,
+            durationMs: message.duration_ms ?? null,
+            errors: message.errors ?? [],
+          });
           // Only resolve if this result matches the current turn
           // (after interrupt + new turn, stale results are ignored)
           if (this._consumerTurnId === this._turnId) {
@@ -803,6 +871,7 @@ export class AgentSession {
     } catch (error) {
       if (this._closed) return;
       const errorMessage = error instanceof Error ? error.message : String(error);
+      traceClaude('sdk', 'consumeLoop error', { error: errorMessage });
       const progressType = isContextOverflowError(errorMessage) ? 'context_overflow' : 'error';
       // Process died — resolve any pending turn
       this._emitProgress?.(progressType as AgentProgress['type'], errorMessage);
@@ -827,6 +896,10 @@ export class AgentSession {
     options: { signal: AbortSignal; toolUseID: string }
   ): Promise<{ behavior: 'allow'; updatedInput?: Record<string, unknown> } | { behavior: 'deny'; message: string; interrupt?: boolean }> {
     if (toolName === 'ExitPlanMode') {
+      traceClaude('tool', 'ExitPlanMode requested', {
+        toolUseId: options.toolUseID,
+        input,
+      });
       if (!this._emitPlanApproval) {
         return {
           behavior: 'deny',
@@ -844,6 +917,9 @@ export class AgentSession {
           };
 
           this._emitPlanApproval?.({ toolUseId: options.toolUseID });
+          traceClaude('tool', 'ExitPlanMode emitted approval request', {
+            toolUseId: options.toolUseID,
+          });
 
           options.signal.addEventListener('abort', () => {
             if (this._pendingPlanApproval?.toolUseId === options.toolUseID) {
@@ -854,6 +930,7 @@ export class AgentSession {
         });
 
         if (decision.approved) {
+          traceClaude('tool', 'ExitPlanMode approved', { toolUseId: options.toolUseID });
           this._planModeActive = false;
           return {
             behavior: 'allow',
@@ -866,6 +943,10 @@ export class AgentSession {
           message: decision.feedback?.trim() || 'Plan rejected by user.',
         };
       } catch (error) {
+        traceClaude('tool', 'ExitPlanMode failed', {
+          toolUseId: options.toolUseID,
+          error: error instanceof Error ? error.message : 'Plan approval failed',
+        });
         return {
           behavior: 'deny',
           message: error instanceof Error ? error.message : 'Plan approval failed',
@@ -879,6 +960,10 @@ export class AgentSession {
     }
 
     const question = normalizeAgentQuestion(input, options.toolUseID);
+    traceClaude('tool', 'AskUserQuestion requested', {
+      toolUseId: options.toolUseID,
+      questionCount: question?.questions.length ?? 0,
+    });
     if (!question) {
       return {
         behavior: 'deny',
@@ -903,6 +988,10 @@ export class AgentSession {
         };
 
         this._emitQuestion?.(question);
+        traceClaude('tool', 'AskUserQuestion emitted question', {
+          toolUseId: options.toolUseID,
+          questionHeaders: question.questions.map((item) => item.header),
+        });
 
         options.signal.addEventListener('abort', () => {
           if (this._pendingQuestion?.toolUseId === options.toolUseID) {
@@ -920,6 +1009,10 @@ export class AgentSession {
         },
       };
     } catch (error) {
+      traceClaude('tool', 'AskUserQuestion failed', {
+        toolUseId: options.toolUseID,
+        error: error instanceof Error ? error.message : 'AskUserQuestion failed',
+      });
       return {
         behavior: 'deny',
         message: error instanceof Error ? error.message : 'AskUserQuestion failed',
@@ -1043,6 +1136,18 @@ function processAssistantMessage(
       }
     }
   }
+}
+
+function summarizeAssistantMessage(message: SDKMessage): { blocks: Array<Record<string, unknown>> } {
+  const content = Array.isArray(message.message?.content) ? message.message?.content : [];
+  return {
+    blocks: content.map((block) => ({
+      type: block.type,
+      name: block.name,
+      id: block.id,
+      textPreview: typeof block.text === 'string' ? block.text.slice(0, 120) : undefined,
+    })),
+  };
 }
 
 function updatePlanModeState(message: SDKMessage, currentState: boolean): boolean {

--- a/extensions/ritemark/src/agent/agentTrace.ts
+++ b/extensions/ritemark/src/agent/agentTrace.ts
@@ -1,0 +1,7 @@
+import { createRuntimeTrace } from '../utils/runtimeTrace';
+
+const agentTrace = createRuntimeTrace('Ritemark Claude Trace', 'ritemark-claude-trace.log');
+
+export const traceClaude = agentTrace.trace;
+export const showClaudeTrace = agentTrace.show;
+export const getClaudeTraceLogPath = agentTrace.getLogPath;

--- a/extensions/ritemark/src/agent/index.ts
+++ b/extensions/ritemark/src/agent/index.ts
@@ -29,6 +29,7 @@ export { CLAUDE_FALLBACK_MODELS } from './claudeModels';
 export type {
   ModelOption,
   AgentId,
+  AgentSettingSource,
   AgentInfo,
   AgentProgress,
   AgentProgressType,
@@ -38,6 +39,10 @@ export type {
   AgentSessionConfig,
   AgentTurnOptions,
   ActiveFileContext,
+  AgentQuestion,
+  AgentQuestionItem,
+  AgentQuestionOption,
+  AgentPlanApprovalRequest,
   FileAttachment,
   ImageAttachment,
   AttachmentKind,

--- a/extensions/ritemark/src/agent/index.ts
+++ b/extensions/ritemark/src/agent/index.ts
@@ -7,6 +7,7 @@
  */
 
 export { runAgent, AgentSession } from './AgentRunner';
+export { traceClaude, showClaudeTrace, getClaudeTraceLogPath } from './agentTrace';
 export {
   getSetupStatus,
   getAgentEnvironmentStatus,

--- a/extensions/ritemark/src/agent/types.ts
+++ b/extensions/ritemark/src/agent/types.ts
@@ -9,6 +9,7 @@
  * Available agent identifiers
  */
 export type AgentId = 'ritemark-agent' | 'claude-code' | 'codex';
+export type AgentSettingSource = 'user' | 'project' | 'local';
 
 /**
  * Agent metadata for the selector dropdown
@@ -75,7 +76,7 @@ export const CODEX_MODELS: ModelOption[] = [
 /**
  * Progress event types from agent execution
  */
-export type AgentProgressType = 'init' | 'thinking' | 'tool_use' | 'text' | 'plan_ready' | 'done' | 'error' | 'context_overflow' | 'subagent_start' | 'subagent_progress' | 'subagent_done' | 'compacting' | 'compacted';
+export type AgentProgressType = 'init' | 'thinking' | 'tool_use' | 'text' | 'plan_text' | 'plan_ready' | 'done' | 'error' | 'context_overflow' | 'subagent_start' | 'subagent_progress' | 'subagent_done' | 'compacting' | 'compacted';
 
 /**
  * Progress event emitted during agent execution
@@ -92,6 +93,27 @@ export interface AgentProgress {
   subagentTask?: string;
   /** For subagent events, the parent tool_use_id for correlation */
   parentToolUseId?: string;
+}
+
+export interface AgentQuestionOption {
+  label: string;
+  description: string;
+}
+
+export interface AgentQuestionItem {
+  header: string;
+  question: string;
+  options: AgentQuestionOption[];
+  multiSelect: boolean;
+}
+
+export interface AgentQuestion {
+  toolUseId: string;
+  questions: AgentQuestionItem[];
+}
+
+export interface AgentPlanApprovalRequest {
+  toolUseId: string;
 }
 
 /**
@@ -201,6 +223,7 @@ export interface AgentExecutionOptions {
   workspacePath: string;
   attachments?: FileAttachment[];
   allowedTools?: string[];
+  settingSources?: AgentSettingSource[];
   excludedFolders?: string[];
   timeoutMinutes?: number;
   abortSignal?: AbortSignal;
@@ -215,6 +238,7 @@ export interface AgentSessionConfig {
   workspacePath: string;
   excludedFolders?: string[];
   allowedTools?: string[];
+  settingSources?: AgentSettingSource[];
   model?: string;
   anthropicApiKey?: string;
   pathToClaudeCodeExecutable?: string;
@@ -237,6 +261,8 @@ export interface AgentTurnOptions {
   activeFile?: ActiveFileContext;
   timeoutMinutes?: number;
   onProgress?: (progress: AgentProgress) => void;
+  onQuestion?: (question: AgentQuestion) => void;
+  onPlanApproval?: (request: AgentPlanApprovalRequest) => void;
 }
 
 /**

--- a/extensions/ritemark/src/codex/codexAppServer.ts
+++ b/extensions/ritemark/src/codex/codexAppServer.ts
@@ -26,12 +26,15 @@ import type {
   TurnStartParams,
   TurnStartResponse,
   TurnInterruptParams,
+  CollaborationMode,
   LoginAccountChatGptParams,
   LoginAccountChatGptResponse,
   LogoutAccountResponse,
   UserInput,
   ExecCommandApprovalResponse,
   ApplyPatchApprovalResponse,
+  ToolRequestUserInputAnswer,
+  ToolRequestUserInputResponse,
   ReviewDecision,
 } from './codexProtocol';
 
@@ -46,9 +49,11 @@ export class CodexAppServer extends EventEmitter {
   private lastStderrMessage: string | null = null;
   private sawStderrSinceStart = false;
   private initializePromise: Promise<InitializeResult> | null = null;
+  private readonly trace?: (scope: string, message: string, payload?: unknown) => void;
 
-  constructor() {
+  constructor(config: { trace?: (scope: string, message: string, payload?: unknown) => void } = {}) {
     super();
+    this.trace = config.trace;
 
     this.manager = new CodexManager({
       onStdout: (data) => this.handleStdout(data),
@@ -75,11 +80,12 @@ export class CodexAppServer extends EventEmitter {
           version: '1.4.0',
         },
         capabilities: {
-          experimentalApi: false,
+          experimentalApi: true,
         },
       });
 
       this.sendNotification('initialized');
+      this.trace?.('app-server', 'initialized', result);
       return result;
     })();
 
@@ -135,7 +141,13 @@ export class CodexAppServer extends EventEmitter {
   /**
    * Start an agent turn (send user message)
    */
-  async turnStart(threadId: string, message: string, model?: string, imageDataUrls?: string[]): Promise<TurnStartResponse> {
+  async turnStart(
+    threadId: string,
+    message: string,
+    model?: string,
+    imageDataUrls?: string[],
+    collaborationMode?: CollaborationMode | null
+  ): Promise<TurnStartResponse> {
     await this.ensureInitialized();
     const input: UserInput[] = [{
       type: 'text',
@@ -151,6 +163,7 @@ export class CodexAppServer extends EventEmitter {
       threadId,
       input,
       model: model || null,
+      collaborationMode: collaborationMode ?? null,
     });
   }
 
@@ -168,15 +181,31 @@ export class CodexAppServer extends EventEmitter {
    * We respond with our decision using that same id.
    */
   sendApprovalResponse(requestId: string | number, decision: ReviewDecision): void {
+    this.sendServerRequestResponse(
+      requestId,
+      { decision } as ExecCommandApprovalResponse | ApplyPatchApprovalResponse,
+      'approval response'
+    );
+  }
+
+  sendToolRequestUserInputResponse(requestId: string | number, answers: Record<string, ToolRequestUserInputAnswer>): void {
+    this.sendServerRequestResponse(
+      requestId,
+      { answers } as ToolRequestUserInputResponse,
+      'request_user_input response'
+    );
+  }
+
+  private sendServerRequestResponse(requestId: string | number, result: unknown, label: string): void {
     const response: JsonRpcResponse = {
       jsonrpc: '2.0',
       id: requestId,
-      result: { decision } as ExecCommandApprovalResponse | ApplyPatchApprovalResponse,
+      result,
     };
     try {
       this.manager.send(JSON.stringify(response));
     } catch (error) {
-      console.error('Failed to send approval response:', error);
+      console.error(`Failed to send ${label}:`, error);
     }
   }
 
@@ -201,11 +230,20 @@ export class CodexAppServer extends EventEmitter {
       }, timeoutMs);
 
       this.pendingRequests.set(id, {
-        resolve: (result: unknown) => { clearTimeout(timer); resolve(result as TResult); },
-        reject: (error: Error) => { clearTimeout(timer); reject(error); },
+        resolve: (result: unknown) => {
+          clearTimeout(timer);
+          this.trace?.('rpc:result', method, { id, result });
+          resolve(result as TResult);
+        },
+        reject: (error: Error) => {
+          clearTimeout(timer);
+          this.trace?.('rpc:error', method, { id, error: error.message });
+          reject(error);
+        },
       });
 
       try {
+        this.trace?.('rpc:request', method, { id, params });
         this.manager.send(JSON.stringify(request));
       } catch (error) {
         clearTimeout(timer);
@@ -219,6 +257,7 @@ export class CodexAppServer extends EventEmitter {
    * Handle stdout data (JSONL parsing)
    */
   private handleStdout(data: string): void {
+    this.trace?.('stdio:stdout', 'chunk', data);
     this.buffer += data;
 
     const lines = this.buffer.split('\n');
@@ -244,10 +283,12 @@ export class CodexAppServer extends EventEmitter {
 
     this.lastStderrMessage = normalized;
     this.sawStderrSinceStart = true;
+    this.trace?.('stdio:stderr', 'message', normalized);
     console.error('[codex stderr]', normalized);
   }
 
   private handleExit(code: number | null): void {
+    this.trace?.('app-server', 'exit', { code });
     for (const [, { reject }] of this.pendingRequests.entries()) {
       reject(new Error('Codex app-server exited unexpectedly'));
     }
@@ -266,6 +307,7 @@ export class CodexAppServer extends EventEmitter {
       params,
     };
 
+    this.trace?.('rpc:notification', method, params);
     this.manager.send(JSON.stringify(notification));
   }
 
@@ -295,6 +337,10 @@ export class CodexAppServer extends EventEmitter {
         }
       }
     } else if (hasId && hasMethod) {
+      this.trace?.('rpc:server-request', String(message.method), {
+        id: message.id,
+        params: message.params,
+      });
       // Server-initiated request (approval)
       // Emit with method name so UnifiedViewProvider can handle & respond
       this.emit('server-request', {
@@ -305,6 +351,7 @@ export class CodexAppServer extends EventEmitter {
     } else if (hasMethod) {
       // Notification (event)
       const notification = message as unknown as JsonRpcNotification;
+      this.trace?.('rpc:event', String(notification.method), notification.params);
       this.emit(notification.method as string, notification.params);
       this.emit('notification', notification);
     }

--- a/extensions/ritemark/src/codex/codexManager.ts
+++ b/extensions/ritemark/src/codex/codexManager.ts
@@ -8,6 +8,9 @@
  * - Graceful shutdown
  */
 
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
 import { spawn, spawnSync, ChildProcess } from 'child_process';
 import { isEnabled } from '../features/featureGate';
 
@@ -30,9 +33,29 @@ export interface CodexBinaryStatus {
   installNodeArch: string | null;
   runtimeNodeArch: string;
   machineArch: string;
+  compatibility: CodexCompatibilityStatus | null;
+}
+
+export interface CodexCapabilityFlags {
+  approvals: boolean;
+  requestUserInput: boolean;
+  planUpdates: boolean;
+}
+
+export interface CodexCompatibilityStatus {
+  state: 'compatible' | 'limited' | 'untested';
+  summary: string;
+  auditedRange: string;
+  versionInAuditedRange: boolean;
+  capabilities: CodexCapabilityFlags;
+  limitations: string[];
 }
 
 export class CodexManager {
+  private static readonly MIN_AUDITED_VERSION = '0.111.0';
+  private static readonly MAX_AUDITED_VERSION_EXCLUSIVE = '0.115.0';
+  private static readonly AUDITED_RANGE_LABEL = '0.111.x - 0.114.x';
+  private static readonly compatibilityCache = new Map<string, CodexCompatibilityStatus>();
   private process: ChildProcess | null = null;
   private config: CodexManagerConfig;
   private isShuttingDown = false;
@@ -125,6 +148,7 @@ export class CodexManager {
         installNodeArch: null,
         runtimeNodeArch,
         machineArch,
+        compatibility: null,
       };
     }
 
@@ -157,6 +181,7 @@ export class CodexManager {
             installNodeArch,
             runtimeNodeArch,
             machineArch,
+            compatibility: this.inspectCompatibility(binaryPath, match ? match[1] : null),
           });
           return;
         }
@@ -175,6 +200,7 @@ export class CodexManager {
           installNodeArch,
           runtimeNodeArch,
           machineArch,
+          compatibility: null,
         });
       });
 
@@ -192,6 +218,7 @@ export class CodexManager {
           installNodeArch,
           runtimeNodeArch,
           machineArch,
+          compatibility: null,
         });
       });
     });
@@ -431,6 +458,156 @@ export class CodexManager {
     return firstLine ?? 'Codex CLI failed to start.';
   }
 
+  private inspectCompatibility(binaryPath: string, version: string | null): CodexCompatibilityStatus {
+    const cacheKey = `${binaryPath}:${version ?? 'unknown'}`;
+    const cached = CodexManager.compatibilityCache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+
+    const defaultCapabilities: CodexCapabilityFlags = {
+      approvals: false,
+      requestUserInput: false,
+      planUpdates: false,
+    };
+    const versionInAuditedRange = version
+      ? this.isVersionInAuditedRange(version)
+      : false;
+    const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ritemark-codex-protocol-'));
+
+    try {
+      const result = this.spawnResolvedBinarySync(binaryPath, ['app-server', 'generate-ts', '--out', tempDir], {
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'pipe'],
+        timeout: 8000,
+      });
+
+      if (result.status !== 0) {
+        const failure = this.summarizeFailure(String(result.stderr || result.stdout || 'Codex protocol probe failed.'));
+        const status = this.buildCompatibilityStatus(
+          version,
+          versionInAuditedRange,
+          defaultCapabilities,
+          [`Protocol probe failed: ${failure}`]
+        );
+        CodexManager.compatibilityCache.set(cacheKey, status);
+        return status;
+      }
+
+      const requestText = this.readGeneratedProtocolFile(tempDir, 'ServerRequest.ts');
+      const notificationText = this.readGeneratedProtocolFile(tempDir, 'ServerNotification.ts');
+      const capabilities: CodexCapabilityFlags = {
+        approvals: requestText.includes('item/commandExecution/requestApproval')
+          && requestText.includes('item/fileChange/requestApproval'),
+        requestUserInput: requestText.includes('item/tool/requestUserInput'),
+        planUpdates: notificationText.includes('turn/plan/updated')
+          || notificationText.includes('item/plan/delta'),
+      };
+
+      const limitations: string[] = [];
+      if (!capabilities.approvals) {
+        limitations.push('Approval requests were not detected in the current Codex app-server protocol.');
+      }
+      if (!capabilities.requestUserInput) {
+        limitations.push('Interactive question prompts were not detected in the current Codex app-server protocol.');
+      }
+      if (!capabilities.planUpdates) {
+        limitations.push('Structured plan update notifications were not detected in the current Codex app-server protocol.');
+      }
+
+      const status = this.buildCompatibilityStatus(version, versionInAuditedRange, capabilities, limitations);
+      CodexManager.compatibilityCache.set(cacheKey, status);
+      return status;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      const status = this.buildCompatibilityStatus(
+        version,
+        versionInAuditedRange,
+        defaultCapabilities,
+        [`Protocol probe failed: ${message}`]
+      );
+      CodexManager.compatibilityCache.set(cacheKey, status);
+      return status;
+    } finally {
+      fs.rmSync(tempDir, { recursive: true, force: true });
+    }
+  }
+
+  private buildCompatibilityStatus(
+    version: string | null,
+    versionInAuditedRange: boolean,
+    capabilities: CodexCapabilityFlags,
+    limitations: string[]
+  ): CodexCompatibilityStatus {
+    if (!versionInAuditedRange) {
+      return {
+        state: 'untested',
+        summary: version
+          ? `Codex ${version} is outside Ritemark's audited range ${CodexManager.AUDITED_RANGE_LABEL}. Ritemark will only enable capabilities it can detect at runtime.`
+          : `Codex version could not be detected. Ritemark will only enable capabilities it can detect at runtime.`,
+        auditedRange: CodexManager.AUDITED_RANGE_LABEL,
+        versionInAuditedRange,
+        capabilities,
+        limitations,
+      };
+    }
+
+    if (limitations.length > 0) {
+      return {
+        state: 'limited',
+        summary: `Codex is runnable, but this version is missing one or more lifecycle capabilities that Ritemark expects in the audited range ${CodexManager.AUDITED_RANGE_LABEL}.`,
+        auditedRange: CodexManager.AUDITED_RANGE_LABEL,
+        versionInAuditedRange,
+        capabilities,
+        limitations,
+      };
+    }
+
+    return {
+      state: 'compatible',
+      summary: `Codex matches the audited lifecycle capability set for ${CodexManager.AUDITED_RANGE_LABEL}.`,
+      auditedRange: CodexManager.AUDITED_RANGE_LABEL,
+      versionInAuditedRange,
+      capabilities,
+      limitations: [],
+    };
+  }
+
+  private readGeneratedProtocolFile(outputDir: string, fileName: string): string {
+    const directPath = path.join(outputDir, fileName);
+    if (fs.existsSync(directPath)) {
+      return fs.readFileSync(directPath, 'utf8');
+    }
+
+    const nestedPath = path.join(outputDir, 'openai', 'codex', fileName);
+    if (fs.existsSync(nestedPath)) {
+      return fs.readFileSync(nestedPath, 'utf8');
+    }
+
+    return '';
+  }
+
+  private isVersionInAuditedRange(version: string): boolean {
+    return this.compareVersions(version, CodexManager.MIN_AUDITED_VERSION) >= 0
+      && this.compareVersions(version, CodexManager.MAX_AUDITED_VERSION_EXCLUSIVE) < 0;
+  }
+
+  private compareVersions(left: string, right: string): number {
+    const leftParts = left.split('.').map((part) => Number.parseInt(part, 10) || 0);
+    const rightParts = right.split('.').map((part) => Number.parseInt(part, 10) || 0);
+    const length = Math.max(leftParts.length, rightParts.length);
+
+    for (let index = 0; index < length; index += 1) {
+      const leftValue = leftParts[index] ?? 0;
+      const rightValue = rightParts[index] ?? 0;
+      if (leftValue !== rightValue) {
+        return leftValue - rightValue;
+      }
+    }
+
+    return 0;
+  }
+
   private spawnResolvedBinary(
     binaryPath: string,
     args: string[],
@@ -438,6 +615,18 @@ export class CodexManager {
   ): ChildProcess {
     const isWindowsScript = process.platform === 'win32' && /\.(cmd|bat)$/i.test(binaryPath);
     return spawn(binaryPath, args, {
+      ...options,
+      shell: options.shell ?? isWindowsScript,
+    });
+  }
+
+  private spawnResolvedBinarySync(
+    binaryPath: string,
+    args: string[],
+    options: Parameters<typeof spawnSync>[2] = {}
+  ): ReturnType<typeof spawnSync> {
+    const isWindowsScript = process.platform === 'win32' && /\.(cmd|bat)$/i.test(binaryPath);
+    return spawnSync(binaryPath, args, {
       ...options,
       shell: options.shell ?? isWindowsScript,
     });

--- a/extensions/ritemark/src/codex/codexProtocol.ts
+++ b/extensions/ritemark/src/codex/codexProtocol.ts
@@ -174,6 +174,7 @@ export interface TurnStartParams {
   threadId: string;
   input: UserInput[];
   model?: string | null;
+  collaborationMode?: CollaborationMode | null;
 }
 
 export interface TurnStartResponse {
@@ -225,6 +226,36 @@ export interface ApplyPatchApprovalResponse {
   decision: ReviewDecision;
 }
 
+/** Server asks client to answer a request_user_input prompt */
+export interface ToolRequestUserInputOption {
+  label: string;
+  description: string;
+}
+
+export interface ToolRequestUserInputQuestion {
+  id: string;
+  header: string;
+  question: string;
+  isOther: boolean;
+  isSecret: boolean;
+  options: ToolRequestUserInputOption[] | null;
+}
+
+export interface ToolRequestUserInputParams {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  questions: ToolRequestUserInputQuestion[];
+}
+
+export interface ToolRequestUserInputAnswer {
+  answers: string[];
+}
+
+export interface ToolRequestUserInputResponse {
+  answers: Record<string, ToolRequestUserInputAnswer>;
+}
+
 export type FileChange =
   | { type: 'add'; content: string }
   | { type: 'delete'; content: string }
@@ -238,6 +269,20 @@ export type FileChange =
 export interface TurnStartedNotification {
   threadId: string;
   turn: TurnInfo;
+  collaborationModeKind?: ModeKind;
+}
+
+export type ModeKind = 'plan' | 'default';
+
+export interface CollaborationModeSettings {
+  model: string;
+  reasoning_effort: string | null;
+  developer_instructions: string | null;
+}
+
+export interface CollaborationMode {
+  mode: ModeKind;
+  settings: CollaborationModeSettings;
 }
 
 /** turn/completed notification */
@@ -266,6 +311,29 @@ export interface ItemCompletedNotification {
   item: unknown;
   threadId: string;
   turnId: string;
+}
+
+export type TurnPlanStepStatus = 'pending' | 'inProgress' | 'completed';
+
+export interface TurnPlanStep {
+  step: string;
+  status: TurnPlanStepStatus;
+}
+
+/** turn/plan/updated notification */
+export interface TurnPlanUpdatedNotification {
+  threadId: string;
+  turnId: string;
+  explanation: string | null;
+  plan: TurnPlanStep[];
+}
+
+/** item/plan/delta notification */
+export interface PlanDeltaNotification {
+  threadId: string;
+  turnId: string;
+  itemId: string;
+  delta: string;
 }
 
 /** account/updated notification */

--- a/extensions/ritemark/src/codex/codexTrace.ts
+++ b/extensions/ritemark/src/codex/codexTrace.ts
@@ -1,47 +1,7 @@
-import * as vscode from 'vscode';
-import * as fs from 'fs';
-import * as os from 'os';
-import * as path from 'path';
+import { createRuntimeTrace } from '../utils/runtimeTrace';
 
-let codexTraceChannel: vscode.OutputChannel | null = null;
-const TRACE_LOG_PATH = path.join(os.tmpdir(), 'ritemark-codex-trace.log');
+const codexTrace = createRuntimeTrace('Ritemark Codex Trace', 'ritemark-codex-trace.log');
 
-function getTraceChannel(): vscode.OutputChannel {
-  if (!codexTraceChannel) {
-    codexTraceChannel = vscode.window.createOutputChannel('Ritemark Codex Trace');
-  }
-  return codexTraceChannel;
-}
-
-function safeSerialize(value: unknown): string {
-  try {
-    const text = JSON.stringify(value);
-    if (!text) {
-      return '';
-    }
-    return text.length > 4000 ? `${text.slice(0, 4000)}…` : text;
-  } catch (error) {
-    return `[unserializable: ${error instanceof Error ? error.message : String(error)}]`;
-  }
-}
-
-export function traceCodex(scope: string, message: string, payload?: unknown): void {
-  const channel = getTraceChannel();
-  const timestamp = new Date().toISOString();
-  const suffix = payload === undefined ? '' : ` ${safeSerialize(payload)}`;
-  const line = `[${timestamp}] [${scope}] ${message}${suffix}`;
-  channel.appendLine(line);
-  try {
-    fs.appendFileSync(TRACE_LOG_PATH, `${line}\n`, 'utf8');
-  } catch {
-    // Ignore file logging failures; the Output channel is still useful.
-  }
-}
-
-export function showCodexTrace(): void {
-  getTraceChannel().show(true);
-}
-
-export function getCodexTraceLogPath(): string {
-  return TRACE_LOG_PATH;
-}
+export const traceCodex = codexTrace.trace;
+export const showCodexTrace = codexTrace.show;
+export const getCodexTraceLogPath = codexTrace.getLogPath;

--- a/extensions/ritemark/src/codex/codexTrace.ts
+++ b/extensions/ritemark/src/codex/codexTrace.ts
@@ -1,0 +1,47 @@
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+let codexTraceChannel: vscode.OutputChannel | null = null;
+const TRACE_LOG_PATH = path.join(os.tmpdir(), 'ritemark-codex-trace.log');
+
+function getTraceChannel(): vscode.OutputChannel {
+  if (!codexTraceChannel) {
+    codexTraceChannel = vscode.window.createOutputChannel('Ritemark Codex Trace');
+  }
+  return codexTraceChannel;
+}
+
+function safeSerialize(value: unknown): string {
+  try {
+    const text = JSON.stringify(value);
+    if (!text) {
+      return '';
+    }
+    return text.length > 4000 ? `${text.slice(0, 4000)}…` : text;
+  } catch (error) {
+    return `[unserializable: ${error instanceof Error ? error.message : String(error)}]`;
+  }
+}
+
+export function traceCodex(scope: string, message: string, payload?: unknown): void {
+  const channel = getTraceChannel();
+  const timestamp = new Date().toISOString();
+  const suffix = payload === undefined ? '' : ` ${safeSerialize(payload)}`;
+  const line = `[${timestamp}] [${scope}] ${message}${suffix}`;
+  channel.appendLine(line);
+  try {
+    fs.appendFileSync(TRACE_LOG_PATH, `${line}\n`, 'utf8');
+  } catch {
+    // Ignore file logging failures; the Output channel is still useful.
+  }
+}
+
+export function showCodexTrace(): void {
+  getTraceChannel().show(true);
+}
+
+export function getCodexTraceLogPath(): string {
+  return TRACE_LOG_PATH;
+}

--- a/extensions/ritemark/src/codex/index.ts
+++ b/extensions/ritemark/src/codex/index.ts
@@ -11,10 +11,16 @@
  * Feature flag: 'codex-integration' (experimental)
  */
 
-export { CodexManager } from './codexManager';
+export {
+  CodexManager,
+  type CodexBinaryStatus,
+  type CodexCapabilityFlags,
+  type CodexCompatibilityStatus,
+} from './codexManager';
 export { CodexAppServer } from './codexAppServer';
 export { CodexAuth } from './codexAuth';
 export { getCodexModels } from './codexModels';
+export { traceCodex, showCodexTrace } from './codexTrace';
 export {
   emitCodexStatusInvalidated,
   onCodexStatusInvalidated,

--- a/extensions/ritemark/src/flows/nodes/ClaudeCodeNodeExecutor.ts
+++ b/extensions/ritemark/src/flows/nodes/ClaudeCodeNodeExecutor.ts
@@ -115,7 +115,7 @@ export async function executeClaudeCodeNode(
     onProgress: onProgress
       ? (progress) => {
           // Map unsupported types to 'done' since flow ProgressCallback has a limited set
-          const type = (progress.type === 'error' || progress.type === 'context_overflow' || progress.type === 'plan_ready'
+          const type = (progress.type === 'error' || progress.type === 'context_overflow' || progress.type === 'plan_ready' || progress.type === 'plan_text'
             || progress.type === 'subagent_start' || progress.type === 'subagent_progress' || progress.type === 'subagent_done'
             || progress.type === 'compacting' || progress.type === 'compacted')
             ? 'done' as const

--- a/extensions/ritemark/src/settings/RitemarkSettingsProvider.ts
+++ b/extensions/ritemark/src/settings/RitemarkSettingsProvider.ts
@@ -23,7 +23,7 @@ import {
   setAnthropicKeyAvailable,
   setClaudeLoginInProgress,
 } from '../agent';
-import { CodexManager } from '../codex/codexManager';
+import { CodexManager, type CodexCompatibilityStatus } from '../codex/codexManager';
 
 export class RitemarkSettingsProvider implements vscode.WebviewPanelSerializer {
   public static readonly viewType = 'ritemark.settings';
@@ -336,6 +336,7 @@ export class RitemarkSettingsProvider implements vscode.WebviewPanelSerializer {
               : 'Failed to inspect component status',
             diagnostics: [],
             repairCommand: null,
+            compatibility: null,
           },
         };
 
@@ -410,6 +411,7 @@ export class RitemarkSettingsProvider implements vscode.WebviewPanelSerializer {
       error: string | null;
       diagnostics: string[];
       repairCommand: string | null;
+      compatibility: CodexCompatibilityStatus | null;
     };
   }> {
     const defaultModelFile = 'ggml-large-v3-turbo.bin';
@@ -463,6 +465,7 @@ export class RitemarkSettingsProvider implements vscode.WebviewPanelSerializer {
         error: codexStatus.runnable ? null : codexStatus.error,
         diagnostics: codexStatus.diagnostics,
         repairCommand: codexStatus.repairCommand,
+        compatibility: codexStatus.compatibility,
       }
     };
   }

--- a/extensions/ritemark/src/utils/runtimeTrace.ts
+++ b/extensions/ritemark/src/utils/runtimeTrace.ts
@@ -1,0 +1,66 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+type OutputChannelLike = {
+  appendLine: (value: string) => void;
+  show: (preserveFocus?: boolean) => void;
+};
+
+function safeSerialize(value: unknown): string {
+  try {
+    const text = JSON.stringify(value);
+    if (!text) {
+      return '';
+    }
+    return text.length > 4000 ? `${text.slice(0, 4000)}…` : text;
+  } catch (error) {
+    return `[unserializable: ${error instanceof Error ? error.message : String(error)}]`;
+  }
+}
+
+export function createRuntimeTrace(outputChannelName: string, logFileName: string) {
+  let channel: OutputChannelLike | null = null;
+  const traceLogPath = path.join(os.tmpdir(), logFileName);
+
+  function tryCreateOutputChannel(): OutputChannelLike | null {
+    try {
+      // Avoid hard dependency on the vscode module in plain node test runs.
+      // eslint-disable-next-line @typescript-eslint/no-implied-eval
+      const dynamicRequire = new Function('name', 'return require(name)') as (name: string) => { window?: { createOutputChannel?: (name: string) => OutputChannelLike } };
+      const vscode = dynamicRequire('vscode');
+      return vscode?.window?.createOutputChannel?.(outputChannelName) ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  function getTraceChannel(): OutputChannelLike | null {
+    if (!channel) {
+      channel = tryCreateOutputChannel();
+    }
+    return channel;
+  }
+
+  function trace(scope: string, message: string, payload?: unknown): void {
+    const timestamp = new Date().toISOString();
+    const suffix = payload === undefined ? '' : ` ${safeSerialize(payload)}`;
+    const line = `[${timestamp}] [${scope}] ${message}${suffix}`;
+    getTraceChannel()?.appendLine(line);
+    try {
+      fs.appendFileSync(traceLogPath, `${line}\n`, 'utf8');
+    } catch {
+      // Ignore file logging failures; the Output channel is still useful.
+    }
+  }
+
+  function show(): void {
+    getTraceChannel()?.show(true);
+  }
+
+  function getLogPath(): string {
+    return traceLogPath;
+  }
+
+  return { trace, show, getLogPath };
+}

--- a/extensions/ritemark/src/views/UnifiedViewProvider.ts
+++ b/extensions/ritemark/src/views/UnifiedViewProvider.ts
@@ -38,14 +38,16 @@ import {
   emitClaudeStatusInvalidated,
   onClaudeStatusInvalidated,
   type AgentId,
+  type AgentPlanApprovalRequest,
   type AgentProgress,
+  type AgentQuestion,
   type FileAttachment,
   type SetupStatus,
   type AgentEnvironmentStatus,
 } from '../agent';
 import { isEnabled } from '../features';
 import { discoverAgents, discoverCommands } from '../agent/discovery';
-import { CodexAppServer, CodexAuth, CodexManager, getCodexModels, onCodexStatusInvalidated, emitCodexStatusInvalidated, routeApprovalRequest } from '../codex';
+import { CodexAppServer, CodexAuth, CodexManager, getCodexModels, onCodexStatusInvalidated, emitCodexStatusInvalidated, routeApprovalRequest, traceCodex, type CodexCompatibilityStatus } from '../codex';
 
 type CodexSidebarStatus = {
   enabled: boolean;
@@ -58,7 +60,34 @@ type CodexSidebarStatus = {
   diagnostics: string[];
   repairCommand: string | null;
   binaryPath: string | null;
+  compatibility: CodexCompatibilityStatus | null;
 };
+
+const CODEX_BASE_INSTRUCTIONS = [
+  'You are running inside Ritemark.',
+  'Prefer structured protocol features over free-form text when the protocol supports them.',
+].join(' ');
+
+const CODEX_DEVELOPER_INSTRUCTIONS = [
+  'When you need the user to choose between options or provide required clarifications before continuing, you must use the request_user_input tool instead of asking in plain assistant text.',
+  'Do not present a question as normal chat text if request_user_input can express it.',
+  'When you produce a plan, prefer structured plan updates over embedding the whole plan only in prose.',
+  'If you already asked for user input via request_user_input, wait for the answer instead of ending the turn with the question rendered as plain text.',
+].join(' ');
+
+const CODEX_TURN_REMINDER = [
+  'Ritemark runtime reminder:',
+  '- If you need the user to answer a question or choose from options, you must call request_user_input.',
+  '- Do not ask the question in normal assistant text when request_user_input can represent it.',
+  '- If the user explicitly asked for multiple-choice questions, use request_user_input for them.',
+  '- After calling request_user_input, wait for the answer instead of finishing the turn with the question in prose.',
+].join('\n');
+
+function shouldStartCodexInPlanMode(prompt: string): boolean {
+  return /\bplan mode\b/i.test(prompt)
+    || /\bwork in plan\b/i.test(prompt)
+    || /\benter plan mode\b/i.test(prompt);
+}
 
 export class UnifiedViewProvider implements vscode.WebviewViewProvider {
   public static readonly viewType = 'ritemark.unifiedView';
@@ -211,6 +240,14 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
           }
           break;
 
+        case 'agent-answer-question':
+          this._handleAgentQuestionAnswer(message.toolUseId, message.answers || {});
+          break;
+
+        case 'agent-answer-plan':
+          this._handleAgentPlanAnswer(message.toolUseId, message.approved === true, message.feedback);
+          break;
+
         case 'agent-setup:install':
           this._handleClaudeInstall();
           break;
@@ -239,7 +276,13 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
 
         // Codex messages
         case 'codex-execute':
-          await this._handleCodexExecution(message.prompt, message.model, message.attachments);
+          traceCodex('webview->extension', 'codex-execute', {
+            promptPreview: typeof message.prompt === 'string' ? message.prompt.slice(0, 200) : '',
+            model: message.model,
+            mode: message.mode,
+            attachmentCount: Array.isArray(message.attachments) ? message.attachments.length : 0,
+          });
+          await this._handleCodexExecution(message.prompt, message.model, message.attachments, message.mode);
           break;
 
         case 'codex:login':
@@ -269,11 +312,32 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
           break;
 
         case 'codex-cancel':
+          traceCodex('webview->extension', 'codex-cancel');
           this._handleCodexCancel();
           break;
 
         case 'codex-approve':
+          traceCodex('webview->extension', 'codex-approve', {
+            requestId: message.requestId,
+            approved: message.approved,
+          });
           this._handleCodexApproval(message.requestId, message.approved);
+          break;
+
+        case 'codex-answer-question':
+          traceCodex('webview->extension', 'codex-answer-question', {
+            requestId: message.requestId,
+            answers: message.answers,
+          });
+          this._handleCodexQuestionAnswer(
+            message.requestId,
+            message.answers && typeof message.answers === 'object' ? message.answers : {}
+          );
+          break;
+
+        case 'conversation:reset':
+          traceCodex('webview->extension', 'conversation:reset');
+          this._resetProviderSessions();
           break;
       }
     });
@@ -360,8 +424,7 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
    * Clear chat history and start fresh conversation
    */
   public clearChat() {
-    this._agentSession?.close();
-    this._agentSession = null;
+    this._resetProviderSessions();
     this._view?.webview.postMessage({ type: 'clear-chat' });
   }
 
@@ -534,8 +597,9 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
       return this._codexAppServer;
     }
 
-    this._codexAppServer = new CodexAppServer();
+    this._codexAppServer = new CodexAppServer({ trace: traceCodex });
     this._codexAuth = new CodexAuth(this._codexAppServer);
+    traceCodex('runtime', 'created codex app-server runtime');
 
     this._codexAuth.on('statusChanged', (status) => {
       if (!status.authenticated) {
@@ -557,7 +621,31 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
     return this._codexAppServer;
   }
 
+  private _disposeCodexRuntime(): void {
+    traceCodex('runtime', 'disposing codex runtime', {
+      hadThreadId: this._codexThreadId,
+      hadTurnId: this._codexTurnId,
+    });
+    this._codexAppServer?.dispose();
+    this._codexAppServer = null;
+    this._codexAuth = null;
+    this._codexLoginInProgress = false;
+    this._stopCodexLoginPolling();
+    this._resetCodexSessionState();
+  }
+
+  private _resetProviderSessions(): void {
+    traceCodex('runtime', 'reset provider sessions');
+    this._agentSession?.close();
+    this._agentSession = null;
+    this._disposeCodexRuntime();
+  }
+
   private _resetCodexSessionState(): void {
+    traceCodex('runtime', 'reset session state', {
+      threadId: this._codexThreadId,
+      turnId: this._codexTurnId,
+    });
     this._codexThreadId = null;
     this._codexTurnId = null;
   }
@@ -619,6 +707,7 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
         diagnostics: [],
         repairCommand: null,
         binaryPath: null,
+        compatibility: null,
       };
     }
 
@@ -637,6 +726,7 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
         diagnostics: binaryStatus.diagnostics,
         repairCommand: binaryStatus.repairCommand,
         binaryPath: binaryStatus.binaryPath,
+        compatibility: binaryStatus.compatibility,
       };
     }
 
@@ -660,6 +750,7 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
         diagnostics: binaryStatus.diagnostics,
         repairCommand: binaryStatus.repairCommand,
         binaryPath: binaryStatus.binaryPath,
+        compatibility: binaryStatus.compatibility,
       };
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
@@ -674,6 +765,7 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
         diagnostics: binaryStatus.diagnostics,
         repairCommand: binaryStatus.repairCommand,
         binaryPath: binaryStatus.binaryPath,
+        compatibility: binaryStatus.compatibility,
       };
     }
   }
@@ -713,6 +805,7 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
         diagnostics: [],
         repairCommand: null,
         binaryPath: null,
+        compatibility: null,
       });
     }
   }
@@ -841,6 +934,18 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
             progress,
           });
         },
+        onQuestion: (question: AgentQuestion) => {
+          this._view?.webview.postMessage({
+            type: 'agent-question',
+            question,
+          });
+        },
+        onPlanApproval: (request: AgentPlanApprovalRequest) => {
+          this._view?.webview.postMessage({
+            type: 'agent-plan-approval',
+            request,
+          });
+        },
       });
 
       this._view?.webview.postMessage({
@@ -859,10 +964,43 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
     }
   }
 
+  private _handleAgentQuestionAnswer(toolUseId: string, answers: Record<string, string>) {
+    if (!this._agentSession) {
+      return;
+    }
+
+    const answered = this._agentSession.answerQuestion(toolUseId, answers);
+    if (!answered) {
+      this._view?.webview.postMessage({
+        type: 'agent-result',
+        error: 'Claude question state was lost. Please retry your last message.',
+      });
+    }
+  }
+
+  private _handleAgentPlanAnswer(toolUseId: string, approved: boolean, feedback?: string) {
+    if (!this._agentSession) {
+      return;
+    }
+
+    const answered = this._agentSession.answerPlanApproval(toolUseId, approved, feedback);
+    if (!answered) {
+      this._view?.webview.postMessage({
+        type: 'agent-result',
+        error: 'Claude plan approval state was lost. Please retry your last message.',
+      });
+    }
+  }
+
   /**
    * Execute a prompt using the Codex agent (persistent thread).
    */
-  private async _handleCodexExecution(prompt: string, model?: string, attachments?: Array<{ kind: string; data: string; mediaType: string }>) {
+  private async _handleCodexExecution(
+    prompt: string,
+    model?: string,
+    attachments?: Array<{ kind: string; data: string; mediaType: string }>,
+    mode?: 'plan' | 'execute'
+  ) {
     if (!isEnabled('codex-integration')) {
       this._view?.webview.postMessage({
         type: 'codex-result',
@@ -873,6 +1011,7 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
 
     try {
       const status = await this._getCodexSidebarStatus();
+      traceCodex('execution', 'status before execute', status);
       this._postCodexSidebarStatus(status);
       if (status.state === 'broken-install') {
         this._view?.webview.postMessage({
@@ -904,8 +1043,16 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
           model: model || null,
           approvalPolicy,
           sandbox,
+          baseInstructions: CODEX_BASE_INSTRUCTIONS,
+          developerInstructions: CODEX_DEVELOPER_INSTRUCTIONS,
         });
         this._codexThreadId = result.thread.id;
+        traceCodex('execution', 'thread started', {
+          threadId: result.thread.id,
+          model: result.model,
+          approvalPolicy,
+          sandbox,
+        });
       }
 
       // Convert image attachments to data URLs for Codex
@@ -913,20 +1060,47 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
         ?.filter(a => a.kind === 'image')
         .map(a => `data:${a.mediaType};base64,${a.data}`);
 
+      const resolvedModel = model || getCodexModels()[0]?.id || 'gpt-5.3-codex';
+      const shouldUsePlanMode = mode === 'plan' || (mode !== 'execute' && shouldStartCodexInPlanMode(prompt));
+      const collaborationMode = shouldUsePlanMode
+        ? {
+            mode: 'plan' as const,
+            settings: {
+              model: resolvedModel,
+              reasoning_effort: null,
+              developer_instructions: CODEX_DEVELOPER_INSTRUCTIONS,
+            },
+          }
+        : null;
+      traceCodex('execution', 'prepared turn start', {
+        threadId: this._codexThreadId,
+        model: resolvedModel,
+        mode: mode ?? (shouldUsePlanMode ? 'plan' : 'execute'),
+        collaborationMode,
+        hasImages: Boolean(imageDataUrls && imageDataUrls.length > 0),
+      });
+
       // Prepend active file context to prompt (same pattern as Claude Code agent)
       const activeFile = this._getActiveFileContext();
-      const enrichedPrompt = activeFile
+      const promptBody = activeFile
         ? `[Currently editing: ${activeFile.path}]\n\n${prompt}`
         : prompt;
+      const enrichedPrompt = `${CODEX_TURN_REMINDER}\n\n${promptBody}`;
 
       // Start turn (send user message)
       const turnResult = await appServer.turnStart(
         this._codexThreadId,
         enrichedPrompt,
-        model,
+        resolvedModel,
         imageDataUrls && imageDataUrls.length > 0 ? imageDataUrls : undefined,
+        collaborationMode,
       );
       this._codexTurnId = turnResult.turn.id;
+      traceCodex('execution', 'turn start acknowledged', {
+        threadId: this._codexThreadId,
+        turnId: turnResult.turn.id,
+        status: turnResult.turn.status,
+      });
 
       this._view?.webview.postMessage({
         type: 'codex-progress',
@@ -934,6 +1108,7 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
       });
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err);
+      traceCodex('execution', 'turn start failed', { error: errorMessage });
       this._view?.webview.postMessage({
         type: 'codex-result',
         error: errorMessage,
@@ -960,6 +1135,11 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
     this._codexAppServer.sendApprovalResponse(requestId, approved ? 'accept' : 'decline');
   }
 
+  private _handleCodexQuestionAnswer(requestId: string | number, answers: Record<string, { answers: string[] }>) {
+    if (!this._codexAppServer) return;
+    this._codexAppServer.sendToolRequestUserInputResponse(requestId, answers);
+  }
+
   /**
    * Set up event listeners on CodexAppServer to forward events to webview.
    */
@@ -967,7 +1147,15 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
     if (!this._codexAppServer) return;
 
     // V2 notifications
+    this._codexAppServer.on('turn/started', (params: { threadId: string; turn: { id: string }; collaborationModeKind?: 'plan' | 'default' }) => {
+      traceCodex('event', 'turn/started', params);
+      if (params.collaborationModeKind) {
+        console.log(`[codex] turn started in ${params.collaborationModeKind} mode`);
+      }
+    });
+
     this._codexAppServer.on('item/started', (params: { item: { type: string; id: string; text?: string }; threadId: string; turnId: string }) => {
+      traceCodex('event', 'item/started', params);
       // Only show activity for actual tool use, not userMessage/reasoning
       const itemType = params.item?.type;
       if (itemType && itemType !== 'userMessage' && itemType !== 'reasoning') {
@@ -980,13 +1168,41 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
     });
 
     this._codexAppServer.on('item/agentMessage/delta', (params: { delta: string }) => {
+      traceCodex('event', 'item/agentMessage/delta', {
+        preview: params.delta.slice(0, 200),
+      });
       this._view?.webview.postMessage({
         type: 'codex-streaming',
         delta: params.delta,
       });
     });
 
+    this._codexAppServer.on('turn/plan/updated', (params: {
+      threadId: string;
+      turnId: string;
+      explanation: string | null;
+      plan: Array<{ step: string; status: 'pending' | 'inProgress' | 'completed' }>;
+    }) => {
+      traceCodex('event', 'turn/plan/updated', params);
+      this._view?.webview.postMessage({
+        type: 'codex-plan-update',
+        explanation: params.explanation,
+        plan: params.plan,
+      });
+    });
+
+    this._codexAppServer.on('item/plan/delta', (params: { delta: string }) => {
+      traceCodex('event', 'item/plan/delta', {
+        preview: params.delta.slice(0, 200),
+      });
+      this._view?.webview.postMessage({
+        type: 'codex-plan-text-delta',
+        delta: params.delta,
+      });
+    });
+
     this._codexAppServer.on('item/completed', (params: { item: { type: string; id: string; text?: string }; threadId: string; turnId: string }) => {
+      traceCodex('event', 'item/completed', params);
       const itemType = params.item?.type;
       // Only show completion for tool items, not userMessage/reasoning/agentMessage
       if (itemType && itemType !== 'userMessage' && itemType !== 'reasoning' && itemType !== 'agentMessage') {
@@ -998,6 +1214,7 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
     });
 
     this._codexAppServer.on('turn/completed', (params: { threadId: string; turn: { id: string; status: string; error: unknown } }) => {
+      traceCodex('event', 'turn/completed', params);
       this._codexTurnId = null;
       this._view?.webview.postMessage({
         type: 'codex-result',
@@ -1008,8 +1225,58 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
 
     // Server-initiated requests (approvals are bidirectional RPC)
     this._codexAppServer.on('server-request', (request: { id: string | number; method: string; params: Record<string, unknown> }) => {
+      traceCodex('event', 'server-request', {
+        requestId: request.id,
+        method: request.method,
+        params: request.params,
+      });
       const routed = routeApprovalRequest(request);
-      if (routed.type === 'command') {
+      if (request.method === 'item/tool/requestUserInput') {
+        console.log('[codex] request_user_input received');
+        const params = request.params;
+        const questions = Array.isArray(params.questions)
+          ? params.questions
+              .filter((question): question is {
+                id?: unknown;
+                header?: unknown;
+                question?: unknown;
+                options?: unknown;
+              } => Boolean(question) && typeof question === 'object')
+              .map((question) => ({
+                id: typeof question.id === 'string' && question.id.trim()
+                  ? question.id.trim()
+                  : crypto.randomUUID(),
+                header: typeof question.header === 'string' && question.header.trim()
+                  ? question.header.trim()
+                  : 'Input',
+                question: typeof question.question === 'string' ? question.question : '',
+                options: Array.isArray(question.options)
+                  ? question.options.flatMap((option: unknown) => {
+                      if (!option || typeof option !== 'object') {
+                        return [];
+                      }
+                      const normalizedOption = option as { label?: unknown; description?: unknown };
+                      const label = typeof normalizedOption.label === 'string' ? normalizedOption.label.trim() : '';
+                      if (!label) {
+                        return [];
+                      }
+                      return [{
+                        label,
+                        description: typeof normalizedOption.description === 'string' ? normalizedOption.description.trim() : '',
+                      }];
+                    })
+                  : [],
+                multiSelect: false,
+              }))
+              .filter((question) => question.question.trim().length > 0)
+          : [];
+
+        this._view?.webview.postMessage({
+          type: 'codex-question',
+          requestId: request.id,
+          questions,
+        });
+      } else if (routed.type === 'command') {
         this._view?.webview.postMessage({
           type: 'codex-approval',
           approvalType: 'command',
@@ -1032,6 +1299,7 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
     });
 
     this._codexAppServer.on('exit', () => {
+      traceCodex('event', 'app-server exit');
       this._codexAppServer = null;
       this._codexAuth = null;
       this._codexThreadId = null;

--- a/extensions/ritemark/src/views/UnifiedViewProvider.ts
+++ b/extensions/ritemark/src/views/UnifiedViewProvider.ts
@@ -44,6 +44,7 @@ import {
   type FileAttachment,
   type SetupStatus,
   type AgentEnvironmentStatus,
+  traceClaude,
 } from '../agent';
 import { isEnabled } from '../features';
 import { discoverAgents, discoverCommands } from '../agent/discovery';
@@ -231,20 +232,35 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
           break;
 
         case 'ai-execute-agent':
+          traceClaude('webview->extension', 'ai-execute-agent', {
+            promptPreview: message.prompt?.slice(0, 200),
+            imageCount: Array.isArray(message.images) ? message.images.length : 0,
+            skipActiveFile: message.skipActiveFile === true,
+          });
           await this._handleAgentExecution(message.prompt, message.images, message.skipActiveFile);
           break;
 
         case 'ai-cancel-agent':
+          traceClaude('webview->extension', 'ai-cancel-agent');
           if (this._agentSession?.isActive) {
             this._agentSession.interrupt();
           }
           break;
 
         case 'agent-answer-question':
+          traceClaude('webview->extension', 'agent-answer-question', {
+            toolUseId: message.toolUseId,
+            answerKeys: Object.keys(message.answers || {}),
+          });
           this._handleAgentQuestionAnswer(message.toolUseId, message.answers || {});
           break;
 
         case 'agent-answer-plan':
+          traceClaude('webview->extension', 'agent-answer-plan', {
+            toolUseId: message.toolUseId,
+            approved: message.approved === true,
+            hasFeedback: Boolean(message.feedback?.trim()),
+          });
           this._handleAgentPlanAnswer(message.toolUseId, message.approved === true, message.feedback);
           break;
 
@@ -880,6 +896,7 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
     }
 
     if (!this._workspacePath) {
+      traceClaude('execution', 'blocked: no workspace');
       this._view?.webview.postMessage({
         type: 'agent-result',
         error: 'No workspace folder open. Please open a folder first.',
@@ -905,6 +922,10 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
         ...(excludedFolders ? { excludedFolders } : {}),
         ...(anthropicApiKey ? { anthropicApiKey } : {}),
       });
+      traceClaude('execution', 'created AgentSession', {
+        model,
+        workspacePath: this._workspacePath,
+      });
 
       // When SDK reports available models, update the webview dropdown
       this._agentSession.onModelsDiscovered = (models) => {
@@ -929,18 +950,28 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
         activeFile,
         timeoutMinutes: agentTimeout,
         onProgress: (progress: AgentProgress) => {
+          traceClaude('bridge', 'agent-progress', {
+            type: progress.type,
+            message: progress.message,
+            tool: progress.tool ?? null,
+          });
           this._view?.webview.postMessage({
             type: 'agent-progress',
             progress,
           });
         },
         onQuestion: (question: AgentQuestion) => {
+          traceClaude('bridge', 'agent-question', {
+            toolUseId: question.toolUseId,
+            questionHeaders: question.questions.map((item) => item.header),
+          });
           this._view?.webview.postMessage({
             type: 'agent-question',
             question,
           });
         },
         onPlanApproval: (request: AgentPlanApprovalRequest) => {
+          traceClaude('bridge', 'agent-plan-approval', request);
           this._view?.webview.postMessage({
             type: 'agent-plan-approval',
             request,
@@ -948,6 +979,11 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
         },
       });
 
+      traceClaude('bridge', 'agent-result', {
+        hasText: Boolean(result.text),
+        filesModified: result.filesModified,
+        error: result.error ?? null,
+      });
       this._view?.webview.postMessage({
         type: 'agent-result',
         text: result.text,
@@ -957,6 +993,7 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
       });
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : String(err);
+      traceClaude('bridge', 'agent-result error', { error: errorMessage });
       this._view?.webview.postMessage({
         type: 'agent-result',
         error: errorMessage,
@@ -966,11 +1003,13 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
 
   private _handleAgentQuestionAnswer(toolUseId: string, answers: Record<string, string>) {
     if (!this._agentSession) {
+      traceClaude('bridge', 'agent-answer-question without session', { toolUseId });
       return;
     }
 
     const answered = this._agentSession.answerQuestion(toolUseId, answers);
     if (!answered) {
+      traceClaude('bridge', 'agent-answer-question lost state', { toolUseId });
       this._view?.webview.postMessage({
         type: 'agent-result',
         error: 'Claude question state was lost. Please retry your last message.',
@@ -980,11 +1019,13 @@ export class UnifiedViewProvider implements vscode.WebviewViewProvider {
 
   private _handleAgentPlanAnswer(toolUseId: string, approved: boolean, feedback?: string) {
     if (!this._agentSession) {
+      traceClaude('bridge', 'agent-answer-plan without session', { toolUseId });
       return;
     }
 
     const answered = this._agentSession.answerPlanApproval(toolUseId, approved, feedback);
     if (!answered) {
+      traceClaude('bridge', 'agent-answer-plan lost state', { toolUseId, approved });
       this._view?.webview.postMessage({
         type: 'agent-result',
         error: 'Claude plan approval state was lost. Please retry your last message.',

--- a/extensions/ritemark/webview/src/components/ai-sidebar/AISidebar.tsx
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/AISidebar.tsx
@@ -20,6 +20,8 @@ import { ChatInput } from './ChatInput';
 import { IndexFooter } from './IndexFooter';
 import { SelectionIndicator } from './SelectionIndicator';
 import { ChatHistoryPanel } from './ChatHistoryPanel';
+import { ActivePlanBanner } from './ActivePlanBanner';
+import { getActiveApprovedPlanForCodex } from './lifecycle';
 import { markdownStyles } from './RenderedMarkdown';
 import type { ExtensionMessage } from './types';
 
@@ -30,6 +32,8 @@ export function AISidebar() {
   const ready = useAISidebarStore((s) => s.ready);
   const agenticEnabled = useAISidebarStore((s) => s.agenticEnabled);
   const selectedAgent = useAISidebarStore((s) => s.selectedAgent);
+  const dismissCurrentPlan = useAISidebarStore((s) => s.dismissCurrentPlan);
+  const dismissedCurrentPlanKey = useAISidebarStore((s) => s.dismissedCurrentPlanKey);
 
   // Set up message listener + handshake
   useEffect(() => {
@@ -60,6 +64,11 @@ export function AISidebar() {
           codexConversation: savedState.codexConversation as typeof store.codexConversation,
         });
       }
+      if ('dismissedCurrentPlanKey' in savedState) {
+        useAISidebarStore.setState({
+          dismissedCurrentPlanKey: (savedState.dismissedCurrentPlanKey as string | null) ?? null,
+        });
+      }
     }
 
     // Tell extension we're ready
@@ -77,6 +86,7 @@ export function AISidebar() {
         agentConversation: state.agentConversation,
         codexConversation: state.codexConversation,
         currentConversationId: state.currentConversationId,
+        dismissedCurrentPlanKey: state.dismissedCurrentPlanKey,
       });
     });
   }, []);
@@ -87,6 +97,8 @@ export function AISidebar() {
   const showHistoryPanel = useAISidebarStore((s) => s.showHistoryPanel);
   const loadConversationList = useAISidebarStore((s) => s.loadConversationList);
   const chatFontSize = useAISidebarStore((s) => s.chatFontSize);
+  const agentConversation = useAISidebarStore((s) => s.agentConversation);
+  const codexConversation = useAISidebarStore((s) => s.codexConversation);
 
   // Initialize chat font size CSS variable
   useEffect(() => {
@@ -107,6 +119,28 @@ export function AISidebar() {
   const showWelcome = isClaudeCode && setupStatus !== null
     && setupStatus.state === 'ready' && !hasSeenWelcome;
   const showCodexSetup = isCodex && codexStatus.state !== 'ready';
+  const currentApprovedPlan = isClaudeCode
+    ? (() => {
+        const approvedTurn = [...agentConversation].reverse().find((turn) =>
+          turn.isPlan
+          && turn.planHandled
+          && turn.planDecision === 'approved'
+          && Boolean(turn.planText?.trim())
+        );
+        return approvedTurn
+          ? {
+              key: approvedTurn.id,
+              planText: approvedTurn.planText || '',
+              isRunning: approvedTurn.isRunning,
+            }
+          : null;
+      })()
+    : isCodex
+      ? getActiveApprovedPlanForCodex(codexConversation)
+      : null;
+  const visibleCurrentPlan = currentApprovedPlan && currentApprovedPlan.key !== dismissedCurrentPlanKey
+    ? currentApprovedPlan
+    : null;
 
   return (
     <div className="flex flex-col h-screen overflow-hidden text-[var(--vscode-foreground)] bg-[var(--vscode-sideBar-background)]">
@@ -148,6 +182,14 @@ export function AISidebar() {
           </div>
 
           {/* Shared input */}
+          {visibleCurrentPlan && (
+            <ActivePlanBanner
+              planText={visibleCurrentPlan.planText}
+              planSteps={'planSteps' in visibleCurrentPlan ? visibleCurrentPlan.planSteps : undefined}
+              isRunning={visibleCurrentPlan.isRunning}
+              onDismiss={() => dismissCurrentPlan(visibleCurrentPlan.key)}
+            />
+          )}
           <ChatInput />
         </>
       )}

--- a/extensions/ritemark/webview/src/components/ai-sidebar/AISidebar.tsx
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/AISidebar.tsx
@@ -21,7 +21,7 @@ import { IndexFooter } from './IndexFooter';
 import { SelectionIndicator } from './SelectionIndicator';
 import { ChatHistoryPanel } from './ChatHistoryPanel';
 import { ActivePlanBanner } from './ActivePlanBanner';
-import { getActiveApprovedPlanForCodex } from './lifecycle';
+import { getActiveApprovedPlanForClaude, getActiveApprovedPlanForCodex } from './lifecycle';
 import { markdownStyles } from './RenderedMarkdown';
 import type { ExtensionMessage } from './types';
 
@@ -120,21 +120,7 @@ export function AISidebar() {
     && setupStatus.state === 'ready' && !hasSeenWelcome;
   const showCodexSetup = isCodex && codexStatus.state !== 'ready';
   const currentApprovedPlan = isClaudeCode
-    ? (() => {
-        const approvedTurn = [...agentConversation].reverse().find((turn) =>
-          turn.isPlan
-          && turn.planHandled
-          && turn.planDecision === 'approved'
-          && Boolean(turn.planText?.trim())
-        );
-        return approvedTurn
-          ? {
-              key: approvedTurn.id,
-              planText: approvedTurn.planText || '',
-              isRunning: approvedTurn.isRunning,
-            }
-          : null;
-      })()
+    ? getActiveApprovedPlanForClaude(agentConversation)
     : isCodex
       ? getActiveApprovedPlanForCodex(codexConversation)
       : null;
@@ -187,6 +173,7 @@ export function AISidebar() {
               planText={visibleCurrentPlan.planText}
               planSteps={'planSteps' in visibleCurrentPlan ? visibleCurrentPlan.planSteps : undefined}
               isRunning={visibleCurrentPlan.isRunning}
+              allCompleted={Boolean(visibleCurrentPlan.allCompleted)}
               onDismiss={() => dismissCurrentPlan(visibleCurrentPlan.key)}
             />
           )}

--- a/extensions/ritemark/webview/src/components/ai-sidebar/ActivePlanBanner.tsx
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/ActivePlanBanner.tsx
@@ -1,0 +1,100 @@
+import { useState } from 'react';
+import { Check, CheckCircle2, ChevronDown, ChevronRight, Circle, ClipboardCheck, Dot } from 'lucide-react';
+import type { CodexPlanStep } from './types';
+import { buildActivePlanViewModel } from './activePlan';
+
+interface ActivePlanBannerProps {
+  planText: string;
+  planSteps?: CodexPlanStep[];
+  isRunning?: boolean;
+  onDismiss?: () => void;
+}
+
+export function ActivePlanBanner({ planText, planSteps, isRunning = false, onDismiss }: ActivePlanBannerProps) {
+  const [expanded, setExpanded] = useState(isRunning);
+  const model = buildActivePlanViewModel(planText, planSteps, isRunning);
+
+  if (!model) {
+    return null;
+  }
+
+  return (
+    <div className="mx-3 mb-2 rounded border border-[var(--vscode-panel-border)] bg-[var(--vscode-editorWidget-background)] px-3 py-2">
+      <div className="flex items-start justify-between gap-3">
+        <button
+          type="button"
+          onClick={() => setExpanded((value) => !value)}
+          className="min-w-0 flex-1 text-left"
+          title={expanded ? 'Collapse plan details' : 'Expand plan details'}
+          aria-label={expanded ? 'Collapse plan details' : 'Expand plan details'}
+        >
+          <div className="flex items-center gap-2 text-[11px] text-[var(--vscode-descriptionForeground)]">
+            <ClipboardCheck size={13} className="shrink-0" />
+            <span>Current plan</span>
+          </div>
+          <div className="mt-1 text-[11px] font-medium text-[var(--vscode-foreground)]">
+            {model.summary}
+          </div>
+        </button>
+        <div className="flex items-center gap-1">
+          {onDismiss && (
+            <button
+              type="button"
+              onClick={onDismiss}
+              className="rounded p-1 text-[var(--vscode-descriptionForeground)] transition-colors hover:bg-[var(--vscode-toolbar-hoverBackground)] hover:text-[var(--vscode-foreground)]"
+              title="Mark plan complete and hide"
+              aria-label="Mark plan complete and hide"
+            >
+              <Check size={13} />
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={() => setExpanded((value) => !value)}
+            className="rounded p-1 text-[var(--vscode-descriptionForeground)] transition-colors hover:bg-[var(--vscode-toolbar-hoverBackground)] hover:text-[var(--vscode-foreground)]"
+            title={expanded ? 'Collapse plan details' : 'Expand plan details'}
+            aria-label={expanded ? 'Collapse plan details' : 'Expand plan details'}
+          >
+            {expanded ? (
+              <ChevronDown size={14} className="shrink-0" />
+            ) : (
+              <ChevronRight size={14} className="shrink-0" />
+            )}
+          </button>
+        </div>
+      </div>
+
+      {expanded && (
+        <div className="mt-2 space-y-1.5">
+          {model.steps.map((step, index) => (
+            <div
+              key={`${step.label}-${index}`}
+              className="flex items-start gap-2 text-[11px] leading-4"
+            >
+              <span className="mt-[1px] shrink-0">
+                {step.status === 'completed' ? (
+                  <CheckCircle2 size={12} className="text-[var(--vscode-testing-iconPassed)]" />
+                ) : step.status === 'inProgress' ? (
+                  <Dot size={16} className="-ml-[2px] text-[var(--vscode-progressBar-background)]" />
+                ) : (
+                  <Circle size={10} className="mt-[1px] text-[var(--vscode-descriptionForeground)]" />
+                )}
+              </span>
+              <span
+                className={
+                  step.status === 'completed'
+                    ? 'opacity-60 line-through'
+                    : step.status === 'inProgress'
+                      ? 'font-medium text-[var(--vscode-foreground)]'
+                      : 'text-[var(--vscode-descriptionForeground)]'
+                }
+              >
+                {step.label}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/extensions/ritemark/webview/src/components/ai-sidebar/ActivePlanBanner.tsx
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/ActivePlanBanner.tsx
@@ -7,12 +7,19 @@ interface ActivePlanBannerProps {
   planText: string;
   planSteps?: CodexPlanStep[];
   isRunning?: boolean;
+  allCompleted?: boolean;
   onDismiss?: () => void;
 }
 
-export function ActivePlanBanner({ planText, planSteps, isRunning = false, onDismiss }: ActivePlanBannerProps) {
+export function ActivePlanBanner({
+  planText,
+  planSteps,
+  isRunning = false,
+  allCompleted = false,
+  onDismiss,
+}: ActivePlanBannerProps) {
   const [expanded, setExpanded] = useState(isRunning);
-  const model = buildActivePlanViewModel(planText, planSteps, isRunning);
+  const model = buildActivePlanViewModel(planText, planSteps, isRunning, allCompleted);
 
   if (!model) {
     return null;

--- a/extensions/ritemark/webview/src/components/ai-sidebar/AgentPlanApproval.tsx
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/AgentPlanApproval.tsx
@@ -1,0 +1,27 @@
+import { PlanReviewCard } from './PlanReviewCard';
+
+interface AgentPlanApprovalProps {
+  turnId: string;
+  planText: string;
+  onApprove: (turnId: string) => void;
+  onReject: (turnId: string, feedback?: string) => void;
+}
+
+export function AgentPlanApproval({
+  turnId,
+  planText,
+  onApprove,
+  onReject,
+}: AgentPlanApprovalProps) {
+  return (
+    <PlanReviewCard
+      title="Claude is waiting for plan approval"
+      planText={planText}
+      approveLabel="Approve plan"
+      rejectLabel="Reject"
+      allowFeedback
+      onApprove={() => onApprove(turnId)}
+      onReject={(feedback) => onReject(turnId, feedback)}
+    />
+  );
+}

--- a/extensions/ritemark/webview/src/components/ai-sidebar/AgentQuestion.tsx
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/AgentQuestion.tsx
@@ -19,6 +19,7 @@ interface AgentQuestionProps {
   turnId: string;
   question: AgentQuestionData;
   onAnswer: (turnId: string, question: AgentQuestionData, answers: Record<string, string>) => void;
+  providerLabel?: string;
 }
 
 /** State for a single question's selected answers */
@@ -209,7 +210,7 @@ function SingleQuestion({
   );
 }
 
-export function AgentQuestion({ turnId, question, onAnswer }: AgentQuestionProps) {
+export function AgentQuestion({ turnId, question, onAnswer, providerLabel = 'Claude' }: AgentQuestionProps) {
   const [answers, setAnswers] = useState<QuestionAnswer[]>(
     question.questions.map(() => null)
   );
@@ -260,7 +261,7 @@ export function AgentQuestion({ turnId, question, onAnswer }: AgentQuestionProps
       {/* Header */}
       <div className="flex items-center gap-2 text-[11px] text-[var(--vscode-descriptionForeground)]">
         <MessageCircle size={13} className="shrink-0" />
-        <span>Claude needs your input to continue</span>
+        <span>{providerLabel} needs your input to continue</span>
       </div>
 
       {/* Questions */}

--- a/extensions/ritemark/webview/src/components/ai-sidebar/AgentResponse.tsx
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/AgentResponse.tsx
@@ -11,6 +11,7 @@ import { RenderedMarkdown } from './RenderedMarkdown';
 import { FilesSummary } from './FilesSummary';
 import { ActivityDetails } from './ActivityDetails';
 import { chatFontStyle } from './ChatBubbles';
+import { extractPlanDisplayText } from './planText';
 import type { AgentConversationTurn } from './types';
 
 const OVERFLOW_PATTERNS = [
@@ -85,15 +86,16 @@ export function AgentResponse({ turn }: AgentResponseProps) {
     );
   }
 
-  const needsApproval = turn.isPlan && !turn.planHandled;
+  const needsApproval = turn.isPlan && !turn.planHandled && !turn.pendingPlanApproval;
 
   // Extract plan content from thinking activities (plan text arrives as 'thinking' type)
   const planText = needsApproval
-    ? activities
+    ? (turn.planText || activities
         .filter(a => a.type === 'thinking' && a.message)
         .map(a => a.message)
-        .join('\n\n')
+        .join('\n\n'))
     : '';
+  const displayPlanText = extractPlanDisplayText(planText);
 
   // Success result
   return (
@@ -103,11 +105,11 @@ export function AgentResponse({ turn }: AgentResponseProps) {
       )}
 
       {/* Plan preview card */}
-      {needsApproval && planText && (
+      {needsApproval && displayPlanText && (
         <div className="mt-2 px-3 py-2 rounded border border-[var(--vscode-panel-border)] bg-[var(--vscode-editorWidget-background)] max-h-[300px] overflow-y-auto">
           <div className="text-[10px] font-medium text-[var(--vscode-descriptionForeground)] uppercase tracking-wide mb-1.5">Plan</div>
           <div className="text-[12px]">
-            <RenderedMarkdown content={planText} />
+            <RenderedMarkdown content={displayPlanText} />
           </div>
         </div>
       )}
@@ -158,7 +160,7 @@ export function AgentResponse({ turn }: AgentResponseProps) {
       {/* Approved/rejected label */}
       {turn.isPlan && turn.planHandled && (
         <div className="mt-2 text-[10px] text-[var(--vscode-descriptionForeground)] italic">
-          Plan approved
+          {turn.planDecision === 'rejected' ? 'Plan sent back for revision' : 'Plan approved'}
         </div>
       )}
 

--- a/extensions/ritemark/webview/src/components/ai-sidebar/AgentView.tsx
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/AgentView.tsx
@@ -8,6 +8,8 @@ import { useAISidebarStore } from './store';
 import { EmptyState } from './EmptyState';
 import { RunningIndicator } from './RunningIndicator';
 import { AgentResponse } from './AgentResponse';
+import { AgentQuestion } from './AgentQuestion';
+import { AgentPlanApproval } from './AgentPlanApproval';
 import { SubagentCard } from './SubagentCard';
 import { UserPromptBubble } from './ChatBubbles';
 import type { AgentProgress } from './types';
@@ -15,6 +17,9 @@ import type { AgentProgress } from './types';
 export function AgentView() {
   const agentConversation = useAISidebarStore((s) => s.agentConversation);
   const sendAgentMessage = useAISidebarStore((s) => s.sendAgentMessage);
+  const answerAgentQuestion = useAISidebarStore((s) => s.answerAgentQuestion);
+  const approvePlan = useAISidebarStore((s) => s.approvePlan);
+  const rejectPlan = useAISidebarStore((s) => s.rejectPlan);
 
   const endRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -30,7 +35,7 @@ export function AgentView() {
   const lastTurn = agentConversation[agentConversation.length - 1];
   useEffect(() => {
     scrollToBottom();
-  }, [agentConversation.length, lastTurn?.activities.length, lastTurn?.result, scrollToBottom]);
+  }, [agentConversation.length, lastTurn?.activities.length, lastTurn?.pendingQuestion, lastTurn?.pendingPlanApproval, lastTurn?.result, scrollToBottom]);
 
   const handleScroll = useCallback(() => {
     const el = containerRef.current;
@@ -80,7 +85,20 @@ export function AgentView() {
             )}
 
             {/* Running indicator */}
-            {turn.isRunning && (
+            {turn.pendingQuestion && (
+              <AgentQuestion turnId={turn.id} question={turn.pendingQuestion} onAnswer={answerAgentQuestion} />
+            )}
+
+            {turn.pendingPlanApproval && (
+              <AgentPlanApproval
+                turnId={turn.id}
+                planText={turn.planText || ''}
+                onApprove={approvePlan}
+                onReject={rejectPlan}
+              />
+            )}
+
+            {turn.isRunning && !turn.pendingQuestion && !turn.pendingPlanApproval && (
               <RunningIndicator activities={turn.activities} subagents={turn.subagents} />
             )}
 

--- a/extensions/ritemark/webview/src/components/ai-sidebar/CodexView.tsx
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/CodexView.tsx
@@ -11,12 +11,24 @@ import { useAISidebarStore } from './store';
 import { Terminal, FileCode, Loader2, Check, X, AlertTriangle, ChevronRight, Wrench } from 'lucide-react';
 import { UserPromptBubble, AIResponseBubble } from './ChatBubbles';
 import { RunningIndicator } from './RunningIndicator';
-import type { CodexConversationTurn, AgentProgress } from './types';
+import { AgentQuestion } from './AgentQuestion';
+import { PlanReviewCard } from './PlanReviewCard';
+import { RenderedMarkdown } from './RenderedMarkdown';
+import { extractPlanDisplayText } from './planText';
+import type { CodexConversationTurn, AgentProgress, CodexSidebarStatus } from './types';
 
 export function CodexView() {
   const codexConversation = useAISidebarStore((s) => s.codexConversation);
+  const codexStatus = useAISidebarStore((s) => s.codexStatus);
+  const dismissedCodexNoticeKey = useAISidebarStore((s) => s.dismissedCodexNoticeKey);
+  const dismissCodexNotice = useAISidebarStore((s) => s.dismissCodexNotice);
   const handleCodexApproval = useAISidebarStore((s) => s.handleCodexApproval);
+  const answerCodexQuestion = useAISidebarStore((s) => s.answerCodexQuestion);
+  const approveCodexPlan = useAISidebarStore((s) => s.approveCodexPlan);
+  const discardCodexPlan = useAISidebarStore((s) => s.discardCodexPlan);
   const scrollRef = useRef<HTMLDivElement>(null);
+  const compatibilityNotice = getCompatibilityNotice(codexStatus);
+  const showCompatibilityNotice = compatibilityNotice && dismissedCodexNoticeKey !== compatibilityNotice.key;
 
   // Auto-scroll to bottom
   useEffect(() => {
@@ -29,6 +41,16 @@ export function CodexView() {
     return (
       <div className="flex-1 flex items-center justify-center p-6 text-center">
         <div className="max-w-xs">
+          {showCompatibilityNotice && (
+            <div className="mb-4 text-left">
+              <CompatibilityNotice
+                title={compatibilityNotice.title}
+                message={compatibilityNotice.message}
+                bullets={compatibilityNotice.bullets}
+                onDismiss={() => dismissCodexNotice(compatibilityNotice.key)}
+              />
+            </div>
+          )}
           <Terminal className="w-10 h-10 mx-auto mb-3 opacity-30" />
           <p className="text-sm font-medium opacity-70">Codex Agent</p>
           <p className="text-xs opacity-50 mt-1">
@@ -42,29 +64,88 @@ export function CodexView() {
 
   return (
     <div ref={scrollRef} className="flex-1 overflow-y-auto px-3 py-3 space-y-4">
+      {showCompatibilityNotice && (
+        <CompatibilityNotice
+          title={compatibilityNotice.title}
+          message={compatibilityNotice.message}
+          bullets={compatibilityNotice.bullets}
+          onDismiss={() => dismissCodexNotice(compatibilityNotice.key)}
+        />
+      )}
       {codexConversation.map((turn) => (
         <CodexTurn
           key={turn.id}
           turn={turn}
           onApprove={(requestId) => handleCodexApproval(requestId, true)}
           onReject={(requestId) => handleCodexApproval(requestId, false)}
+          onAnswerQuestion={answerCodexQuestion}
+          onApprovePlan={approveCodexPlan}
+          onDiscardPlan={discardCodexPlan}
         />
       ))}
     </div>
   );
 }
 
+function getCompatibilityNotice(status: CodexSidebarStatus): {
+  key: string;
+  title: string;
+  message: string;
+  bullets: string[];
+} | null {
+  const compatibility = status.compatibility;
+  if (status.state !== 'ready' || !compatibility || compatibility.state === 'compatible') {
+    return null;
+  }
+
+  const capabilities = compatibility.capabilities;
+  const bullets = [
+    `Approvals: ${capabilities.approvals ? 'available' : 'not detected'}`,
+    `Ask questions: ${capabilities.requestUserInput ? 'available' : 'not detected'}`,
+    `Plan updates: ${capabilities.planUpdates ? 'available' : 'not detected'}`,
+    ...compatibility.limitations,
+  ];
+
+  return {
+    key: [
+      status.version ?? 'unknown',
+      compatibility.state,
+      capabilities.approvals ? 'approvals' : 'no-approvals',
+      capabilities.requestUserInput ? 'question' : 'no-question',
+      capabilities.planUpdates ? 'plan' : 'no-plan',
+    ].join(':'),
+    title: compatibility.state === 'untested'
+      ? 'Codex version not yet audited'
+      : 'Codex session is running with limits',
+    message: compatibility.summary,
+    bullets,
+  };
+}
+
 function CodexTurn({
   turn,
   onApprove,
   onReject,
+  onAnswerQuestion,
+  onApprovePlan,
+  onDiscardPlan,
 }: {
   turn: CodexConversationTurn;
   onApprove: (requestId: string | number) => void;
   onReject: (requestId: string | number) => void;
+  onAnswerQuestion: (turnId: string, question: NonNullable<CodexConversationTurn['pendingQuestion']>, answers: Record<string, string>) => void;
+  onApprovePlan: (turnId: string) => void;
+  onDiscardPlan: (turnId: string) => void;
 }) {
   const hasActivities = turn.activities.length > 0;
   const lastActivity = hasActivities ? turn.activities[turn.activities.length - 1] : null;
+  const rawPlanText = turn.planText || ((turn.result && !turn.result.error) ? turn.streamingText : '');
+  const displayPlanText = extractPlanDisplayText(rawPlanText);
+  const showPlanCard = Boolean((turn.planSteps && turn.planSteps.length > 0) || displayPlanText);
+  const needsPlanReview = Boolean(showPlanCard && turn.result && !turn.result.error && turn.requiresPlanReview && !turn.planHandled);
+  const shouldHideStreamingBubble = Boolean(displayPlanText)
+    && turn.streamingText.trim().length > 0
+    && rawPlanText.trim() === turn.streamingText.trim();
 
   return (
     <div className="space-y-2">
@@ -91,8 +172,35 @@ function CodexTurn({
         />
       )}
 
+      {turn.pendingQuestion && (
+        <AgentQuestion
+          turnId={turn.id}
+          question={{
+            toolUseId: String(turn.pendingQuestion.requestId),
+            questions: turn.pendingQuestion.questions,
+          }}
+          providerLabel="Codex"
+          onAnswer={(turnId, _question, answers) => onAnswerQuestion(turnId, turn.pendingQuestion!, answers)}
+        />
+      )}
+
+      {showPlanCard && !needsPlanReview && (
+        <PlanCard explanation={turn.planExplanation} planSteps={turn.planSteps} planText={displayPlanText} />
+      )}
+
+      {needsPlanReview && (
+        <PlanReviewCard
+          title="Codex is waiting for plan review"
+          planText={rawPlanText}
+          approveLabel="Approve & continue"
+          rejectLabel="Discard"
+          onApprove={() => onApprovePlan(turn.id)}
+          onReject={() => onDiscardPlan(turn.id)}
+        />
+      )}
+
       {/* Streaming text */}
-      {turn.streamingText && (
+      {turn.streamingText && !shouldHideStreamingBubble && (
         <AIResponseBubble content={turn.streamingText} />
       )}
 
@@ -113,9 +221,57 @@ function CodexTurn({
       {turn.result && !turn.result.error && turn.result.status === 'completed' && (
         <div className="flex items-center gap-2 text-xs text-[var(--vscode-testing-iconPassed)] pl-2">
           <Check size={12} />
-          <span>Done</span>
+          <span>
+            {needsPlanReview
+              ? 'Waiting for plan review'
+              : turn.planHandled
+              ? turn.planDecision === 'approved'
+                ? 'Plan approved; continuation started below'
+                : 'Plan discarded'
+              : 'Done'}
+          </span>
         </div>
       )}
+    </div>
+  );
+}
+
+function PlanCard({
+  explanation,
+  planSteps,
+  planText,
+}: {
+  explanation?: string;
+  planSteps?: NonNullable<CodexConversationTurn['planSteps']>;
+  planText?: string;
+}) {
+  return (
+    <div className="mx-1 p-3 rounded-lg border border-[var(--vscode-panel-border)] bg-[var(--vscode-input-background)]">
+      <div className="text-[11px] opacity-70 mb-2 font-medium">Codex plan</div>
+      {explanation && (
+        <p className="text-[12px] opacity-85 mb-2 whitespace-pre-wrap">{explanation}</p>
+      )}
+      {planSteps && planSteps.length > 0 ? (
+        <div className="space-y-1.5">
+          {planSteps.map((step, index) => (
+            <div key={`${step.step}-${index}`} className="flex items-start gap-2 text-[12px]">
+              <span className="mt-[2px] shrink-0 opacity-60">
+                {step.status === 'completed' ? '✓' : step.status === 'inProgress' ? '•' : '○'}
+              </span>
+              <div>
+                <div>{step.step}</div>
+                <div className="text-[10px] opacity-55">
+                  {step.status === 'inProgress' ? 'In progress' : step.status === 'completed' ? 'Completed' : 'Pending'}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : planText ? (
+        <div className="text-[12px]">
+          <RenderedMarkdown content={planText} />
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -253,6 +409,47 @@ function ApprovalCard({
           className="flex items-center gap-1 px-3 py-1 text-xs rounded bg-[var(--vscode-button-secondaryBackground)] text-[var(--vscode-button-secondaryForeground)] hover:bg-[var(--vscode-button-secondaryHoverBackground)]"
         >
           <X size={12} /> Reject
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function CompatibilityNotice({
+  title,
+  message,
+  bullets,
+  onDismiss,
+}: {
+  title: string;
+  message: string;
+  bullets: string[];
+  onDismiss: () => void;
+}) {
+  return (
+    <div className="rounded-lg border border-[var(--vscode-inputValidation-warningBorder)] bg-[var(--vscode-editorWarning-background)]/20 p-3 text-left">
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-start gap-2 min-w-0">
+          <AlertTriangle size={14} className="mt-0.5 shrink-0 text-[var(--vscode-inputValidation-warningBorder)]" />
+          <div className="min-w-0">
+            <div className="text-xs font-semibold">{title}</div>
+            <p className="mt-1 text-xs leading-5 opacity-80">{message}</p>
+            <div className="mt-2 space-y-1">
+              {bullets.map((bullet) => (
+                <div key={bullet} className="text-[11px] leading-4 opacity-75">
+                  {bullet}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+        <button
+          onClick={onDismiss}
+          className="rounded p-1 opacity-60 hover:opacity-100"
+          aria-label="Dismiss Codex compatibility notice"
+          title="Dismiss"
+        >
+          <X size={12} />
         </button>
       </div>
     </div>

--- a/extensions/ritemark/webview/src/components/ai-sidebar/PlanReviewCard.tsx
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/PlanReviewCard.tsx
@@ -1,0 +1,99 @@
+import { useState } from 'react';
+import { Check, ClipboardList, X } from 'lucide-react';
+import { RenderedMarkdown } from './RenderedMarkdown';
+import { extractPlanDisplayText } from './planText';
+
+interface PlanReviewCardProps {
+  title: string;
+  planText: string;
+  approveLabel: string;
+  rejectLabel: string;
+  rejectPlaceholder?: string;
+  allowFeedback?: boolean;
+  onApprove: () => void;
+  onReject: (feedback?: string) => void;
+}
+
+export function PlanReviewCard({
+  title,
+  planText,
+  approveLabel,
+  rejectLabel,
+  rejectPlaceholder = 'What should be different?',
+  allowFeedback = false,
+  onApprove,
+  onReject,
+}: PlanReviewCardProps) {
+  const [rejectInput, setRejectInput] = useState('');
+  const [showRejectInput, setShowRejectInput] = useState(false);
+  const displayText = extractPlanDisplayText(planText);
+
+  return (
+    <div
+      className="rounded border px-3 py-3 space-y-4"
+      style={{
+        background: 'var(--vscode-input-background)',
+        borderColor: 'var(--vscode-panel-border)',
+      }}
+    >
+      <div className="flex items-center gap-2 text-[11px] text-[var(--vscode-descriptionForeground)]">
+        <ClipboardList size={13} className="shrink-0" />
+        <span>{title}</span>
+      </div>
+
+      {displayText && (
+        <div className="rounded border px-3 py-2 max-h-[300px] overflow-y-auto border-[var(--vscode-panel-border)] bg-[var(--vscode-editorWidget-background)]">
+          <div className="text-[10px] font-medium text-[var(--vscode-descriptionForeground)] uppercase tracking-wide mb-1.5">
+            Plan
+          </div>
+          <div style={{ fontSize: 'var(--chat-font-size, 13px)' }}>
+            <RenderedMarkdown content={displayText} />
+          </div>
+        </div>
+      )}
+
+      <div className="flex gap-2">
+        <button
+          onClick={onApprove}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium bg-[var(--vscode-button-background)] text-[var(--vscode-button-foreground)] hover:bg-[var(--vscode-button-hoverBackground)]"
+        >
+          <Check size={12} />
+          {approveLabel}
+        </button>
+        <button
+          onClick={() => {
+            if (allowFeedback && showRejectInput) {
+              onReject(rejectInput.trim() || undefined);
+              return;
+            }
+            if (allowFeedback) {
+              setShowRejectInput(true);
+              return;
+            }
+            onReject();
+          }}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded text-xs font-medium bg-[var(--vscode-button-secondaryBackground)] text-[var(--vscode-button-secondaryForeground)] hover:opacity-80"
+        >
+          <X size={12} />
+          {allowFeedback && showRejectInput ? 'Send feedback' : rejectLabel}
+        </button>
+      </div>
+
+      {allowFeedback && showRejectInput && (
+        <input
+          type="text"
+          value={rejectInput}
+          onChange={(e) => setRejectInput(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter') {
+              onReject(rejectInput.trim() || undefined);
+            }
+          }}
+          placeholder={rejectPlaceholder}
+          autoFocus
+          className="w-full px-2.5 py-1.5 rounded text-xs bg-[var(--vscode-input-background)] text-[var(--vscode-input-foreground)] border border-[var(--vscode-input-border)] outline-none focus:border-[var(--vscode-focusBorder)]"
+        />
+      )}
+    </div>
+  );
+}

--- a/extensions/ritemark/webview/src/components/ai-sidebar/RunningIndicator.tsx
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/RunningIndicator.tsx
@@ -17,6 +17,7 @@ function getStatusText(activities: AgentProgress[]): string {
   const last = activities[activities.length - 1];
 
   if (last.type === 'compacting') return last.message;
+  if (last.type === 'plan_text') return 'Planning...';
   if (last.type === 'thinking') return 'Thinking...';
   if (last.type === 'init') return 'Starting...';
   if (last.type === 'subagent_start') return `Starting: ${last.subagentTask || 'subagent'}`;

--- a/extensions/ritemark/webview/src/components/ai-sidebar/activePlan.ts
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/activePlan.ts
@@ -1,0 +1,161 @@
+import type { CodexPlanStep } from './types';
+import { extractPlanDisplayText } from './planText';
+
+export type ActivePlanStepStatus = 'pending' | 'inProgress' | 'completed';
+
+export interface ActivePlanStep {
+  label: string;
+  status: ActivePlanStepStatus;
+}
+
+export interface ActivePlanViewModel {
+  summary: string;
+  steps: ActivePlanStep[];
+}
+
+function cleanPlanLine(line: string): string {
+  return line
+    .trim()
+    .replace(/^#{1,6}\s+/, '')
+    .replace(/^[-*+]\s+/, '')
+    .replace(/^\d+[.)]\s+/, '')
+    .replace(/^[A-Z][.)]\s+/, '')
+    .replace(/^\[[ xX]\]\s+/, '')
+    .replace(/^(?:✅|☑️|✔️|✓)\s+/, '')
+    .replace(/^(?:▶️|🔄|⏳)\s+/, '')
+    .replace(/^(?:⬜|☐|◻️)\s+/, '')
+    .trim();
+}
+
+function parsePlanLineStatus(line: string): ActivePlanStepStatus {
+  const trimmed = line.trim();
+  if (/^(?:[-*+]\s+)?\[[xX]\]\s+/.test(trimmed)) {
+    return 'completed';
+  }
+  if (/^(?:[-*+]\s+)?\[\s\]\s+/.test(trimmed)) {
+    return 'pending';
+  }
+  if (/^(?:[-*+]\s+)?(?:✅|☑️|✔️|✓)\s+/.test(trimmed)) {
+    return 'completed';
+  }
+  if (/^(?:[-*+]\s+)?(?:▶️|🔄|⏳)\s+/.test(trimmed)) {
+    return 'inProgress';
+  }
+  if (/^(?:[-*+]\s+)?(?:⬜|☐|◻️)\s+/.test(trimmed)) {
+    return 'pending';
+  }
+  return 'pending';
+}
+
+function extractChecklistBlock(planText: string): string {
+  const normalized = planText.trim();
+  if (!normalized) {
+    return '';
+  }
+
+  const lines = normalized.split('\n');
+  const checklistLinePattern = /^(?:\s*[-*+]\s+)?(?:\[[ xX]\]|✅|☑️|✔️|✓|▶️|🔄|⏳|⬜|☐|◻️)\s+/;
+
+  const firstChecklistIndex = lines.findIndex((line) => checklistLinePattern.test(line.trim()));
+  if (firstChecklistIndex === -1) {
+    return '';
+  }
+
+  let start = firstChecklistIndex;
+  const previousLine = lines[firstChecklistIndex - 1]?.trim() || '';
+  if (previousLine && /checklist|tööseis/i.test(previousLine)) {
+    start = firstChecklistIndex - 1;
+  }
+
+  let end = lines.length;
+  for (let i = firstChecklistIndex + 1; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
+    if (!trimmed) {
+      end = i;
+      break;
+    }
+    if (!checklistLinePattern.test(trimmed) && !/checklist|tööseis/i.test(trimmed)) {
+      end = i;
+      break;
+    }
+  }
+
+  return lines.slice(start, end).join('\n').trim();
+}
+
+function parsePlanTextToSteps(planText: string): ActivePlanStep[] {
+  const displayText = extractChecklistBlock(planText) || extractPlanDisplayText(planText);
+  if (!displayText) {
+    return [];
+  }
+
+  const lines = displayText
+    .split('\n')
+    .map((rawLine) => ({
+      label: cleanPlanLine(rawLine),
+      status: parsePlanLineStatus(rawLine),
+    }))
+    .filter((line) => line.label.length > 0)
+    .filter((line) => !/^plan:?$/i.test(line.label))
+    .filter((line) => !/^working checklist:?$/i.test(line.label))
+    .filter((line) => !/^checklist:?$/i.test(line.label))
+    .filter((line) => !/^lühike checklist:?$/i.test(line.label))
+    .filter((line) => !/^töö-?checklist:?$/i.test(line.label))
+    .filter((line) => !/^tööseis/i.test(line.label))
+    .filter((line) => !/^i will not /i.test(line.label))
+    .filter((line) => !/^do not /i.test(line.label));
+
+  return lines.slice(0, 6);
+}
+
+function summarizeSteps(steps: ActivePlanStep[]): string {
+  const completed = steps.filter((step) => step.status === 'completed').length;
+  const inProgress = steps.filter((step) => step.status === 'inProgress').length;
+  const pending = steps.filter((step) => step.status === 'pending').length;
+
+  const parts: string[] = [];
+  if (inProgress > 0) {
+    parts.push(`${inProgress} in progress`);
+  }
+  if (pending > 0) {
+    parts.push(`${pending} pending`);
+  }
+  if (completed > 0) {
+    parts.push(`${completed} done`);
+  }
+
+  return parts.join(' · ') || 'Plan ready';
+}
+
+export function buildActivePlanViewModel(
+  planText: string,
+  planSteps?: CodexPlanStep[],
+  isRunning = false
+): ActivePlanViewModel | null {
+  const normalizedSteps = (planSteps || [])
+    .map((step) => ({
+      label: step.step.trim(),
+      status: step.status,
+    }))
+    .filter((step) => step.label.length > 0);
+
+  const fallbackSteps = normalizedSteps.length > 0 ? normalizedSteps : parsePlanTextToSteps(planText);
+  if (fallbackSteps.length === 0) {
+    return null;
+  }
+
+  const steps = fallbackSteps.map((step, index) => {
+    if (isRunning && !fallbackSteps.some((candidate) => candidate.status === 'inProgress' || candidate.status === 'completed')) {
+      return {
+        ...step,
+        status: index === 0 ? 'inProgress' : 'pending',
+      };
+    }
+    return step;
+  });
+
+  return {
+    summary: summarizeSteps(steps),
+    steps,
+  };
+}

--- a/extensions/ritemark/webview/src/components/ai-sidebar/activePlan.ts
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/activePlan.ts
@@ -130,7 +130,8 @@ function summarizeSteps(steps: ActivePlanStep[]): string {
 export function buildActivePlanViewModel(
   planText: string,
   planSteps?: CodexPlanStep[],
-  isRunning = false
+  isRunning = false,
+  allCompleted = false
 ): ActivePlanViewModel | null {
   const normalizedSteps = (planSteps || [])
     .map((step) => ({
@@ -145,6 +146,12 @@ export function buildActivePlanViewModel(
   }
 
   const steps = fallbackSteps.map((step, index) => {
+    if (allCompleted && normalizedSteps.length === 0) {
+      return {
+        ...step,
+        status: 'completed' as const,
+      };
+    }
     if (isRunning && !fallbackSteps.some((candidate) => candidate.status === 'inProgress' || candidate.status === 'completed')) {
       return {
         ...step,

--- a/extensions/ritemark/webview/src/components/ai-sidebar/conversationReset.test.ts
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/conversationReset.test.ts
@@ -1,0 +1,151 @@
+import assert from 'node:assert/strict';
+import { useAISidebarStore } from './store';
+import { vscode } from '../../lib/vscode';
+import type { CodexConversationTurn } from './types';
+
+const initialState = useAISidebarStore.getState();
+
+function resetStore(): void {
+  useAISidebarStore.setState(initialState, true);
+}
+
+function makeCodexTurn(): CodexConversationTurn {
+  return {
+    id: 'turn-1',
+    userPrompt: 'Plan the task',
+    streamingText: '',
+    activities: [],
+    planText: '',
+    planSteps: [],
+    planHandled: false,
+    isRunning: true,
+    timestamp: 1,
+    executionContinuation: false,
+    requiresPlanReview: false,
+  };
+}
+
+function testStartNewConversationResetsProviderSessions() {
+  const posted: unknown[] = [];
+  const originalPostMessage = vscode.postMessage;
+  vscode.postMessage = (message: unknown) => {
+    posted.push(message);
+  };
+
+  try {
+    useAISidebarStore.setState({
+      ...useAISidebarStore.getState(),
+      selectedAgent: 'codex',
+      codexConversation: [makeCodexTurn()],
+      currentConversationId: null,
+    });
+
+    useAISidebarStore.getState().startNewConversation();
+
+    assert.equal(useAISidebarStore.getState().codexConversation.length, 0);
+    assert.ok(
+      posted.some(
+        (message) =>
+          typeof message === 'object'
+          && message !== null
+          && 'type' in message
+          && message.type === 'conversation:reset'
+      ),
+      'starting a new conversation must reset provider sessions in the extension'
+    );
+  } finally {
+    vscode.postMessage = originalPostMessage;
+    resetStore();
+  }
+}
+
+function testClearChatResetsProviderSessions() {
+  const posted: unknown[] = [];
+  const originalPostMessage = vscode.postMessage;
+  vscode.postMessage = (message: unknown) => {
+    posted.push(message);
+  };
+
+  try {
+    useAISidebarStore.setState({
+      ...useAISidebarStore.getState(),
+      selectedAgent: 'claude-code',
+      agentConversation: [{
+        id: 'agent-turn-1',
+        userPrompt: 'Do the task',
+        activities: [],
+        isRunning: true,
+        isPlan: false,
+        planHandled: false,
+        timestamp: 1,
+      }],
+    });
+
+    useAISidebarStore.getState().clearChat();
+
+    assert.equal(useAISidebarStore.getState().agentConversation.length, 0);
+    assert.ok(
+      posted.some(
+        (message) =>
+          typeof message === 'object'
+          && message !== null
+          && 'type' in message
+          && message.type === 'conversation:reset'
+      ),
+      'clearing chat must reset provider sessions in the extension'
+    );
+  } finally {
+    vscode.postMessage = originalPostMessage;
+    resetStore();
+  }
+}
+
+function testDismissedCurrentPlanKeyResetsForNewConversation() {
+  try {
+    useAISidebarStore.setState({
+      ...useAISidebarStore.getState(),
+      dismissedCurrentPlanKey: 'plan-turn-1',
+      codexConversation: [makeCodexTurn()],
+      currentConversationId: 'conv-1',
+    });
+
+    useAISidebarStore.getState().startNewConversation();
+
+    assert.equal(
+      useAISidebarStore.getState().dismissedCurrentPlanKey,
+      null,
+      'starting a new conversation must clear dismissed current plan state'
+    );
+  } finally {
+    resetStore();
+  }
+}
+
+function testDismissCurrentPlanStoresKey() {
+  try {
+    useAISidebarStore.setState({
+      ...useAISidebarStore.getState(),
+      dismissedCurrentPlanKey: null,
+    });
+
+    useAISidebarStore.getState().dismissCurrentPlan('approved-plan-1');
+
+    assert.equal(
+      useAISidebarStore.getState().dismissedCurrentPlanKey,
+      'approved-plan-1',
+      'dismissing current plan should remember the specific plan key'
+    );
+  } finally {
+    resetStore();
+  }
+}
+
+function main() {
+  testStartNewConversationResetsProviderSessions();
+  testClearChatResetsProviderSessions();
+  testDismissedCurrentPlanKeyResetsForNewConversation();
+  testDismissCurrentPlanStoresKey();
+  console.log('Conversation reset tests passed.');
+}
+
+main();

--- a/extensions/ritemark/webview/src/components/ai-sidebar/conversationReset.test.ts
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/conversationReset.test.ts
@@ -121,6 +121,27 @@ function testDismissedCurrentPlanKeyResetsForNewConversation() {
   }
 }
 
+function testDismissedCurrentPlanKeyResetsForClearChatMessage() {
+  try {
+    useAISidebarStore.setState({
+      ...useAISidebarStore.getState(),
+      dismissedCurrentPlanKey: 'plan-turn-1',
+      codexConversation: [makeCodexTurn()],
+      currentConversationId: 'conv-1',
+    });
+
+    useAISidebarStore.getState().handleExtensionMessage({ type: 'clear-chat' });
+
+    assert.equal(
+      useAISidebarStore.getState().dismissedCurrentPlanKey,
+      null,
+      'extension-driven clear-chat must clear dismissed current plan state'
+    );
+  } finally {
+    resetStore();
+  }
+}
+
 function testDismissCurrentPlanStoresKey() {
   try {
     useAISidebarStore.setState({
@@ -144,6 +165,7 @@ function main() {
   testStartNewConversationResetsProviderSessions();
   testClearChatResetsProviderSessions();
   testDismissedCurrentPlanKeyResetsForNewConversation();
+  testDismissedCurrentPlanKeyResetsForClearChatMessage();
   testDismissCurrentPlanStoresKey();
   console.log('Conversation reset tests passed.');
 }

--- a/extensions/ritemark/webview/src/components/ai-sidebar/lifecycle.test.ts
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/lifecycle.test.ts
@@ -1,7 +1,15 @@
 import assert from 'node:assert/strict';
 import { buildActivePlanViewModel } from './activePlan';
-import { applyCodexPlanApproval, applyCodexPlanUpdate, buildCodexApprovedPlanPrompt, finalizeCodexTurnResult, getActiveApprovedPlanForCodex, shouldRequestPlanMode } from './lifecycle';
-import type { CodexConversationTurn } from './types';
+import {
+  applyCodexPlanApproval,
+  applyCodexPlanUpdate,
+  buildCodexApprovedPlanPrompt,
+  finalizeCodexTurnResult,
+  getActiveApprovedPlanForClaude,
+  getActiveApprovedPlanForCodex,
+  shouldRequestPlanMode,
+} from './lifecycle';
+import type { AgentConversationTurn, CodexConversationTurn } from './types';
 
 function makeTurn(overrides: Partial<CodexConversationTurn>): CodexConversationTurn {
   return {
@@ -23,6 +31,26 @@ function makeTurn(overrides: Partial<CodexConversationTurn>): CodexConversationT
     planDecision: overrides.planDecision,
     result: overrides.result,
     isRunning: overrides.isRunning ?? false,
+    timestamp: overrides.timestamp ?? 1,
+  };
+}
+
+function makeAgentTurn(overrides: Partial<AgentConversationTurn>): AgentConversationTurn {
+  return {
+    id: overrides.id || 'agent-turn-1',
+    userPrompt: overrides.userPrompt || 'Improve the document',
+    activeFilePath: overrides.activeFilePath,
+    attachments: overrides.attachments,
+    activities: overrides.activities || [],
+    subagents: overrides.subagents,
+    result: overrides.result,
+    isRunning: overrides.isRunning ?? false,
+    isPlan: overrides.isPlan ?? false,
+    planHandled: overrides.planHandled ?? false,
+    planDecision: overrides.planDecision,
+    planText: overrides.planText,
+    pendingQuestion: overrides.pendingQuestion,
+    pendingPlanApproval: overrides.pendingPlanApproval,
     timestamp: overrides.timestamp ?? 1,
   };
 }
@@ -75,6 +103,24 @@ function testActivePlanParsesMarkdownChecklistStatuses() {
   assert.deepEqual(
     model?.steps.map((step) => step.status),
     ['completed', 'completed', 'pending']
+  );
+}
+
+function testActivePlanCanForceCompletedFallback() {
+  const model = buildActivePlanViewModel(
+    `1. Review structure
+2. Edit sections
+3. Final pass`,
+    undefined,
+    false,
+    true
+  );
+
+  assert.ok(model, 'forced-complete fallback should build a view model');
+  assert.equal(model?.summary, '3 done');
+  assert.deepEqual(
+    model?.steps.map((step) => step.status),
+    ['completed', 'completed', 'completed']
   );
 }
 
@@ -194,6 +240,39 @@ function testActiveApprovedPlanUsesLiveStreamingFallback() {
   );
 }
 
+function testClaudeApprovedPlanUsesCompletedResultOverlay() {
+  const approvedTurn = makeAgentTurn({
+    id: 'claude-plan-turn',
+    isPlan: true,
+    planHandled: true,
+    planDecision: 'approved',
+    planText: `1. Review structure
+2. Edit sections
+3. Final pass`,
+    result: {
+      text: `1. Fixed wording
+2. Adjusted structure
+3. Re-checked consistency`,
+      filesModified: [],
+      metrics: { durationMs: 1000, costUsd: null, model: null },
+    },
+    isRunning: false,
+    timestamp: 10,
+  });
+
+  const activePlan = getActiveApprovedPlanForClaude([approvedTurn]);
+
+  assert.ok(activePlan, 'approved Claude plan should be derivable');
+  assert.equal(activePlan?.allCompleted, true);
+  const model = buildActivePlanViewModel(
+    activePlan?.planText || '',
+    activePlan?.planSteps,
+    activePlan?.isRunning,
+    activePlan?.allCompleted
+  );
+  assert.equal(model?.summary, '3 done');
+}
+
 function testBuildCodexApprovedPlanPromptKeepsOriginalRequest() {
   const prompt = buildCodexApprovedPlanPrompt(
     'Update the policy document',
@@ -272,10 +351,12 @@ function main() {
   testActivePlanFallbackPromotesFirstItemToInProgress();
   testActivePlanUsesStructuredStatusesWhenAvailable();
   testActivePlanParsesMarkdownChecklistStatuses();
+  testActivePlanCanForceCompletedFallback();
   testActivePlanPrefersChecklistBlockOverLaterHeadings();
   testCodexPlanApprovalCreatesContinuationTurn();
   testActiveApprovedPlanPrefersLiveExecutionSteps();
   testActiveApprovedPlanUsesLiveStreamingFallback();
+  testClaudeApprovedPlanUsesCompletedResultOverlay();
   testBuildCodexApprovedPlanPromptKeepsOriginalRequest();
   testApprovedContinuationPlanUpdateDoesNotReenterReview();
   testPlanModeResultWithoutStructuredUpdateStillRequiresReview();

--- a/extensions/ritemark/webview/src/components/ai-sidebar/lifecycle.test.ts
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/lifecycle.test.ts
@@ -1,0 +1,286 @@
+import assert from 'node:assert/strict';
+import { buildActivePlanViewModel } from './activePlan';
+import { applyCodexPlanApproval, applyCodexPlanUpdate, buildCodexApprovedPlanPrompt, finalizeCodexTurnResult, getActiveApprovedPlanForCodex, shouldRequestPlanMode } from './lifecycle';
+import type { CodexConversationTurn } from './types';
+
+function makeTurn(overrides: Partial<CodexConversationTurn>): CodexConversationTurn {
+  return {
+    id: overrides.id || 'turn-1',
+    userPrompt: overrides.userPrompt || 'Improve the document',
+    requestedPlanMode: overrides.requestedPlanMode,
+    activeFilePath: overrides.activeFilePath,
+    attachments: overrides.attachments,
+    streamingText: overrides.streamingText || '',
+    activities: overrides.activities || [],
+    approval: overrides.approval,
+    pendingQuestion: overrides.pendingQuestion,
+    executionContinuation: overrides.executionContinuation,
+    requiresPlanReview: overrides.requiresPlanReview,
+    planText: overrides.planText,
+    planExplanation: overrides.planExplanation,
+    planSteps: overrides.planSteps,
+    planHandled: overrides.planHandled ?? false,
+    planDecision: overrides.planDecision,
+    result: overrides.result,
+    isRunning: overrides.isRunning ?? false,
+    timestamp: overrides.timestamp ?? 1,
+  };
+}
+
+function testActivePlanFallbackPromotesFirstItemToInProgress() {
+  const model = buildActivePlanViewModel(
+    `
+Plan:
+1. Review current section order
+2. Add missing approval limits
+3. Tighten wording in exceptions
+    `,
+    undefined,
+    true
+  );
+
+  assert.ok(model, 'fallback plan text should build a view model');
+  assert.equal(model?.summary, '1 in progress · 2 pending');
+  assert.equal(model?.steps[0].status, 'inProgress');
+  assert.equal(model?.steps[1].status, 'pending');
+}
+
+function testActivePlanUsesStructuredStatusesWhenAvailable() {
+  const model = buildActivePlanViewModel('', [
+    { step: 'Review section order', status: 'completed' },
+    { step: 'Add missing approval limits', status: 'inProgress' },
+    { step: 'Tighten wording in exceptions', status: 'pending' },
+  ]);
+
+  assert.ok(model, 'structured plan should build a view model');
+  assert.equal(model?.summary, '1 in progress · 1 pending · 1 done');
+  assert.deepEqual(
+    model?.steps.map((step) => step.status),
+    ['completed', 'inProgress', 'pending']
+  );
+}
+
+function testActivePlanParsesMarkdownChecklistStatuses() {
+  const model = buildActivePlanViewModel(
+    `Working checklist:
+- [x] Review structure
+- [x] Identify overlaps
+- [ ] Draft rewrite outline`,
+    undefined,
+    false
+  );
+
+  assert.ok(model, 'markdown checklist should build a view model');
+  assert.equal(model?.summary, '1 pending · 2 done');
+  assert.deepEqual(
+    model?.steps.map((step) => step.status),
+    ['completed', 'completed', 'pending']
+  );
+}
+
+function testActivePlanPrefersChecklistBlockOverLaterHeadings() {
+  const model = buildActivePlanViewModel(
+    `Jätkan — siin on konkreetne pakett.
+
+### Töö-checklist
+- ✅ Struktuur
+- ✅ Sisu täpsus
+- ▶️ Täpne uus sõnastus
+
+---
+
+## 6) Alkoholi reegli dubleerimise vähendamine
+
+Soovitus: jäta detailne alkoholireegel ainult p 5 alla.`,
+    undefined,
+    false
+  );
+
+  assert.ok(model, 'emoji checklist should build a view model');
+  assert.equal(model?.summary, '1 in progress · 2 done');
+  assert.deepEqual(
+    model?.steps.map((step) => step.label),
+    ['Struktuur', 'Sisu täpsus', 'Täpne uus sõnastus']
+  );
+  assert.deepEqual(
+    model?.steps.map((step) => step.status),
+    ['completed', 'completed', 'inProgress']
+  );
+}
+
+function testCodexPlanApprovalCreatesContinuationTurn() {
+  const turns = [
+    makeTurn({
+      id: 'plan-turn',
+      userPrompt: 'Refactor the document',
+      planText: '1. Review structure\n2. Edit sections',
+      result: { status: 'completed' },
+      timestamp: 10,
+    }),
+  ];
+
+  const { conversation, prompt } = applyCodexPlanApproval(turns, 'plan-turn', () => 'continuation-turn');
+
+  assert.ok(prompt, 'plan approval should emit a continuation prompt');
+  assert.match(prompt || '', /Continue the task now instead of re-planning/);
+  assert.match(prompt || '', /update step statuses as you progress/);
+  assert.equal(conversation.length, 2, 'approval should append a continuation turn');
+  assert.equal(conversation[0].planHandled, true);
+  assert.equal(conversation[0].planDecision, 'approved');
+  assert.equal(conversation[1].id, 'continuation-turn');
+  assert.equal(conversation[1].userPrompt, 'Continue with approved plan');
+  assert.equal(conversation[1].isRunning, true);
+}
+
+function testActiveApprovedPlanPrefersLiveExecutionSteps() {
+  const approvedTurn = makeTurn({
+    id: 'plan-turn',
+    planHandled: true,
+    planDecision: 'approved',
+    planText: '1. Review structure\n2. Edit sections',
+    timestamp: 10,
+  });
+
+  const liveExecutionTurn = makeTurn({
+    id: 'exec-turn',
+    userPrompt: 'Continue with approved plan',
+    planSteps: [
+      { step: 'Review structure', status: 'completed' },
+      { step: 'Edit sections', status: 'inProgress' },
+    ],
+    planText: '1. Review structure\n2. Edit sections',
+    isRunning: true,
+    timestamp: 20,
+  });
+
+  const activePlan = getActiveApprovedPlanForCodex([approvedTurn, liveExecutionTurn]);
+
+  assert.ok(activePlan, 'approved plan should be derivable');
+  assert.equal(activePlan?.isRunning, true);
+  assert.deepEqual(
+    activePlan?.planSteps?.map((step) => step.status),
+    ['completed', 'inProgress']
+  );
+}
+
+function testActiveApprovedPlanUsesLiveStreamingFallback() {
+  const approvedTurn = makeTurn({
+    id: 'plan-turn',
+    planHandled: true,
+    planDecision: 'approved',
+    planText: '1. Review structure\n2. Edit sections',
+    timestamp: 10,
+  });
+
+  const liveExecutionTurn = makeTurn({
+    id: 'exec-turn',
+    userPrompt: 'Continue with approved plan',
+    streamingText: `Working checklist:
+- [x] Review structure
+- [ ] Edit sections`,
+    isRunning: true,
+    timestamp: 20,
+  });
+
+  const activePlan = getActiveApprovedPlanForCodex([approvedTurn, liveExecutionTurn]);
+
+  assert.ok(activePlan, 'approved plan should be derivable');
+  assert.equal(activePlan?.isRunning, true);
+  const model = buildActivePlanViewModel(activePlan?.planText || '', activePlan?.planSteps, activePlan?.isRunning);
+  assert.equal(model?.summary, '1 pending · 1 done');
+  assert.deepEqual(
+    model?.steps.map((step) => step.status),
+    ['completed', 'pending']
+  );
+}
+
+function testBuildCodexApprovedPlanPromptKeepsOriginalRequest() {
+  const prompt = buildCodexApprovedPlanPrompt(
+    'Update the policy document',
+    '1. Review structure\n2. Edit sections'
+  );
+
+  assert.match(prompt, /Original task context:/);
+  assert.match(prompt, /Update the policy document/);
+  assert.match(prompt, /Approved plan:/);
+}
+
+function testApprovedContinuationPlanUpdateDoesNotReenterReview() {
+  const continuationTurn = makeTurn({
+    id: 'exec-turn',
+    userPrompt: 'Continue with approved plan',
+    executionContinuation: true,
+    isRunning: true,
+    timestamp: 20,
+  });
+
+  const updatedTurn = applyCodexPlanUpdate(continuationTurn, {
+    explanation: 'Continue execution using the approved plan.',
+    plan: [
+      { step: 'Review structure', status: 'completed' },
+      { step: 'Edit sections', status: 'inProgress' },
+    ],
+  });
+
+  assert.equal(
+    updatedTurn.requiresPlanReview,
+    false,
+    'approved continuation turn must stay in execute mode instead of re-entering plan review'
+  );
+  assert.deepEqual(
+    updatedTurn.planSteps?.map((step) => step.status),
+    ['completed', 'inProgress']
+  );
+}
+
+function testPlanModeResultWithoutStructuredUpdateStillRequiresReview() {
+  const turn = makeTurn({
+    id: 'plan-turn',
+    userPrompt: 'Work in plan mode first. Ask one question, then make a short 3-step plan.',
+    requestedPlanMode: true,
+    streamingText: `3-step plan
+
+1. Review the current structure
+2. Propose a clearer section order
+3. Add a compact validation checklist`,
+    isRunning: true,
+    timestamp: 30,
+  });
+
+  const finalizedTurn = finalizeCodexTurnResult(turn, { status: 'completed' });
+
+  assert.equal(
+    finalizedTurn.requiresPlanReview,
+    true,
+    'a plan-mode turn that ends with plain-text plan output must still enter review even without codex-plan-update'
+  );
+  assert.equal(finalizedTurn.isRunning, false);
+}
+
+function testPlanModePromptDetection() {
+  assert.equal(shouldRequestPlanMode('Work in plan mode first.'), true);
+  assert.equal(shouldRequestPlanMode('Enter plan mode and propose steps.'), true);
+  assert.equal(
+    shouldRequestPlanMode(buildCodexApprovedPlanPrompt('Work in plan mode first.', '1. Do work')),
+    false,
+    'approved-plan continuation prompt must not accidentally re-enter plan mode'
+  );
+  assert.equal(shouldRequestPlanMode('Just edit the file directly.'), false);
+}
+
+function main() {
+  testActivePlanFallbackPromotesFirstItemToInProgress();
+  testActivePlanUsesStructuredStatusesWhenAvailable();
+  testActivePlanParsesMarkdownChecklistStatuses();
+  testActivePlanPrefersChecklistBlockOverLaterHeadings();
+  testCodexPlanApprovalCreatesContinuationTurn();
+  testActiveApprovedPlanPrefersLiveExecutionSteps();
+  testActiveApprovedPlanUsesLiveStreamingFallback();
+  testBuildCodexApprovedPlanPromptKeepsOriginalRequest();
+  testApprovedContinuationPlanUpdateDoesNotReenterReview();
+  testPlanModeResultWithoutStructuredUpdateStillRequiresReview();
+  testPlanModePromptDetection();
+  console.log('Webview lifecycle tests passed.');
+}
+
+main();

--- a/extensions/ritemark/webview/src/components/ai-sidebar/lifecycle.ts
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/lifecycle.ts
@@ -1,4 +1,4 @@
-import type { CodexConversationTurn } from './types';
+import type { AgentConversationTurn, CodexConversationTurn } from './types';
 import { extractPlanDisplayText } from './planText';
 
 export interface ActiveApprovedPlan {
@@ -6,6 +6,7 @@ export interface ActiveApprovedPlan {
   planText: string;
   planSteps?: CodexConversationTurn['planSteps'];
   isRunning: boolean;
+  allCompleted?: boolean;
 }
 
 export function buildCodexApprovedPlanPrompt(originalPrompt: string, planText: string): string {
@@ -148,5 +149,29 @@ export function getActiveApprovedPlanForCodex(turns: CodexConversationTurn[]): A
       || '',
     planSteps: livePlanSource.planSteps || approvedTurn.planSteps,
     isRunning: Boolean(livePlanSource.isRunning),
+  };
+}
+
+export function getActiveApprovedPlanForClaude(turns: AgentConversationTurn[]): ActiveApprovedPlan | null {
+  const approvedTurn = [...turns].reverse().find((turn) =>
+    turn.isPlan
+    && turn.planHandled
+    && turn.planDecision === 'approved'
+    && Boolean(turn.planText?.trim())
+  );
+
+  if (!approvedTurn) {
+    return null;
+  }
+
+  const completedResultText = approvedTurn.result && !approvedTurn.result.error
+    ? approvedTurn.result.text.trim()
+    : '';
+
+  return {
+    key: approvedTurn.id,
+    planText: completedResultText || approvedTurn.planText || '',
+    isRunning: Boolean(approvedTurn.isRunning),
+    allCompleted: Boolean(completedResultText) && !approvedTurn.isRunning,
   };
 }

--- a/extensions/ritemark/webview/src/components/ai-sidebar/lifecycle.ts
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/lifecycle.ts
@@ -1,0 +1,152 @@
+import type { CodexConversationTurn } from './types';
+import { extractPlanDisplayText } from './planText';
+
+export interface ActiveApprovedPlan {
+  key: string;
+  planText: string;
+  planSteps?: CodexConversationTurn['planSteps'];
+  isRunning: boolean;
+}
+
+export function buildCodexApprovedPlanPrompt(originalPrompt: string, planText: string): string {
+  return [
+    'The user approved this plan. Continue the task now instead of re-planning.',
+    'Do not ask for plan approval again unless the plan must materially change.',
+    'Keep the approved plan as a short working checklist and update step statuses as you progress when the protocol supports it.',
+    '',
+    'Original task context:',
+    originalPrompt,
+    '',
+    'Approved plan:',
+    planText,
+  ].join('\n');
+}
+
+export function shouldRequestPlanMode(prompt: string): boolean {
+  if (/^The user approved this plan\./i.test(prompt.trim())) {
+    return false;
+  }
+  return /\bplan mode\b/i.test(prompt)
+    || /\bwork in plan\b/i.test(prompt)
+    || /\benter plan mode\b/i.test(prompt);
+}
+
+export function applyCodexPlanApproval(
+  turns: CodexConversationTurn[],
+  turnId: string,
+  createId: () => string
+): { conversation: CodexConversationTurn[]; prompt: string | null } {
+  const approvedTurn = turns.find((turn) => turn.id === turnId);
+  if (!approvedTurn) {
+    return { conversation: turns, prompt: null };
+  }
+
+  const prompt = buildCodexApprovedPlanPrompt(
+    approvedTurn.userPrompt,
+    approvedTurn.planText || approvedTurn.streamingText || ''
+  );
+
+  const continuationTurn: CodexConversationTurn = {
+    id: createId(),
+    userPrompt: 'Continue with approved plan',
+    requestedPlanMode: false,
+    activeFilePath: approvedTurn.activeFilePath,
+    attachments: approvedTurn.attachments,
+    streamingText: '',
+    activities: [],
+    pendingQuestion: undefined,
+    executionContinuation: true,
+    requiresPlanReview: false,
+    planText: '',
+    planExplanation: undefined,
+    planSteps: [],
+    planHandled: false,
+    planDecision: undefined,
+    isRunning: true,
+    timestamp: Date.now(),
+  };
+
+  const conversation = turns.map((turn) =>
+    turn.id === turnId
+      ? { ...turn, planHandled: true, planDecision: 'approved' as const }
+      : turn
+  );
+
+  return {
+    conversation: [...conversation, continuationTurn],
+    prompt,
+  };
+}
+
+export function finalizeCodexTurnResult(
+  turn: CodexConversationTurn,
+  result: { status?: string; error?: string }
+): CodexConversationTurn {
+  const fallbackPlanText = (!turn.planText || !turn.planText.trim())
+    ? turn.streamingText
+    : turn.planText;
+  const displayPlanText = extractPlanDisplayText(fallbackPlanText);
+  const shouldRequirePlanReview = Boolean(
+    !result.error
+    && !turn.executionContinuation
+    && turn.requestedPlanMode
+    && !turn.planHandled
+    && !turn.requiresPlanReview
+    && displayPlanText
+  );
+
+  return {
+    ...turn,
+    isRunning: false,
+    pendingQuestion: undefined,
+    planText: fallbackPlanText,
+    requiresPlanReview: turn.requiresPlanReview || shouldRequirePlanReview,
+    result: { status: result.status || 'success', error: result.error },
+  };
+}
+
+export function applyCodexPlanUpdate(
+  turn: CodexConversationTurn,
+  update: {
+    explanation?: string | null;
+    plan: NonNullable<CodexConversationTurn['planSteps']>;
+  }
+): CodexConversationTurn {
+  return {
+    ...turn,
+    planText: turn.planText || '',
+    planExplanation: update.explanation || undefined,
+    planSteps: update.plan,
+    requiresPlanReview: turn.executionContinuation ? false : true,
+    planHandled: turn.executionContinuation ? turn.planHandled : false,
+    planDecision: turn.executionContinuation ? turn.planDecision : undefined,
+  };
+}
+
+export function getActiveApprovedPlanForCodex(turns: CodexConversationTurn[]): ActiveApprovedPlan | null {
+  const approvedTurn = [...turns].reverse().find((turn) =>
+    turn.planHandled
+    && turn.planDecision === 'approved'
+    && Boolean((turn.planText || turn.streamingText).trim())
+  );
+
+  if (!approvedTurn) {
+    return null;
+  }
+
+  const latestTurn = turns[turns.length - 1];
+  const livePlanSource = latestTurn && latestTurn.timestamp >= approvedTurn.timestamp
+    ? latestTurn
+    : approvedTurn;
+
+  return {
+    key: approvedTurn.id,
+    planText: livePlanSource.planText
+      || livePlanSource.streamingText
+      || approvedTurn.planText
+      || approvedTurn.streamingText
+      || '',
+    planSteps: livePlanSource.planSteps || approvedTurn.planSteps,
+    isRunning: Boolean(livePlanSource.isRunning),
+  };
+}

--- a/extensions/ritemark/webview/src/components/ai-sidebar/planText.ts
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/planText.ts
@@ -1,0 +1,29 @@
+function isListParagraph(paragraph: string): boolean {
+  return paragraph
+    .split('\n')
+    .some((line) => /^(\s*[-*+]\s+|\s*\d+\.\s+)/.test(line.trimStart()));
+}
+
+function isHeadingParagraph(paragraph: string): boolean {
+  return /^#{1,6}\s+/.test(paragraph.trimStart());
+}
+
+export function extractPlanDisplayText(planText: string): string {
+  const normalized = planText.trim();
+  if (!normalized) {
+    return '';
+  }
+
+  const paragraphs = normalized.split(/\n\s*\n/).map((paragraph) => paragraph.trim()).filter(Boolean);
+  for (let i = paragraphs.length - 1; i >= 0; i--) {
+    if (isListParagraph(paragraphs[i]) || isHeadingParagraph(paragraphs[i])) {
+      return paragraphs.slice(i).join('\n\n');
+    }
+  }
+
+  if (paragraphs.length > 2) {
+    return paragraphs.slice(-2).join('\n\n');
+  }
+
+  return normalized;
+}

--- a/extensions/ritemark/webview/src/components/ai-sidebar/store.ts
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/store.ts
@@ -17,6 +17,7 @@ import {
   setWorkspaceContext,
   type SavedConversation,
 } from './chatHistoryStorage';
+import { applyCodexPlanApproval, applyCodexPlanUpdate, finalizeCodexTurnResult, shouldRequestPlanMode } from './lifecycle';
 import type {
   AgentId,
   AgentInfo,
@@ -27,8 +28,11 @@ import type {
   RAGCitation,
   WidgetData,
   AgentConversationTurn,
+  AgentPlanApprovalRequest,
+  AgentQuestion,
   CodexConversationTurn,
   CodexSidebarStatus,
+  CodexQuestion,
   FileAttachment,
   DiscoveredAgent,
   DiscoveredCommand,
@@ -46,6 +50,10 @@ function nextId(): string {
   return `msg-${++msgCounter}-${Date.now()}`;
 }
 
+function resetProviderSessions(): void {
+  vscode.postMessage({ type: 'conversation:reset' });
+}
+
 const DEFAULT_CODEX_STATUS: CodexSidebarStatus = {
   enabled: false,
   state: 'disabled',
@@ -57,6 +65,7 @@ const DEFAULT_CODEX_STATUS: CodexSidebarStatus = {
   diagnostics: [],
   repairCommand: null,
   binaryPath: null,
+  compatibility: null,
 };
 
 // ── Context window estimation ─────────────────────────────────────────
@@ -67,6 +76,22 @@ const DEFAULT_CODEX_STATUS: CodexSidebarStatus = {
 
 function computeContextState(_turns: AgentConversationTurn[]) {
   return { estimatedTokens: 0, contextUsagePercent: 0, showContextWarning: false };
+}
+
+function getCodexCompatibilityNoticeKey(status: CodexSidebarStatus): string | null {
+  const compatibility = status.compatibility;
+  if (status.state !== 'ready' || !compatibility || compatibility.state === 'compatible') {
+    return null;
+  }
+
+  const caps = compatibility.capabilities;
+  return [
+    status.version ?? 'unknown',
+    compatibility.state,
+    caps.approvals ? 'approvals' : 'no-approvals',
+    caps.requestUserInput ? 'question' : 'no-question',
+    caps.planUpdates ? 'plan' : 'no-plan',
+  ].join(':');
 }
 
 interface AISidebarState {
@@ -102,6 +127,8 @@ interface AISidebarState {
   codexSelectedModel: string;
   codexStatus: CodexSidebarStatus;
   codexConversation: CodexConversationTurn[];
+  dismissedCodexNoticeKey: string | null;
+  dismissedCurrentPlanKey: string | null;
 
   // ── Chat history state ──
   currentConversationId: string | null;
@@ -152,14 +179,20 @@ interface AISidebarState {
   recheckSetup: () => void;
   approvePlan: (turnId: string) => void;
   rejectPlan: (turnId: string, feedback?: string) => void;
+  answerAgentQuestion: (turnId: string, question: AgentQuestion, answers: Record<string, string>) => void;
   dismissWelcome: () => void;
   sendCodexMessage: (prompt: string, attachments?: FileAttachment[]) => void;
   selectCodexModel: (modelId: string) => void;
   handleCodexApproval: (requestId: string | number, approved: boolean) => void;
+  answerCodexQuestion: (turnId: string, question: CodexQuestion, answers: Record<string, string>) => void;
+  approveCodexPlan: (turnId: string) => void;
+  discardCodexPlan: (turnId: string) => void;
   startCodexLogin: () => void;
   logoutCodex: () => void;
   refreshCodexStatus: () => void;
   repairCodex: () => void;
+  dismissCodexNotice: (key: string) => void;
+  dismissCurrentPlan: (key: string) => void;
   reloadWindow: () => void;
   openAgentSettings: () => void;
 
@@ -203,6 +236,8 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
   codexSelectedModel: 'gpt-5.3-codex',
   codexStatus: DEFAULT_CODEX_STATUS,
   codexConversation: [],
+  dismissedCodexNoticeKey: null,
+  dismissedCurrentPlanKey: null,
 
   currentConversationId: null,
   savedConversations: [],
@@ -279,6 +314,10 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
       isRunning: true,
       isPlan: false,
       planHandled: false,
+      planDecision: undefined,
+      planText: '',
+      pendingQuestion: undefined,
+      pendingPlanApproval: undefined,
       timestamp: Date.now(),
     };
 
@@ -390,55 +429,68 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
 
   approvePlan: (turnId) => {
     const state = get();
+    const targetTurn = state.agentConversation.find((t) => t.id === turnId);
+    if (!targetTurn?.pendingPlanApproval) {
+      return;
+    }
+
     const conv = state.agentConversation.map((t) =>
-      t.id === turnId ? { ...t, planHandled: true } : t
+      t.id === turnId
+        ? {
+            ...t,
+            planHandled: true,
+            planDecision: 'approved' as const,
+            pendingPlanApproval: undefined,
+          }
+        : t
     );
     set({ agentConversation: conv });
-
-    // Send approval as a follow-up message to the agent
     vscode.postMessage({
-      type: 'ai-execute-agent',
-      prompt: 'Plan approved. Proceed with implementation.',
+      type: 'agent-answer-plan',
+      toolUseId: targetTurn.pendingPlanApproval.toolUseId,
+      approved: true,
     });
-
-    // Add a new running turn for the implementation
-    const implTurn: AgentConversationTurn = {
-      id: nextId(),
-      userPrompt: 'Plan approved. Proceed with implementation.',
-      activities: [],
-      isRunning: true,
-      isPlan: false,
-      planHandled: false,
-      timestamp: Date.now(),
-    };
-    set({ agentConversation: [...conv, implTurn] });
   },
 
   rejectPlan: (turnId, feedback?) => {
     const state = get();
+    const targetTurn = state.agentConversation.find((t) => t.id === turnId);
+    if (!targetTurn?.pendingPlanApproval) {
+      return;
+    }
+
     const conv = state.agentConversation.map((t) =>
-      t.id === turnId ? { ...t, planHandled: true } : t
+      t.id === turnId
+        ? {
+            ...t,
+            planHandled: true,
+            planDecision: 'rejected' as const,
+            pendingPlanApproval: undefined,
+          }
+        : t
     );
     set({ agentConversation: conv });
+    vscode.postMessage({
+      type: 'agent-answer-plan',
+      toolUseId: targetTurn.pendingPlanApproval.toolUseId,
+      approved: false,
+      feedback,
+    });
+  },
 
-    if (feedback) {
-      const rejectPrompt = `Plan rejected. ${feedback}`;
-      vscode.postMessage({
-        type: 'ai-execute-agent',
-        prompt: rejectPrompt,
-      });
-
-      const retryTurn: AgentConversationTurn = {
-        id: nextId(),
-        userPrompt: rejectPrompt,
-        activities: [],
-        isRunning: true,
-        isPlan: false,
-        planHandled: false,
-        timestamp: Date.now(),
-      };
-      set({ agentConversation: [...conv, retryTurn] });
-    }
+  answerAgentQuestion: (turnId, question, answers) => {
+    const state = get();
+    const conv = state.agentConversation.map((turn) =>
+      turn.id === turnId
+        ? { ...turn, pendingQuestion: undefined }
+        : turn
+    );
+    set({ agentConversation: conv });
+    vscode.postMessage({
+      type: 'agent-answer-question',
+      toolUseId: question.toolUseId,
+      answers,
+    });
   },
 
   dismissWelcome: () => {
@@ -454,10 +506,19 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
     const turn: CodexConversationTurn = {
       id: nextId(),
       userPrompt: prompt,
+      requestedPlanMode: shouldRequestPlanMode(prompt),
       activeFilePath: state.activeFilePath || undefined,
       attachments,
       streamingText: '',
       activities: [],
+      pendingQuestion: undefined,
+      executionContinuation: false,
+      requiresPlanReview: false,
+      planText: '',
+      planExplanation: undefined,
+      planSteps: [],
+      planHandled: false,
+      planDecision: undefined,
       isRunning: true,
       timestamp: Date.now(),
     };
@@ -485,6 +546,52 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
     vscode.postMessage({ type: 'codex-approve', requestId, approved });
   },
 
+  answerCodexQuestion: (turnId, question, answers) => {
+    const state = get();
+    const answerMap = Object.fromEntries(
+      question.questions.map((item) => {
+        const value = answers[item.question] ?? '';
+        const normalizedAnswers = value
+          .split(',')
+          .map((entry) => entry.trim())
+          .filter(Boolean);
+        return [item.id, { answers: normalizedAnswers }];
+      })
+    );
+    const conv = state.codexConversation.map((turn) =>
+      turn.id === turnId
+        ? { ...turn, pendingQuestion: undefined }
+        : turn
+    );
+    set({ codexConversation: conv });
+    vscode.postMessage({ type: 'codex-answer-question', requestId: question.requestId, answers: answerMap });
+  },
+
+  approveCodexPlan: (turnId) => {
+    const state = get();
+    const { conversation, prompt } = applyCodexPlanApproval(state.codexConversation, turnId, nextId);
+    if (!prompt) {
+      return;
+    }
+    set({ codexConversation: conversation });
+    vscode.postMessage({
+      type: 'codex-execute',
+      prompt,
+      model: state.codexSelectedModel,
+      mode: 'execute',
+    });
+  },
+
+  discardCodexPlan: (turnId) => {
+    const state = get();
+    const conv = state.codexConversation.map((turn) =>
+      turn.id === turnId
+        ? { ...turn, planHandled: true, planDecision: 'rejected' as const }
+        : turn
+    );
+    set({ codexConversation: conv });
+  },
+
   startCodexLogin: () => {
     const status = get().codexStatus;
     set({
@@ -507,6 +614,14 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
 
   repairCodex: () => {
     vscode.postMessage({ type: 'codex:repair' });
+  },
+
+  dismissCodexNotice: (key) => {
+    set({ dismissedCodexNoticeKey: key });
+  },
+
+  dismissCurrentPlan: (key) => {
+    set({ dismissedCurrentPlanKey: key });
   },
 
   reloadWindow: () => {
@@ -561,6 +676,8 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
     const data = loadConversation(id);
     if (!data) return;
 
+    resetProviderSessions();
+
     // Handle legacy saves: Codex conversations were stored in agentConversation
     // before the codexConversation field was added
     let agentConv = data.agentConversation || [];
@@ -576,6 +693,7 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
       selectedAgent: data.agentId,
       agentConversation: agentConv,
       codexConversation: codexConv,
+      dismissedCurrentPlanKey: null,
       chatMessages: data.chatMessages || [],
       conversationHistory: data.conversationHistory || [],
       showHistoryPanel: false,
@@ -598,6 +716,7 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
         conversationHistory: [],
         agentConversation: [],
         codexConversation: [],
+        dismissedCurrentPlanKey: null,
       });
     }
 
@@ -617,6 +736,8 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
       get().saveCurrentConversation();
     }
 
+    resetProviderSessions();
+
     // Clear and start fresh
     set({
       currentConversationId: null,
@@ -627,6 +748,7 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
       pendingCitations: [],
       agentConversation: [],
       codexConversation: [],
+      dismissedCurrentPlanKey: null,
       showHistoryPanel: false,
       estimatedTokens: 0,
       contextUsagePercent: 0,
@@ -644,6 +766,7 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
   },
 
   clearChat: () => {
+    resetProviderSessions();
     set({
       chatMessages: [],
       conversationHistory: [],
@@ -652,6 +775,7 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
       pendingCitations: [],
       agentConversation: [],
       codexConversation: [],
+      dismissedCurrentPlanKey: null,
       estimatedTokens: 0,
       contextUsagePercent: 0,
       showContextWarning: false,
@@ -688,6 +812,7 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
         const selectedModel = newClaudeModels.some((m: { id: string }) => m.id === currentClaude)
           ? currentClaude
           : (newClaudeModels[0]?.id || currentClaude);
+        const incomingCodexStatus = message.codexStatus ?? get().codexStatus;
         set({
           agenticEnabled: message.agenticEnabled,
           codexEnabled: message.codexEnabled ?? false,
@@ -697,7 +822,10 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
           models: newClaudeModels,
           codexModels: newCodexModels,
           codexSelectedModel,
-          codexStatus: message.codexStatus ?? get().codexStatus,
+          codexStatus: incomingCodexStatus,
+          dismissedCodexNoticeKey: getCodexCompatibilityNoticeKey(incomingCodexStatus)
+            ? get().dismissedCodexNoticeKey
+            : null,
           setupStatus: message.setupStatus ?? get().setupStatus,
           environmentStatus: message.environmentStatus ?? get().environmentStatus,
           hasSeenWelcome: message.hasSeenWelcome ?? get().hasSeenWelcome,
@@ -710,6 +838,10 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
         const updates: Partial<AISidebarState> = {
           codexStatus: message.status,
         };
+
+        if (!getCodexCompatibilityNoticeKey(message.status)) {
+          updates.dismissedCodexNoticeKey = null;
+        }
 
         if (message.status.state !== 'ready') {
           const conv = [...state.codexConversation];
@@ -883,6 +1015,15 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
         if (lastTurn?.isRunning) {
           const progress = message.progress as AgentProgress;
 
+          if (progress.type === 'plan_text') {
+            conv[conv.length - 1] = {
+              ...lastTurn,
+              planText: `${lastTurn.planText || ''}${lastTurn.planText ? '\n\n' : ''}${progress.message}`,
+            };
+            set({ agentConversation: conv });
+            break;
+          }
+
           // Handle subagent events specially
           if (progress.type === 'subagent_start' && progress.subagentId) {
             // Create a new subagent entry
@@ -935,6 +1076,36 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
         break;
       }
 
+      case 'agent-question': {
+        const conv = [...state.agentConversation];
+        const lastTurn = conv[conv.length - 1];
+        if (lastTurn?.isRunning) {
+          conv[conv.length - 1] = {
+            ...lastTurn,
+            pendingQuestion: message.question,
+          };
+          set({ agentConversation: conv });
+        }
+        break;
+      }
+
+      case 'agent-plan-approval': {
+        const conv = [...state.agentConversation];
+        const lastTurn = conv[conv.length - 1];
+        if (lastTurn?.isRunning) {
+          const pendingPlanApproval: AgentPlanApprovalRequest = message.request;
+          conv[conv.length - 1] = {
+            ...lastTurn,
+            isPlan: true,
+            planHandled: false,
+            planDecision: undefined,
+            pendingPlanApproval,
+          };
+          set({ agentConversation: conv });
+        }
+        break;
+      }
+
       case 'agent-result': {
         const conv = [...state.agentConversation];
         const lastTurn = conv[conv.length - 1];
@@ -945,6 +1116,8 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
             ...lastTurn,
             isRunning: false,
             isPlan: hasPlanActivity,
+            pendingQuestion: undefined,
+            pendingPlanApproval: undefined,
             result: {
               text: message.text || '',
               filesModified: message.filesModified || [],
@@ -1006,15 +1179,61 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
         break;
       }
 
+      case 'codex-question': {
+        const conv = [...state.codexConversation];
+        const lastTurn = conv[conv.length - 1];
+        if (lastTurn?.isRunning) {
+          conv[conv.length - 1] = {
+            ...lastTurn,
+            pendingQuestion: {
+              requestId: message.requestId,
+              questions: message.questions,
+            },
+            requiresPlanReview: false,
+            planHandled: false,
+            planDecision: undefined,
+          };
+          set({ codexConversation: conv });
+        }
+        break;
+      }
+
+      case 'codex-plan-text-delta': {
+        const conv = [...state.codexConversation];
+        const lastTurn = conv[conv.length - 1];
+        if (lastTurn?.isRunning) {
+          conv[conv.length - 1] = {
+            ...lastTurn,
+            planText: `${lastTurn.planText || ''}${message.delta}`,
+            planHandled: false,
+            planDecision: undefined,
+          };
+          set({ codexConversation: conv });
+        }
+        break;
+      }
+
+      case 'codex-plan-update': {
+        const conv = [...state.codexConversation];
+        const lastTurn = conv[conv.length - 1];
+        if (lastTurn?.isRunning) {
+          conv[conv.length - 1] = applyCodexPlanUpdate(lastTurn, {
+            explanation: message.explanation,
+            plan: message.plan,
+          });
+          set({ codexConversation: conv });
+        }
+        break;
+      }
+
       case 'codex-result': {
         const conv = [...state.codexConversation];
         const lastTurn = conv[conv.length - 1];
         if (lastTurn) {
-          conv[conv.length - 1] = {
-            ...lastTurn,
-            isRunning: false,
-            result: { status: message.status || 'success', error: message.error },
-          };
+          conv[conv.length - 1] = finalizeCodexTurnResult(lastTurn, {
+            status: message.status,
+            error: message.error,
+          });
           set({ codexConversation: conv });
           setTimeout(() => get().saveCurrentConversation(), 100);
         }

--- a/extensions/ritemark/webview/src/components/ai-sidebar/store.ts
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/store.ts
@@ -974,6 +974,7 @@ export const useAISidebarStore = create<AISidebarState>((set, get) => ({
           pendingCitations: [],
           agentConversation: [],
           codexConversation: [],
+          dismissedCurrentPlanKey: null,
         });
         break;
 

--- a/extensions/ritemark/webview/src/components/ai-sidebar/types.ts
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/types.ts
@@ -22,7 +22,7 @@ export interface ModelOption {
   description: string;
 }
 
-export type AgentProgressType = 'init' | 'thinking' | 'tool_use' | 'text' | 'plan_ready' | 'done' | 'error' | 'context_overflow' | 'subagent_start' | 'subagent_progress' | 'subagent_done' | 'compacting' | 'compacted';
+export type AgentProgressType = 'init' | 'thinking' | 'tool_use' | 'text' | 'plan_text' | 'plan_ready' | 'done' | 'error' | 'context_overflow' | 'subagent_start' | 'subagent_progress' | 'subagent_done' | 'compacting' | 'compacted';
 
 export interface AgentProgress {
   type: AgentProgressType;
@@ -36,6 +36,27 @@ export interface AgentProgress {
   subagentTask?: string;
   /** For subagent events, the parent tool_use_id for correlation */
   parentToolUseId?: string;
+}
+
+export interface AgentQuestionOption {
+  label: string;
+  description: string;
+}
+
+export interface AgentQuestionItem {
+  header: string;
+  question: string;
+  options: AgentQuestionOption[];
+  multiSelect: boolean;
+}
+
+export interface AgentQuestion {
+  toolUseId: string;
+  questions: AgentQuestionItem[];
+}
+
+export interface AgentPlanApprovalRequest {
+  toolUseId: string;
 }
 
 /**
@@ -170,6 +191,10 @@ export interface AgentConversationTurn {
   isPlan: boolean;
   /** User has approved/rejected this plan */
   planHandled: boolean;
+  planDecision?: 'approved' | 'rejected';
+  planText?: string;
+  pendingQuestion?: AgentQuestion;
+  pendingPlanApproval?: AgentPlanApprovalRequest;
   timestamp: number;
 }
 
@@ -211,6 +236,16 @@ export interface CodexApprovalRequest {
   fileChanges?: Record<string, unknown>;
 }
 
+export interface CodexQuestion {
+  requestId: string | number;
+  questions: Array<AgentQuestionItem & { id: string }>;
+}
+
+export interface CodexPlanStep {
+  step: string;
+  status: 'pending' | 'inProgress' | 'completed';
+}
+
 export type CodexSidebarState =
   | 'disabled'
   | 'checking'
@@ -218,6 +253,21 @@ export type CodexSidebarState =
   | 'needs-auth'
   | 'auth-in-progress'
   | 'ready';
+
+export interface CodexCapabilityFlags {
+  approvals: boolean;
+  requestUserInput: boolean;
+  planUpdates: boolean;
+}
+
+export interface CodexCompatibilityStatus {
+  state: 'compatible' | 'limited' | 'untested';
+  summary: string;
+  auditedRange: string;
+  versionInAuditedRange: boolean;
+  capabilities: CodexCapabilityFlags;
+  limitations: string[];
+}
 
 export interface CodexSidebarStatus {
   enabled: boolean;
@@ -230,17 +280,27 @@ export interface CodexSidebarStatus {
   diagnostics: string[];
   repairCommand: string | null;
   binaryPath: string | null;
+  compatibility: CodexCompatibilityStatus | null;
 }
 
 export interface CodexConversationTurn {
   id: string;
   userPrompt: string;
+  requestedPlanMode?: boolean;
   /** Active file path that was included as context */
   activeFilePath?: string;
   attachments?: FileAttachment[];
   streamingText: string;
   activities: AgentProgress[];
   approval?: CodexApprovalRequest;
+  pendingQuestion?: CodexQuestion;
+  executionContinuation?: boolean;
+  requiresPlanReview?: boolean;
+  planText?: string;
+  planExplanation?: string;
+  planSteps?: CodexPlanStep[];
+  planHandled?: boolean;
+  planDecision?: 'approved' | 'rejected';
   result?: {
     status: string;
     error?: string;
@@ -268,6 +328,8 @@ export type ExtensionMessage =
   | { type: 'index-progress'; processed: number; total: number; current: string }
   | { type: 'index-done' }
   | { type: 'agent-progress'; progress: AgentProgress }
+  | { type: 'agent-question'; question: AgentQuestion }
+  | { type: 'agent-plan-approval'; request: AgentPlanApprovalRequest }
   | { type: 'agent-result'; text?: string; filesModified?: string[]; metrics?: AgentMetrics; error?: string }
   | { type: 'agent-setup:progress'; progress: InstallProgress }
   | { type: 'agent-setup:complete'; status: SetupStatus; environmentStatus?: AgentEnvironmentStatus }
@@ -280,5 +342,8 @@ export type ExtensionMessage =
   | { type: 'codex:status'; status: CodexSidebarStatus }
   | { type: 'codex-progress'; progress: AgentProgress }
   | { type: 'codex-streaming'; delta: string }
+  | { type: 'codex-question'; requestId: string | number; questions: Array<AgentQuestionItem & { id: string }> }
+  | { type: 'codex-plan-text-delta'; delta: string }
+  | { type: 'codex-plan-update'; explanation?: string | null; plan: CodexPlanStep[] }
   | { type: 'codex-result'; status?: string; error?: string }
   | { type: 'codex-approval'; approvalType: 'command' | 'fileChange'; requestId: string | number; command?: string; workingDir?: string; fileChanges?: Record<string, unknown> };

--- a/extensions/ritemark/webview/src/components/settings/RitemarkSettings.tsx
+++ b/extensions/ritemark/webview/src/components/settings/RitemarkSettings.tsx
@@ -104,6 +104,18 @@ interface SettingsData {
       error: string | null;
       diagnostics: string[];
       repairCommand: string | null;
+      compatibility: {
+        state: 'compatible' | 'limited' | 'untested';
+        summary: string;
+        auditedRange: string;
+        versionInAuditedRange: boolean;
+        capabilities: {
+          approvals: boolean;
+          requestUserInput: boolean;
+          planUpdates: boolean;
+        };
+        limitations: string[];
+      } | null;
     };
   };
 }
@@ -1241,7 +1253,11 @@ export function RitemarkSettings() {
                 title="Codex CLI"
                 status={
                   settings.componentStatus.codex.state === 'ready'
-                    ? 'Ready'
+                    ? settings.componentStatus.codex.compatibility?.state === 'limited'
+                      ? 'Ready with limits'
+                      : settings.componentStatus.codex.compatibility?.state === 'untested'
+                        ? 'Ready (untested)'
+                        : 'Ready'
                     : settings.componentStatus.codex.state === 'broken'
                       ? 'Broken'
                       : 'Not installed'
@@ -1259,6 +1275,17 @@ export function RitemarkSettings() {
                     : settings.componentStatus.codex.installed
                       ? 'Managed by user'
                       : 'CLI not detected',
+                  settings.componentStatus.codex.compatibility?.summary ?? 'Compatibility not checked',
+                  settings.componentStatus.codex.compatibility
+                    ? `Approvals: ${settings.componentStatus.codex.compatibility.capabilities.approvals ? 'available' : 'not detected'}`
+                    : 'Approvals: unknown',
+                  settings.componentStatus.codex.compatibility
+                    ? `Ask questions: ${settings.componentStatus.codex.compatibility.capabilities.requestUserInput ? 'available' : 'not detected'}`
+                    : 'Ask questions: unknown',
+                  settings.componentStatus.codex.compatibility
+                    ? `Plan updates: ${settings.componentStatus.codex.compatibility.capabilities.planUpdates ? 'available' : 'not detected'}`
+                    : 'Plan updates: unknown',
+                  ...(settings.componentStatus.codex.compatibility?.limitations ?? []),
                   ...settings.componentStatus.codex.diagnostics,
                 ]}
               />

--- a/scripts/validate-qa.sh
+++ b/scripts/validate-qa.sh
@@ -28,4 +28,15 @@ if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(extensions/ritemark/src/flows/|e
   )
 fi
 
+if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(extensions/ritemark/src/agent/|extensions/ritemark/src/codex/|extensions/ritemark/src/views/UnifiedViewProvider\.ts|extensions/ritemark/webview/src/components/ai-sidebar/)'; then
+  echo "Agent lifecycle changes detected; running targeted lifecycle tests..."
+  (
+    cd "$PROJECT_ROOT/extensions/ritemark"
+    npx tsx src/agent/AgentRunner.test.ts
+    npx tsx src/codex/codexApproval.test.ts
+    npx tsx webview/src/components/ai-sidebar/lifecycle.test.ts
+    npx tsx webview/src/components/ai-sidebar/conversationReset.test.ts
+  )
+fi
+
 echo "Codex QA validation passed"


### PR DESCRIPTION
## Summary
- harden Claude and Codex plan/question lifecycle handling in the AI sidebar
- add trace logging for Codex and Claude to debug tool and plan transitions
- unify current-plan UX and shared lifecycle helpers/tests across providers

## Validation
- cd extensions/ritemark && npm run compile
- cd extensions/ritemark/webview && npm run build
- ./scripts/validate-qa.sh