### PR TITLE
feat: mermaid diagram rendering and export

### DIFF
--- a/docs/development/sprints/sprint-30-mermaid-diagrams/research/codebase-analysis.md
+++ b/docs/development/sprints/sprint-30-mermaid-diagrams/research/codebase-analysis.md
@@ -1,0 +1,192 @@
+# Sprint 30: Mermaid Diagrams — Research Findings
+
+## 1. How Code Blocks Currently Work
+
+### Extension Stack
+
+Code blocks are handled by `CodeBlockWithCopyExtension`, which extends `@tiptap/extension-code-block-lowlight`:
+
+- **File:** `extensions/ritemark/webview/src/extensions/CodeBlockWithCopyExtension.ts`
+- It overrides `addNodeView()` to return a React `NodeViewRenderer`, which renders the component at:
+  `extensions/ritemark/webview/src/components/CodeBlockWithCopy.tsx`
+
+### NodeView Component (`CodeBlockWithCopy.tsx`)
+
+The component uses two TipTap primitives:
+- `<NodeViewWrapper as="pre">` — wraps the block and provides drag/selection handles
+- `<NodeViewContent as="code">` — renders the editable code content inside
+
+It adds a copy button (Copy/Copied! with `lucide-react` icons) layered over the block.
+
+The component receives `node.textContent` and `node.attrs.language` as props.
+
+### Editor Registration (`Editor.tsx`)
+
+In `useEditor()`, `StarterKit` is configured with `codeBlock: false` to suppress the default. The custom extension is registered:
+
+```typescript
+CodeBlockWithCopyExtension.configure({
+  lowlight,
+  defaultLanguage: 'plaintext',
+  HTMLAttributes: { class: 'tiptap-code-block' },
+})
+```
+
+`lowlight` is created with `createLowlight(common)` — the common language pack from `lowlight` v3.
+
+### Markdown Roundtrip
+
+- **Load:** `marked` parses markdown to HTML (including ` ```mermaid ` blocks as `<pre><code class="language-mermaid">`)
+- **Save:** `TurndownService` with `codeBlockStyle: 'fenced'` serializes `<pre><code>` back to fenced code blocks, preserving the language identifier
+
+No custom Turndown rule for code blocks exists — the default fenced style handles it. This means the mermaid language tag is preserved across load/save cycles.
+
+---
+
+## 2. TipTap Extensions for Code Blocks
+
+### Currently Used
+- `@tiptap/extension-code-block-lowlight` v2.1.0 — syntax highlighting via lowlight/highlight.js
+- Custom `CodeBlockWithCopyExtension` extends it with a React NodeView
+
+### Mermaid-Specific TipTap Options (from ecosystem research)
+
+There is no official `@tiptap/extension-mermaid`. The standard approach in the TipTap community is:
+
+**Option A: Extend existing NodeView in `CodeBlockWithCopy`**
+- Detect `node.attrs.language === 'mermaid'` inside the existing React component
+- Conditionally render either the raw code view OR an SVG rendered by mermaid.js
+- This requires **no new TipTap extension** — just React component logic
+
+**Option B: Create a separate `MermaidBlock` TipTap node**
+- Register a distinct ProseMirror node type for mermaid blocks
+- Requires parsing rules to convert `<pre><code class="language-mermaid">` to the new node
+- More complex, but gives finer control over serialization
+- Risk: the separate node type can break the markdown roundtrip unless Turndown gets a custom rule
+
+**Recommendation: Option A** — lower risk, no new node type, reuses existing serialization.
+
+---
+
+## 3. Webview Bundle Setup
+
+### Vite Config (`extensions/ritemark/webview/vite.config.ts`)
+
+Key facts:
+- Output: single `../media/webview.js` (IIFE, `inlineDynamicImports: true`)
+- **No code splitting** — everything is bundled into one file
+- `assetsInlineLimit: 50000` — assets under 50KB are base64-inlined
+- No CSP exceptions exist for external CDN scripts
+
+This means mermaid.js **must be bundled** into `webview.js` rather than loaded from a CDN. CDN loading would be blocked by the VS Code webview Content Security Policy.
+
+### Current Bundle Size
+~900KB (per CLAUDE.md invariant). mermaid.js is approximately 1.5–2.5MB minified (it includes Dagre, elkjs layouts, and D3). This will significantly increase bundle size.
+
+**Mitigation strategies:**
+1. Use `mermaid` with tree-shaking — import only what is needed
+2. `mermaid` v11 supports lazy-loading diagrams; only the core is needed upfront
+3. Use `mermaid/dist/mermaid.esm.min.mjs` (the ES module build) for better tree-shaking
+
+---
+
+## 4. How to Integrate mermaid.js Rendering
+
+### mermaid.js v11 API (current stable)
+
+```typescript
+import mermaid from 'mermaid'
+
+mermaid.initialize({ startOnLoad: false, theme: 'neutral' })
+
+// Render to SVG string
+const { svg } = await mermaid.render('diagram-id', diagramSource)
+```
+
+The `render()` function:
+- Is async
+- Returns `{ svg: string, bindFunctions?: (el: Element) => void }`
+- Throws on invalid syntax — must be caught
+
+### Integration in `CodeBlockWithCopy.tsx`
+
+```typescript
+// When language === 'mermaid':
+const [rendered, setRendered] = useState<string | null>(null)
+const [error, setError] = useState<string | null>(null)
+const [showCode, setShowCode] = useState(false)
+
+useEffect(() => {
+  if (node.attrs.language !== 'mermaid') return
+  mermaid.render('mermaid-' + uniqueId, node.textContent)
+    .then(({ svg }) => setRendered(svg))
+    .catch((err) => setError(err.message))
+}, [node.textContent, node.attrs.language])
+```
+
+### Theme Integration
+
+mermaid supports VS Code dark/light themes via its `theme` config:
+- `'dark'` for dark themes
+- `'neutral'` or `'default'` for light themes
+- `'base'` with custom `themeVariables` for full control
+
+The webview already uses VS Code CSS variables (e.g., `--vscode-editor-background`). mermaid's `themeVariables` can be configured to match.
+
+### Toggle (Code vs. Rendered)
+
+The existing `CodeBlockWithCopy` component can be enhanced with a toggle button (similar to the existing copy button). When in "code" mode, the `NodeViewContent` is shown normally. When in "rendered" mode, the SVG is shown and the `NodeViewContent` is hidden (but still present for editing).
+
+**Critical:** `NodeViewContent` must remain in the DOM (even if hidden via CSS) when the cursor is inside the block, otherwise TipTap loses the editable node reference.
+
+---
+
+## 5. Existing Mermaid-Related Code
+
+**None found.** `grep -r "mermaid"` across `extensions/ritemark/` returns no results. This is a greenfield addition.
+
+---
+
+## 6. Key Risks and Constraints
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Bundle size increase (~1.5–2.5MB) | Webview load time | Measure actual delta; mermaid ESM may tree-shake |
+| Mermaid `render()` ID collisions | Broken SVG output | Use stable unique IDs per node (ProseMirror node position or UUID) |
+| NodeViewContent must stay in DOM | Editing broken if hidden | Use CSS visibility/height:0, not `display:none` or conditional render |
+| VS Code webview CSP | Cannot load external mermaid CDN | Bundle with Vite (confirmed viable) |
+| Dark/light theme sync | Diagrams don't match editor theme | Read `document.body.classList` for `vscode-dark` class |
+| `mermaid.initialize()` called multiple times | Config errors | Call once at module load, not inside component |
+
+---
+
+## 7. Turndown Serialization for Mermaid Blocks
+
+Because we are using Option A (extending the existing NodeView, not a new node type), the ProseMirror node type remains `codeBlock` with `language: "mermaid"`. Turndown's default fenced code block rule will serialize this as:
+
+```
+```mermaid
+graph TD...
+```
+```
+
+No custom Turndown rule needed. The roundtrip is preserved.
+
+---
+
+## 8. Slash Command Addition
+
+A "Mermaid Diagram" entry in the slash command menu (`SlashCommands.tsx`) would insert a code block with `language: 'mermaid'` pre-filled. This uses the existing `setCodeBlock({ language: 'mermaid' })` command from CodeBlockLowlight.
+
+---
+
+## Summary
+
+The cleanest implementation path:
+
+1. Add `mermaid` npm dependency to `webview/package.json`
+2. Extend `CodeBlockWithCopy.tsx` to detect language `'mermaid'`, render SVG, handle toggle and errors
+3. Initialize mermaid once at module level with VS Code theme detection
+4. Add a "Mermaid Diagram" slash command entry
+5. Add CSS for the rendered diagram container and toggle button
+6. No new TipTap extension or Turndown rule required

--- a/docs/development/sprints/sprint-30-mermaid-diagrams/sprint-plan.md
+++ b/docs/development/sprints/sprint-30-mermaid-diagrams/sprint-plan.md
@@ -1,0 +1,97 @@
+# Sprint 30: Mermaid Diagram Rendering
+
+## Goal
+
+Render `mermaid` code blocks as visual SVG diagrams inline in the TipTap editor, with a toggle between rendered and source views and graceful error handling.
+
+## Feature Flag Check
+
+- [ ] Does this sprint need a feature flag?
+  - This is a new rendering feature that adds a significant bundle size (mermaid.js ~1.5–2.5MB). It is not platform-specific, premium, or experimental in behavior, but the large download size warrants a kill-switch in case it causes performance problems for users on slower machines.
+  - **Decision: No flag at launch.** The feature is pure UI enhancement with no network calls, no permissions, and no risk of data loss. The toggle (code vs. rendered) already provides user control. If bundle size causes regressions we can gate it retroactively via a flag. Document why: small behavioral scope, zero side effects, user-visible toggle built in.
+
+## Success Criteria
+
+- [ ] Opening a file with a ` ```mermaid ` code block shows a rendered SVG diagram, not raw text
+- [ ] A "Code" toggle button switches to editable source view and back to rendered view
+- [ ] Invalid mermaid syntax shows an error state with the raw code still visible (no crash)
+- [ ] Diagrams re-render when the source code changes (after switching back to code view and editing)
+- [ ] Theme matches the VS Code editor (dark/light)
+- [ ] A `/Mermaid Diagram` slash command inserts a pre-configured mermaid code block
+- [ ] Markdown roundtrip is preserved: save and reopen yields identical ` ```mermaid ` fenced block
+- [ ] Webview bundle builds without error (`vite build`)
+
+## Deliverables
+
+| Deliverable | Description |
+|-------------|-------------|
+| `mermaid` npm dependency | Added to `webview/package.json` |
+| Updated `CodeBlockWithCopy.tsx` | Detects `language === 'mermaid'`, renders SVG, handles toggle and errors |
+| Mermaid initializer | One-time `mermaid.initialize()` call with VS Code theme detection at module level |
+| Slash command entry | "Mermaid Diagram" in `SlashCommands.tsx` |
+| CSS styles | Diagram container, toggle button, error state |
+
+## Implementation Checklist
+
+### Phase 1: Dependency and Initialization
+- [ ] Add `mermaid` to `extensions/ritemark/webview/package.json` dependencies (use latest v11)
+- [ ] Run `npm install` in `extensions/ritemark/webview/`
+- [ ] Create `extensions/ritemark/webview/src/lib/mermaid.ts` — initialize mermaid once, export `renderMermaid(id, source)` helper
+  - Read `document.body.classList` for `vscode-dark` / `vscode-high-contrast` to pick `dark` or `neutral` theme
+  - Call `mermaid.initialize({ startOnLoad: false, theme })` once at module load
+
+### Phase 2: CodeBlockWithCopy Component Extension
+- [ ] Update `extensions/ritemark/webview/src/components/CodeBlockWithCopy.tsx`
+  - When `node.attrs.language === 'mermaid'`, render in "diagram mode" by default
+  - Add state: `showCode: boolean` (default `false` for mermaid blocks, irrelevant for others)
+  - Add state: `svgContent: string | null` and `renderError: string | null`
+  - `useEffect` watching `node.textContent` + `node.attrs.language`: call `renderMermaid()`, update states
+  - Use a unique stable ID per node: `'mermaid-' + useId()` (React 18 `useId` hook)
+  - When `showCode === false` (rendered view): show SVG container + hide `NodeViewContent` with CSS (`height: 0; overflow: hidden; position: absolute`), NOT `display: none`
+  - When `showCode === true` (code view): show `NodeViewContent` normally + hide SVG
+  - Error state: show error message box with raw code visible (fall back to code view)
+  - Toggle button: "Diagram" / "Code" label, positioned with existing copy button
+
+### Phase 3: Slash Command
+- [ ] Update `extensions/ritemark/webview/src/extensions/SlashCommands.tsx`
+  - Add a "Mermaid Diagram" entry with an appropriate icon (e.g., `GitBranch` from lucide-react)
+  - Command: `editor.chain().focus().deleteRange(range).setCodeBlock({ language: 'mermaid' }).run()`
+  - Insert a starter diagram template as text content after setting the block
+
+### Phase 4: Styles
+- [ ] Add CSS for `.mermaid-rendered-diagram` container (padding, border, rounded corners matching other blocks)
+- [ ] Add CSS for `.mermaid-toggle-btn` (consistent with existing `.code-copy-btn`)
+- [ ] Add CSS for `.mermaid-error` error state (red border, monospace error text)
+- [ ] Ensure SVG scales to container width (`svg { max-width: 100%; height: auto; }`)
+
+### Phase 5: Build Verification
+- [ ] Run `npm run build` in `extensions/ritemark/webview/` and confirm no errors
+- [ ] Note the new bundle size (expected to grow significantly due to mermaid.js)
+- [ ] Verify the bundle size does not exceed a sensible threshold (document final size)
+
+## Technical Constraints (from Research)
+
+- `NodeViewContent` MUST remain in the DOM even in rendered mode — use CSS to hide it, not conditional rendering or `display: none`. TipTap loses the editable node reference otherwise.
+- `mermaid.initialize()` must be called ONCE at module load, not inside the component render cycle.
+- `mermaid.render()` ID must be unique per block. React 18 `useId()` is the right tool.
+- mermaid.js cannot be loaded from CDN — VS Code webview CSP blocks external scripts. Must bundle via Vite.
+- No new TipTap extension or Turndown rule is needed — roundtrip works via existing fenced code block serialization.
+
+## Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Bundle size grows by ~1.5–2.5MB | Acceptable for this feature; document final size; revisit if load time regresses |
+| `mermaid.render()` ID collisions across multiple blocks | Use `useId()` which is unique per component instance |
+| NodeViewContent hidden incorrectly | Use `position: absolute; height: 0; overflow: hidden` not `display: none` |
+| Theme mismatch after system theme switch | Re-initialize on `vscode-dark` class change (stretch goal) |
+| Mermaid render errors crash component | Wrap `render()` in try/catch, show error UI |
+
+## Status
+
+**Current Phase:** 2 (PLAN)
+**Approval Required:** Yes — Jarmo must approve before Phase 3 (DEVELOP) begins
+
+## Approval
+
+- [ ] Jarmo approved this sprint plan

--- a/docs/development/sprints/sprint-46-mermaid-diagrams/notes/mermaid-smoke-test.md
+++ b/docs/development/sprints/sprint-46-mermaid-diagrams/notes/mermaid-smoke-test.md
@@ -1,0 +1,129 @@
+# Mermaid Smoke Test
+
+Open this file in Ritemark after `Developer: Reload Window`.
+
+## Expected Checks
+
+-   The first mermaid block should render as a diagram by default.
+    
+-   The `Code` button should switch to raw source and back to the diagram.
+    
+-   The `Copy` button should copy the mermaid source, not SVG.
+    
+-   The invalid mermaid block should show an error state and still allow source editing.
+    
+-   Saving and reopening should preserve the fenced `mermaid` blocks unchanged.
+    
+
+## Valid Diagram
+
+```mermaid
+flowchart TD
+  A[Start] --> B{Decision}
+  B -->|Yes| C[Render diagram]
+  B -->|No| D[Show source]
+  C --> E[Done]
+  D --> E
+```
+
+## Sequence Diagram
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant R as Ritemark
+  participant M as Mermaid
+
+  U->>R: Open markdown file
+  R->>M: Render mermaid block
+  M-->>R: SVG output
+  R-->>U: Show diagram
+```
+
+## Class Diagram
+
+```mermaid
+classDiagram
+  class Document {
+    +String title
+    +String status
+    +save()
+    +export()
+  }
+
+  class MermaidRenderer {
+    +render(source)
+    +toggleView()
+  }
+
+  Document --> MermaidRenderer : uses
+```
+
+## State Diagram
+
+```mermaid
+stateDiagram-v2
+  [*] --> Draft
+  Draft --> Review
+  Review --> Approved
+  Review --> Draft : changes requested
+  Approved --> Published
+  Published --> [*]
+```
+
+## Entity Relationship Diagram
+
+```mermaid
+erDiagram
+  CLIENT ||--o{ PROJECT : owns
+  PROJECT ||--|{ DOCUMENT : contains
+  DOCUMENT ||--o{ COMMENT : receives
+
+  CLIENT {
+    string name
+    string org
+  }
+
+  PROJECT {
+    string title
+    string status
+  }
+
+  DOCUMENT {
+    string title
+    string type
+  }
+```
+
+## Gantt Chart
+
+```mermaid
+gantt
+  title Sprint 46 Mermaid Test
+  dateFormat  YYYY-MM-DD
+  section Build
+  Install dependency     :done,    dep, 2026-03-20, 1d
+  Fix node view          :done,    ui,  2026-03-21, 1d
+  section QA
+  Smoke test diagrams    :active,  qa,  2026-03-22, 2d
+  Polish visuals         :         polish, after qa, 1d
+```
+
+## Pie Chart
+
+```mermaid
+pie title Feature Coverage
+  "Flowchart" : 30
+  "Sequence" : 20
+  "State" : 15
+  "ER" : 15
+  "Gantt" : 20
+```
+
+## Invalid Diagram
+
+```mermaid
+flowchart TD
+  A[Broken
+  B --> C
+```

--- a/docs/development/sprints/sprint-46-mermaid-diagrams/research/codebase-analysis.md
+++ b/docs/development/sprints/sprint-46-mermaid-diagrams/research/codebase-analysis.md
@@ -1,4 +1,4 @@
-# Sprint 30: Mermaid Diagrams — Research Findings
+# Sprint 46: Mermaid Diagrams — Research Findings
 
 ## 1. How Code Blocks Currently Work
 

--- a/docs/development/sprints/sprint-46-mermaid-diagrams/sprint-plan.md
+++ b/docs/development/sprints/sprint-46-mermaid-diagrams/sprint-plan.md
@@ -1,8 +1,8 @@
-# Sprint 30: Mermaid Diagram Rendering
+# Sprint 46: Mermaid Diagram Rendering
 
 ## Goal
 
-Render `mermaid` code blocks as visual SVG diagrams inline in the TipTap editor, with a toggle between rendered and source views and graceful error handling.
+Render `mermaid` code blocks as visual SVG diagrams inline in the TipTap editor, with a toggle between rendered and source views, graceful error handling, and export behavior that matches user expectations in Word/PDF.
 
 ## Feature Flag Check
 
@@ -19,6 +19,7 @@ Render `mermaid` code blocks as visual SVG diagrams inline in the TipTap editor,
 - [ ] Theme matches the VS Code editor (dark/light)
 - [ ] A `/Mermaid Diagram` slash command inserts a pre-configured mermaid code block
 - [ ] Markdown roundtrip is preserved: save and reopen yields identical ` ```mermaid ` fenced block
+- [ ] Export expectation is handled explicitly: either Mermaid diagrams render as diagrams in Word/PDF export, or the UI/export flow makes the limitation unambiguous before users assume parity
 - [ ] Webview bundle builds without error (`vite build`)
 
 ## Deliverables
@@ -30,6 +31,7 @@ Render `mermaid` code blocks as visual SVG diagrams inline in the TipTap editor,
 | Mermaid initializer | One-time `mermaid.initialize()` call with VS Code theme detection at module level |
 | Slash command entry | "Mermaid Diagram" in `SlashCommands.tsx` |
 | CSS styles | Diagram container, toggle button, error state |
+| Export decision | Mermaid behavior for Word/PDF is explicitly implemented or documented in-product |
 
 ## Implementation Checklist
 
@@ -69,6 +71,14 @@ Render `mermaid` code blocks as visual SVG diagrams inline in the TipTap editor,
 - [ ] Note the new bundle size (expected to grow significantly due to mermaid.js)
 - [ ] Verify the bundle size does not exceed a sensible threshold (document final size)
 
+### Phase 6: Export Parity / Expectation Management
+- [ ] Audit current Word/PDF export behavior for ` ```mermaid ` fenced blocks
+- [ ] Decide product behavior:
+  - [ ] Option A: export Mermaid as rendered diagram in Word/PDF
+  - [ ] Option B: keep source-code export for now, but add explicit user-facing limitation so preview does not imply export parity
+- [ ] If Option A: implement Mermaid rendering in export pipeline and verify Word/PDF outputs
+- [ ] If Option B: add a visible note in the relevant UI/export flow and document the limitation in release/sprint notes
+
 ## Technical Constraints (from Research)
 
 - `NodeViewContent` MUST remain in the DOM even in rendered mode — use CSS to hide it, not conditional rendering or `display: none`. TipTap loses the editable node reference otherwise.
@@ -86,12 +96,13 @@ Render `mermaid` code blocks as visual SVG diagrams inline in the TipTap editor,
 | NodeViewContent hidden incorrectly | Use `position: absolute; height: 0; overflow: hidden` not `display: none` |
 | Theme mismatch after system theme switch | Re-initialize on `vscode-dark` class change (stretch goal) |
 | Mermaid render errors crash component | Wrap `render()` in try/catch, show error UI |
+| Users assume editor preview means Word/PDF export parity | Treat export as in-scope decision, not a follow-up surprise |
 
 ## Status
 
-**Current Phase:** 2 (PLAN)
-**Approval Required:** Yes — Jarmo must approve before Phase 3 (DEVELOP) begins
+**Current Phase:** 6 (DEVELOP / VERIFY)
+**Approval Required:** No — implementation is in progress on the approved sprint branch
 
 ## Approval
 
-- [ ] Jarmo approved this sprint plan
+- [x] Jarmo approved this sprint plan

--- a/extensions/ritemark/src/export/v2/imageSource.test.ts
+++ b/extensions/ritemark/src/export/v2/imageSource.test.ts
@@ -1,0 +1,12 @@
+import assert from 'node:assert/strict'
+import { tryLoadImageSource } from './imageSource'
+
+function run() {
+  const documentUri = { fsPath: '/tmp/example.md' }
+  const buffer = tryLoadImageSource('data:image/png;base64,ZmFrZQ==', documentUri)
+
+  assert.ok(buffer)
+  assert.equal(buffer?.toString('utf8'), 'fake')
+}
+
+run()

--- a/extensions/ritemark/src/export/v2/imageSource.test.ts
+++ b/extensions/ritemark/src/export/v2/imageSource.test.ts
@@ -3,10 +3,23 @@ import { tryLoadImageSource } from './imageSource'
 
 function run() {
   const documentUri = { fsPath: '/tmp/example.md' }
-  const buffer = tryLoadImageSource('data:image/png;base64,ZmFrZQ==', documentUri)
 
+  // PNG data URL — accepted
+  const buffer = tryLoadImageSource('data:image/png;base64,ZmFrZQ==', documentUri)
   assert.ok(buffer)
   assert.equal(buffer?.toString('utf8'), 'fake')
+
+  // JPEG data URL — accepted
+  const jpegBuffer = tryLoadImageSource('data:image/jpeg;base64,ZmFrZQ==', documentUri)
+  assert.ok(jpegBuffer)
+
+  // SVG data URL — rejected (not raster, would crash pdfkit/docx)
+  const svgBuffer = tryLoadImageSource('data:image/svg+xml;base64,ZmFrZQ==', documentUri)
+  assert.equal(svgBuffer, null)
+
+  // WebP data URL — rejected
+  const webpBuffer = tryLoadImageSource('data:image/webp;base64,ZmFrZQ==', documentUri)
+  assert.equal(webpBuffer, null)
 }
 
 run()

--- a/extensions/ritemark/src/export/v2/imageSource.ts
+++ b/extensions/ritemark/src/export/v2/imageSource.ts
@@ -10,11 +10,12 @@ export function tryLoadImageSource(imagePath: string, documentUri: DocumentUriLi
     let normalizedPath = imagePath.trim();
 
     if (normalizedPath.startsWith('data:image/')) {
-      const match = normalizedPath.match(/^data:image\/[a-zA-Z0-9.+-]+;base64,(.+)$/);
+      // Only accept raster formats that pdfkit/docx can handle
+      const match = normalizedPath.match(/^data:image\/(png|jpeg|jpg|gif|bmp|tiff);base64,(.+)$/i);
       if (!match) {
         return null;
       }
-      return Buffer.from(match[1], 'base64');
+      return Buffer.from(match[2], 'base64');
     }
 
     if (normalizedPath.startsWith('vscode-file://')) normalizedPath = normalizedPath.replace('vscode-file://', '');

--- a/extensions/ritemark/src/export/v2/imageSource.ts
+++ b/extensions/ritemark/src/export/v2/imageSource.ts
@@ -1,0 +1,35 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface DocumentUriLike {
+  fsPath: string;
+}
+
+export function tryLoadImageSource(imagePath: string, documentUri: DocumentUriLike): Buffer | null {
+  try {
+    let normalizedPath = imagePath.trim();
+
+    if (normalizedPath.startsWith('data:image/')) {
+      const match = normalizedPath.match(/^data:image\/[a-zA-Z0-9.+-]+;base64,(.+)$/);
+      if (!match) {
+        return null;
+      }
+      return Buffer.from(match[1], 'base64');
+    }
+
+    if (normalizedPath.startsWith('vscode-file://')) normalizedPath = normalizedPath.replace('vscode-file://', '');
+    if (normalizedPath.startsWith('file://')) normalizedPath = normalizedPath.replace('file://', '');
+    if (normalizedPath.startsWith('http://') || normalizedPath.startsWith('https://')) return null;
+
+    const absolutePath = path.isAbsolute(normalizedPath)
+      ? normalizedPath
+      : path.resolve(path.dirname(documentUri.fsPath), normalizedPath);
+
+    if (!fs.existsSync(absolutePath)) {
+      return null;
+    }
+    return fs.readFileSync(absolutePath);
+  } catch {
+    return null;
+  }
+}

--- a/extensions/ritemark/src/export/v2/pdfHtmlExporter.ts
+++ b/extensions/ritemark/src/export/v2/pdfHtmlExporter.ts
@@ -4,6 +4,7 @@ import * as fs from 'fs';
 import PDFDocument from 'pdfkit';
 import { parse, HTMLElement, type Node as HtmlNode, TextNode } from 'node-html-parser';
 import { buildNormalizedExportHtml, type ExportTemplateStyle } from './htmlPipeline';
+import { tryLoadImageSource } from './imageSource';
 import type { ExportV2Request } from './types';
 
 const PAGE_MARGIN = 72;
@@ -36,26 +37,6 @@ function compactText(text: string): string {
 function getImmediateChildren(node: HTMLElement, tagNames: string[]): HTMLElement[] {
   const wanted = new Set(tagNames.map(tag => tag.toUpperCase()));
   return node.childNodes.filter(child => isElement(child) && wanted.has(child.tagName)) as HTMLElement[];
-}
-
-function tryLoadImage(imagePath: string, documentUri: vscode.Uri): Buffer | null {
-  try {
-    let normalizedPath = imagePath.trim();
-    if (normalizedPath.startsWith('vscode-file://')) normalizedPath = normalizedPath.replace('vscode-file://', '');
-    if (normalizedPath.startsWith('file://')) normalizedPath = normalizedPath.replace('file://', '');
-    if (normalizedPath.startsWith('http://') || normalizedPath.startsWith('https://')) return null;
-
-    const absolutePath = path.isAbsolute(normalizedPath)
-      ? normalizedPath
-      : path.resolve(path.dirname(documentUri.fsPath), normalizedPath);
-
-    if (!fs.existsSync(absolutePath)) {
-      return null;
-    }
-    return fs.readFileSync(absolutePath);
-  } catch {
-    return null;
-  }
 }
 
 function ensurePageRoom(doc: PDFKit.PDFDocument, minimumHeight: number): void {
@@ -199,7 +180,7 @@ function renderNode(doc: PDFKit.PDFDocument, node: HtmlNode, documentUri: vscode
   const tag = node.tagName;
   const text = compactText(getNodeText(node));
 
-  if (!text && tag !== 'HR' && tag !== 'IMG' && tag !== 'TABLE') return;
+  if (!text && tag !== 'HR' && tag !== 'IMG' && tag !== 'TABLE' && tag !== 'FIGURE') return;
 
   switch (tag) {
     case 'H1':
@@ -285,15 +266,18 @@ function renderNode(doc: PDFKit.PDFDocument, node: HtmlNode, documentUri: vscode
       const src = node.getAttribute('src');
       const imagePath = title || src;
       if (!imagePath) return;
-      const imgBuffer = tryLoadImage(imagePath, documentUri);
+      const imgBuffer = tryLoadImageSource(imagePath, documentUri);
       if (!imgBuffer) return;
 
-      const maxWidth = doc.page.width - PAGE_MARGIN * 2;
-      const maxHeight = 400;
+      const usableWidth = doc.page.width - PAGE_MARGIN * 2;
+      const usableHeight = doc.page.height - PAGE_MARGIN * 2 - RESERVED_FOOTER_SPACE;
+      // Cap images to ~50% of page height so they don't dominate the layout.
+      // Wide/landscape images get full width; tall/portrait images get constrained.
+      const maxHeight = Math.min(usableHeight * 0.55, 400);
       // Get actual image dimensions for proper scaling
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const pdfImage = (doc as any).openImage(imgBuffer);
-      const scale = Math.min(maxWidth / pdfImage.width, maxHeight / pdfImage.height, 1);
+      const scale = Math.min(usableWidth / pdfImage.width, maxHeight / pdfImage.height, 1);
       const renderWidth = pdfImage.width * scale;
       const renderHeight = pdfImage.height * scale;
 

--- a/extensions/ritemark/src/export/v2/wordHtmlExporter.ts
+++ b/extensions/ritemark/src/export/v2/wordHtmlExporter.ts
@@ -19,29 +19,10 @@ import {
 } from 'docx';
 import { parse, HTMLElement, type Node as HtmlNode, TextNode } from 'node-html-parser';
 import { buildNormalizedExportHtml, type ExportTemplateStyle } from './htmlPipeline';
+import { tryLoadImageSource } from './imageSource';
 import type { ExportV2Request } from './types';
 
 type DocChild = Paragraph | Table;
-
-function tryLoadImage(imagePath: string, documentUri: vscode.Uri): Buffer | null {
-  try {
-    let normalizedPath = imagePath.trim();
-    if (normalizedPath.startsWith('vscode-file://')) normalizedPath = normalizedPath.replace('vscode-file://', '');
-    if (normalizedPath.startsWith('file://')) normalizedPath = normalizedPath.replace('file://', '');
-    if (normalizedPath.startsWith('http://') || normalizedPath.startsWith('https://')) return null;
-
-    const absolutePath = path.isAbsolute(normalizedPath)
-      ? normalizedPath
-      : path.resolve(path.dirname(documentUri.fsPath), normalizedPath);
-
-    if (!fs.existsSync(absolutePath)) {
-      return null;
-    }
-    return fs.readFileSync(absolutePath);
-  } catch {
-    return null;
-  }
-}
 
 function getImageDimensions(data: Buffer): { width: number; height: number } | null {
   try {
@@ -279,17 +260,24 @@ function parseBlocks(node: HtmlNode, style: ExportTemplateStyle, documentUri: vs
       const src = node.getAttribute('src');
       const imagePath = title || src;
       if (!imagePath) return [];
-      const imgData = tryLoadImage(imagePath, documentUri);
+      const imgData = tryLoadImageSource(imagePath, documentUri);
       if (!imgData) return [];
 
       const dims = getImageDimensions(imgData);
-      const maxWidth = 580; // ~6 inches at 96 DPI
-      let imgWidth = dims?.width || 580;
+      // docx library converts pixels to EMU via: px * 9525
+      // A4 usable width: 8.27" - 2*1" margins = 6.27" ≈ 602px at 96 DPI
+      // Letter usable width: 8.5" - 2*1" margins = 6.5" ≈ 624px at 96 DPI
+      // Use 600px as safe max that fits both page sizes
+      const maxWidth = 600;
+      // Cap height to ~50% of page so diagrams don't dominate layout
+      // Letter: 11" - 2*1" margins = 9" usable, 55% ≈ 5" ≈ 480px at 96 DPI
+      const maxHeight = 480;
+      let imgWidth = dims?.width || maxWidth;
       let imgHeight = dims?.height || 400;
-      if (imgWidth > maxWidth) {
-        const scale = maxWidth / imgWidth;
-        imgHeight = Math.round(imgHeight * scale);
-        imgWidth = maxWidth;
+      const scaleFactor = Math.min(maxWidth / imgWidth, maxHeight / imgHeight, 1);
+      if (scaleFactor < 1) {
+        imgWidth = Math.round(imgWidth * scaleFactor);
+        imgHeight = Math.round(imgHeight * scaleFactor);
       }
 
       return [new Paragraph({

--- a/extensions/ritemark/src/ritemarkEditor.ts
+++ b/extensions/ritemark/src/ritemarkEditor.ts
@@ -938,7 +938,7 @@ export class RitemarkEditorProvider implements vscode.CustomTextEditorProvider {
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}' ${webview.cspSource}; font-src ${webview.cspSource} data:; img-src ${webview.cspSource} data:;">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src ${webview.cspSource} 'unsafe-inline'; script-src 'nonce-${nonce}' ${webview.cspSource}; font-src ${webview.cspSource} data:; img-src ${webview.cspSource} data: blob:;">
   <title>Ritemark</title>
   <style>
     * {

--- a/extensions/ritemark/webview/package-lock.json
+++ b/extensions/ritemark/webview/package-lock.json
@@ -51,6 +51,7 @@
         "lowlight": "^3.1.0",
         "lucide-react": "^0.294.0",
         "marked": "^9.1.0",
+        "mermaid": "^11.13.0",
         "papaparse": "^5.5.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -89,6 +90,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
@@ -120,7 +134,6 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -371,6 +384,51 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-11.1.2.tgz",
+      "integrity": "sha512-XTsjvDVB5nDZBQB8o0o/0ozNelQtn2KrUVteIHSlPd2VAV2utEb6JzyCJaJ8tGxACR4RiBNWy5uYUHX2eji88Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "11.1.2",
+        "@chevrotain/types": "11.1.2",
+        "lodash-es": "4.17.23"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-11.1.2.tgz",
+      "integrity": "sha512-Z9zfXR5jNZb1Hlsd/p+4XWeUFugrHirq36bKzPWDSIacV+GPSVXdk+ahVWZTwjhNwofAWg/sZg58fyucKSQx5g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "11.1.2",
+        "lodash-es": "4.17.23"
+      }
+    },
+    "node_modules/@chevrotain/regexp-to-ast": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-11.1.2.tgz",
+      "integrity": "sha512-nMU3Uj8naWer7xpZTYJdxbAs6RIv/dxYzkYU8GSwgUtcAAlzjcPfX1w+RKRcYG8POlzMeayOQ/znfwxEGo5ulw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-11.1.2.tgz",
+      "integrity": "sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-11.1.2.tgz",
+      "integrity": "sha512-4mudFAQ6H+MqBTfqLmU7G1ZwRzCLfJEooL/fsF6rCX5eePMbGhoy5n4g+G4vlh2muDcsCTJtL+uKbOzWxs5LHA==",
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",
@@ -801,6 +859,23 @@
       "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==",
       "license": "MIT"
     },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
+      "integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "mlly": "^1.8.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.3.13",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
@@ -849,6 +924,15 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.0.1.tgz",
+      "integrity": "sha512-opmV19kN1JsK0T6HhhokHpcVkqKpF+x2pPDKKM2ThHtZAB5F4PROopk0amuVYK5qMrIA4erzpNm8gmPNJgMDxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "langium": "^4.0.0"
       }
     },
     "node_modules/@mixmark-io/domino": {
@@ -2781,7 +2865,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-2.27.2.tgz",
       "integrity": "sha512-ABL1N6eoxzDzC1bYvkMbvyexHacszsKdVPYqhl5GwHLOvpZcv9VE9QaKwDILTyz5voCA0lGcAAXZp+qnXOk5lQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -2864,7 +2947,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/extension-code-block/-/extension-code-block-2.27.2.tgz",
       "integrity": "sha512-KgvdQHS4jXr79aU3wZOGBIZYYl9vCB7uDEuRFV4so2rYrfmiYMw3T8bTnlNEEGe4RUeAms1i4fdwwvQp9nR1Dw==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/ueberdosis"
@@ -3223,7 +3305,6 @@
       "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-2.27.2.tgz",
       "integrity": "sha512-kaEg7BfiJPDQMKbjVIzEPO3wlcA+pZb2tlcK9gPrdDnEFaec2QTF1sXz2ak2IIb2curvnIrQ4yrfHgLlVA72wA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-changeset": "^2.3.0",
         "prosemirror-collab": "^1.3.1",
@@ -3364,10 +3445,100 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-color": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
       "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
       "license": "MIT"
     },
     "node_modules/@types/d3-drag": {
@@ -3379,6 +3550,54 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
@@ -3388,10 +3607,76 @@
         "@types/d3-color": "*"
       }
     },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/d3-selection": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
       "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
       "license": "MIT"
     },
     "node_modules/@types/d3-transition": {
@@ -3418,6 +3703,12 @@
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
       "license": "MIT"
     },
     "node_modules/@types/hast": {
@@ -3482,7 +3773,6 @@
       "integrity": "sha512-z9VXpC7MWrhfWipitjNdgCauoMLRdIILQsAEV+ZesIzBq/oUlxk0m3ApZuMFCXdnS4U7KrI+l3WRUEGQ8K1QKw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "csstype": "^3.2.2"
@@ -3494,10 +3784,16 @@
       "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@types/turndown": {
       "version": "5.0.6",
@@ -3517,6 +3813,16 @@
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
       "license": "MIT"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
@@ -3597,6 +3903,18 @@
         "d3-interpolate": "^3.0.1",
         "d3-selection": "^3.0.0",
         "d3-zoom": "^3.0.0"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/adler-32": {
@@ -3747,7 +4065,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -3804,6 +4121,32 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/chevrotain": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-11.1.2.tgz",
+      "integrity": "sha512-opLQzEVriiH1uUQ4Kctsd49bRoFDXGGSC4GUqj7pGyxM3RehRhvTlZJc1FL/Flew2p5uwxa1tUDWKzI4wNM8pg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "11.1.2",
+        "@chevrotain/gast": "11.1.2",
+        "@chevrotain/regexp-to-ast": "11.1.2",
+        "@chevrotain/types": "11.1.2",
+        "@chevrotain/utils": "11.1.2",
+        "lodash-es": "4.17.23"
+      }
+    },
+    "node_modules/chevrotain-allstar": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.3.1.tgz",
+      "integrity": "sha512-b7g+y9A0v4mxCW1qUhf3BSVPg+/NvGErk/dOkrDaHA0nQIQGAtrOjlX//9OQtRlSCy+x9rfB5N8yC71lH1nvMw==",
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.17.21"
+      },
+      "peerDependencies": {
+        "chevrotain": "^11.0.0"
       }
     },
     "node_modules/chokidar": {
@@ -3890,6 +4233,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "license": "MIT"
+    },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
@@ -3902,6 +4251,15 @@
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "license": "MIT"
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
     },
     "node_modules/crc-32": {
       "version": "1.2.2",
@@ -3941,11 +4299,173 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/cytoscape": {
+      "version": "3.33.1",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.1.tgz",
+      "integrity": "sha512-iJc4TwyANnOGR1OmWhsS9ayRS3s+XQ185FmuHObThD+5AeJCakAAbWv8KimMTt08xCCLNgneQwFp+JRJOr9qGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-color": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
       "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
       "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -3972,11 +4492,101 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/d3-ease": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
       "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
       "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "license": "ISC",
       "engines": {
         "node": ">=12"
       }
@@ -3993,12 +4603,152 @@
         "node": ">=12"
       }
     },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
       "engines": {
         "node": ">=12"
       }
@@ -4047,6 +4797,22 @@
         "node": ">=12"
       }
     },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -4063,6 +4829,15 @@
         "supports-color": {
           "optional": true
         }
+      }
+    },
+    "node_modules/delaunator": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.0.1.tgz",
+      "integrity": "sha512-8nvh+XBe96aCESrGOqMp/84b13H9cdKbG5P2ejQCh4d4sK9RL4371qou9drQjMhvnPmhWl5hnmqbEE0fXr9Xnw==",
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
       }
     },
     "node_modules/dequal": {
@@ -4114,6 +4889,15 @@
       "license": "Apache-2.0",
       "dependencies": {
         "jszip": ">=3.0.0"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
+      "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -4341,6 +5125,12 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "license": "MIT"
+    },
     "node_modules/hasown": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
@@ -4359,9 +5149,20 @@
       "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.11.1.tgz",
       "integrity": "sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==",
       "license": "BSD-3-Clause",
-      "peer": true,
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/immediate": {
@@ -4375,6 +5176,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
@@ -4450,7 +5260,6 @@
       "integrity": "sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "jiti": "bin/jiti.js"
       }
@@ -4499,6 +5308,59 @@
         "setimmediate": "^1.0.5"
       }
     },
+    "node_modules/katex": {
+      "version": "0.16.38",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.38.tgz",
+      "integrity": "sha512-cjHooZUmIAUmDsHBN+1n8LaZdpmbj03LtYeYPyuYB7OuloiaeaV6N4LcfjcnHVzGWjVQmKrxxTrpDcmSzEZQwQ==",
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw=="
+    },
+    "node_modules/langium": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.1.tgz",
+      "integrity": "sha512-zu9QWmjpzJcomzdJQAHgDVhLGq5bLosVak1KVa40NzQHXfqr4eAHupvnPOVXEoLkg6Ocefvf/93d//SB7du4YQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chevrotain": "~11.1.1",
+        "chevrotain-allstar": "~0.3.1",
+        "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-textdocument": "~1.0.11",
+        "vscode-uri": "~3.1.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "license": "MIT"
+    },
     "node_modules/lie": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/lie/-/lie-3.3.0.tgz",
@@ -4543,6 +5405,12 @@
       "integrity": "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==",
       "license": "MIT"
     },
+    "node_modules/lodash-es": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
+      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "license": "MIT"
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -4560,7 +5428,6 @@
       "resolved": "https://registry.npmjs.org/lowlight/-/lowlight-3.3.0.tgz",
       "integrity": "sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/hast": "^3.0.0",
         "devlop": "^1.0.0",
@@ -4670,6 +5537,47 @@
         "node": ">= 8"
       }
     },
+    "node_modules/mermaid": {
+      "version": "11.13.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.13.0.tgz",
+      "integrity": "sha512-fEnci+Immw6lKMFI8sqzjlATTyjLkRa6axrEgLV2yHTfv8r+h1wjFbV6xeRtd4rUV1cS4EpR9rwp3Rci7TRWDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.0.1",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "lodash-es": "^4.17.23",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0"
+      }
+    },
+    "node_modules/mermaid/node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -4682,6 +5590,18 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mlly": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.1.tgz",
+      "integrity": "sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
       }
     },
     "node_modules/ms": {
@@ -4765,6 +5685,12 @@
       "integrity": "sha512-TvAWxi0nDe1j/rtMcWcIj94+Ffe6n7zhow33h40SKxmsmozs6dz/e+EajymfoFcHd7sxNn8yHM8839uixMOV6g==",
       "license": "MIT"
     },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "license": "MIT"
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -4777,11 +5703,23 @@
       "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
       "license": "MIT"
     },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "license": "MIT"
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "license": "MIT"
     },
     "node_modules/pdfjs-dist": {
@@ -4836,6 +5774,33 @@
         "node": ">= 6"
       }
     },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
+      }
+    },
     "node_modules/postcss": {
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
@@ -4856,7 +5821,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -5118,7 +6082,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
       "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "orderedmap": "^2.0.0"
       }
@@ -5148,7 +6111,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
       "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.0.0",
         "prosemirror-transform": "^1.0.0",
@@ -5197,7 +6159,6 @@
       "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.6.tgz",
       "integrity": "sha512-mxpcDG4hNQa/CPtzxjdlir5bJFDlm0/x5nGBbStB2BWX+XOQ9M8ekEG+ojqB5BcVu2Rc80/jssCMZzSstJuSYg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "prosemirror-model": "^1.20.0",
         "prosemirror-state": "^1.0.0",
@@ -5239,7 +6200,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
       "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
       },
@@ -5252,7 +6212,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.2"
@@ -5439,6 +6398,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/robust-predicates": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.2.tgz",
+      "integrity": "sha512-IXgzBWvWQwE6PrDI05OvmXUIruQTcoMDzRsOd5CDvHCVLcLHMTSYvOK5Cm46kWqlV3yAbuSpBZdJ5oP5OUoStg==",
+      "license": "Unlicense"
+    },
     "node_modules/rollup": {
       "version": "4.57.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.57.1.tgz",
@@ -5490,6 +6455,18 @@
       "integrity": "sha512-UT5EDe2cu2E/6O4igUr5PSFs23nvvukicWHx6GnOPlHAiiYbzNuCRQCuiUdHJQcqKalLKlrYJnjY0ySGsXNQXQ==",
       "license": "MIT"
     },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -5514,10 +6491,22 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
     "node_modules/scheduler": {
@@ -5575,6 +6564,12 @@
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT"
     },
     "node_modules/sucrase": {
       "version": "3.35.1",
@@ -5689,6 +6684,15 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -5730,7 +6734,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5770,6 +6773,15 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -5818,6 +6830,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
       "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
       "license": "MIT"
     },
     "node_modules/undici-types": {
@@ -5915,13 +6933,25 @@
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
     },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
     "node_modules/vite": {
       "version": "5.4.21",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
       "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.21.3",
         "postcss": "^8.4.43",
@@ -5975,6 +7005,55 @@
           "optional": true
         }
       }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "license": "MIT"
     },
     "node_modules/w3c-keyname": {
       "version": "2.2.8",

--- a/extensions/ritemark/webview/package.json
+++ b/extensions/ritemark/webview/package.json
@@ -53,6 +53,7 @@
     "lowlight": "^3.1.0",
     "lucide-react": "^0.294.0",
     "marked": "^9.1.0",
+    "mermaid": "^11.13.0",
     "papaparse": "^5.5.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/extensions/ritemark/webview/src/App.tsx
+++ b/extensions/ritemark/webview/src/App.tsx
@@ -5,6 +5,7 @@ import { SpreadsheetViewer } from './components/SpreadsheetViewer'
 import { PDFViewer } from './components/viewers/PDFViewer'
 import { DOCXViewer } from './components/viewers/DOCXViewer'
 import { DocumentHeader, PropertiesModal, ExportMenu } from './components/header'
+import { inlineMermaidDiagramsForExport } from './lib/mermaidExport'
 import { marked } from 'marked'
 import type { EditorSelection } from './types/editor'
 import type { Editor as TipTapEditor } from '@tiptap/react'
@@ -320,8 +321,9 @@ function App() {
   }, [])
 
   // Export handlers
-  const handleExportPDF = useCallback((templateId = 'default') => {
-    const html = editorRef.current ? preprocessTableHTML(editorRef.current.getHTML()) : ''
+  const handleExportPDF = useCallback(async (templateId = 'default') => {
+    const rawHtml = editorRef.current ? preprocessTableHTML(editorRef.current.getHTML()) : ''
+    const html = await inlineMermaidDiagramsForExport(rawHtml)
 
     sendToExtension('exportPDF', {
       content, // markdown fallback (V1 compatibility)
@@ -331,8 +333,9 @@ function App() {
     })
   }, [content, properties])
 
-  const handleExportWord = useCallback((templateId = 'default') => {
-    const html = editorRef.current ? preprocessTableHTML(editorRef.current.getHTML()) : ''
+  const handleExportWord = useCallback(async (templateId = 'default') => {
+    const rawHtml = editorRef.current ? preprocessTableHTML(editorRef.current.getHTML()) : ''
+    const html = await inlineMermaidDiagramsForExport(rawHtml)
 
     sendToExtension('exportWord', {
       markdown: content, // markdown fallback (V1 compatibility)

--- a/extensions/ritemark/webview/src/components/CodeBlockWithCopy.tsx
+++ b/extensions/ritemark/webview/src/components/CodeBlockWithCopy.tsx
@@ -5,7 +5,7 @@
  * For mermaid code blocks, renders the diagram as SVG with a code/diagram toggle.
  *
  * @see Sprint 14: Block Interactions
- * @see Sprint 30: Mermaid Diagram Rendering
+ * @see Sprint 46: Mermaid Diagram Rendering
  */
 
 import { NodeViewWrapper, NodeViewContent } from '@tiptap/react'
@@ -87,7 +87,7 @@ export function CodeBlockWithCopy({ node }: CodeBlockWithCopyProps) {
     return (
       <NodeViewWrapper
         as="pre"
-        className="tiptap-code-block mermaid-block"
+        className={`tiptap-code-block mermaid-block ${showDiagram ? 'mermaid-block--diagram' : 'mermaid-block--code'}`}
         style={{ position: 'relative' }}
       >
         {/* Toolbar buttons */}

--- a/extensions/ritemark/webview/src/components/CodeBlockWithCopy.tsx
+++ b/extensions/ritemark/webview/src/components/CodeBlockWithCopy.tsx
@@ -2,14 +2,16 @@
  * CodeBlockWithCopy Component
  *
  * Custom React NodeView for TipTap code blocks that adds a copy button.
- * Shows "Copied!" text feedback after copying.
+ * For mermaid code blocks, renders the diagram as SVG with a code/diagram toggle.
  *
  * @see Sprint 14: Block Interactions
+ * @see Sprint 30: Mermaid Diagram Rendering
  */
 
 import { NodeViewWrapper, NodeViewContent } from '@tiptap/react'
-import { useState, useCallback } from 'react'
-import { Copy, Check } from 'lucide-react'
+import { useState, useCallback, useEffect, useId, useRef } from 'react'
+import { Copy, Check, Code, Eye } from 'lucide-react'
+import { renderMermaid } from '../lib/mermaid'
 
 interface CodeBlockWithCopyProps {
   node: {
@@ -22,6 +24,44 @@ interface CodeBlockWithCopyProps {
 
 export function CodeBlockWithCopy({ node }: CodeBlockWithCopyProps) {
   const [copied, setCopied] = useState(false)
+  const isMermaid = node.attrs.language === 'mermaid'
+
+  // Mermaid rendering state
+  const [showCode, setShowCode] = useState(false)
+  const [svgContent, setSvgContent] = useState<string | null>(null)
+  const [renderError, setRenderError] = useState<string | null>(null)
+  const uniqueId = useId()
+  const diagramRef = useRef<HTMLDivElement>(null)
+
+  // Render mermaid diagram when content changes
+  useEffect(() => {
+    if (!isMermaid) return
+    if (!node.textContent.trim()) {
+      setSvgContent(null)
+      setRenderError(null)
+      return
+    }
+
+    let cancelled = false
+    // Clean ID for mermaid (no colons allowed)
+    const cleanId = 'mermaid-' + uniqueId.replace(/:/g, '-')
+
+    renderMermaid(cleanId, node.textContent)
+      .then((svg) => {
+        if (!cancelled) {
+          setSvgContent(svg)
+          setRenderError(null)
+        }
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setSvgContent(null)
+          setRenderError(err?.message || 'Failed to render diagram')
+        }
+      })
+
+    return () => { cancelled = true }
+  }, [node.textContent, isMermaid, uniqueId])
 
   const handleCopy = useCallback(async () => {
     const text = node.textContent
@@ -36,6 +76,97 @@ export function CodeBlockWithCopy({ node }: CodeBlockWithCopyProps) {
     }
   }, [node.textContent])
 
+  const toggleView = useCallback(() => {
+    setShowCode((prev) => !prev)
+  }, [])
+
+  // For mermaid blocks: show diagram or code
+  if (isMermaid) {
+    const showDiagram = !showCode && svgContent && !renderError
+
+    return (
+      <NodeViewWrapper
+        as="pre"
+        className="tiptap-code-block mermaid-block"
+        style={{ position: 'relative' }}
+      >
+        {/* Toolbar buttons */}
+        <div className="mermaid-toolbar">
+          <button
+            type="button"
+            onClick={toggleView}
+            onMouseDown={(e) => e.preventDefault()}
+            className="code-copy-btn mermaid-toggle-btn"
+            title={showCode ? 'Show diagram' : 'Show code'}
+            aria-label={showCode ? 'Show diagram' : 'Show code'}
+          >
+            {showCode ? (
+              <>
+                <Eye size={14} />
+                <span>Diagram</span>
+              </>
+            ) : (
+              <>
+                <Code size={14} />
+                <span>Code</span>
+              </>
+            )}
+          </button>
+          <button
+            type="button"
+            onClick={handleCopy}
+            onMouseDown={(e) => e.preventDefault()}
+            className={`code-copy-btn ${copied ? 'copied' : ''}`}
+            title={copied ? 'Copied!' : 'Copy code'}
+            aria-label={copied ? 'Copied!' : 'Copy code'}
+          >
+            {copied ? (
+              <>
+                <Check size={14} />
+                <span>Copied!</span>
+              </>
+            ) : (
+              <>
+                <Copy size={14} />
+                <span>Copy</span>
+              </>
+            )}
+          </button>
+        </div>
+
+        {/* Rendered diagram */}
+        {showDiagram && (
+          <div
+            ref={diagramRef}
+            className="mermaid-rendered-diagram"
+            dangerouslySetInnerHTML={{ __html: svgContent }}
+          />
+        )}
+
+        {/* Error message */}
+        {renderError && !showCode && (
+          <div className="mermaid-error">
+            <span>Diagram error: {renderError}</span>
+          </div>
+        )}
+
+        {/* Code content - always in DOM, hidden via CSS when showing diagram */}
+        <div
+          style={showDiagram ? {
+            position: 'absolute',
+            height: 0,
+            overflow: 'hidden',
+            opacity: 0,
+            pointerEvents: 'none',
+          } : undefined}
+        >
+          <NodeViewContent as="code" />
+        </div>
+      </NodeViewWrapper>
+    )
+  }
+
+  // Non-mermaid code blocks: original behavior
   return (
     <NodeViewWrapper
       as="pre"
@@ -45,7 +176,7 @@ export function CodeBlockWithCopy({ node }: CodeBlockWithCopyProps) {
       <button
         type="button"
         onClick={handleCopy}
-        onMouseDown={(e) => e.preventDefault()} // Prevent editor focus loss
+        onMouseDown={(e) => e.preventDefault()}
         className={`code-copy-btn ${copied ? 'copied' : ''}`}
         title={copied ? 'Copied!' : 'Copy code'}
         aria-label={copied ? 'Copied!' : 'Copy code'}

--- a/extensions/ritemark/webview/src/components/Editor.tsx
+++ b/extensions/ritemark/webview/src/components/Editor.tsx
@@ -1245,6 +1245,56 @@ export function Editor({
           opacity: 1 !important;
         }
 
+        /* Mermaid diagram styles */
+        .wysiwyg-editor .ProseMirror pre.tiptap-code-block.mermaid-block {
+          background: var(--vscode-editor-background, #1e1e1e) !important;
+          border: 1px solid var(--vscode-panel-border, rgba(255, 255, 255, 0.1)) !important;
+          border-radius: 6px !important;
+          padding-top: 36px !important;
+        }
+
+        .wysiwyg-editor .ProseMirror pre.tiptap-code-block .mermaid-toolbar {
+          position: absolute !important;
+          top: 8px !important;
+          right: 8px !important;
+          display: flex !important;
+          gap: 4px !important;
+          z-index: 10 !important;
+          opacity: 0 !important;
+          transition: opacity 0.2s !important;
+        }
+
+        .wysiwyg-editor .ProseMirror pre.tiptap-code-block.mermaid-block:hover .mermaid-toolbar {
+          opacity: 1 !important;
+        }
+
+        .wysiwyg-editor .ProseMirror pre.tiptap-code-block .mermaid-toggle-btn {
+          opacity: 1 !important;
+        }
+
+        .wysiwyg-editor .ProseMirror .mermaid-rendered-diagram {
+          display: flex !important;
+          justify-content: center !important;
+          padding: 16px !important;
+          min-height: 60px !important;
+        }
+
+        .wysiwyg-editor .ProseMirror .mermaid-rendered-diagram svg {
+          max-width: 100% !important;
+          height: auto !important;
+        }
+
+        .wysiwyg-editor .ProseMirror .mermaid-error {
+          padding: 12px 16px !important;
+          color: #f87171 !important;
+          font-size: 13px !important;
+          font-family: var(--vscode-editor-font-family, monospace) !important;
+          border: 1px solid rgba(248, 113, 113, 0.3) !important;
+          border-radius: 4px !important;
+          margin: 8px 16px !important;
+          background: rgba(248, 113, 113, 0.05) !important;
+        }
+
         /* Enhanced mobile selection */
         @media (max-width: 768px) {
           div.wysiwyg-editor .ProseMirror.ProseMirror ::selection {

--- a/extensions/ritemark/webview/src/components/Editor.tsx
+++ b/extensions/ritemark/webview/src/components/Editor.tsx
@@ -1247,10 +1247,13 @@ export function Editor({
 
         /* Mermaid diagram styles */
         .wysiwyg-editor .ProseMirror pre.tiptap-code-block.mermaid-block {
-          background: var(--vscode-editor-background, #1e1e1e) !important;
-          border: 1px solid var(--vscode-panel-border, rgba(255, 255, 255, 0.1)) !important;
-          border-radius: 6px !important;
           padding-top: 36px !important;
+        }
+
+        .wysiwyg-editor .ProseMirror pre.tiptap-code-block.mermaid-block.mermaid-block--diagram {
+          background: #f5f7fb !important;
+          border: 1px solid var(--vscode-panel-border, rgba(0, 0, 0, 0.12)) !important;
+          color: var(--vscode-editor-foreground, #111827) !important;
         }
 
         .wysiwyg-editor .ProseMirror pre.tiptap-code-block .mermaid-toolbar {
@@ -1268,20 +1271,52 @@ export function Editor({
           opacity: 1 !important;
         }
 
+        .wysiwyg-editor .ProseMirror pre.tiptap-code-block .mermaid-toolbar .code-copy-btn {
+          position: static !important;
+          top: auto !important;
+          right: auto !important;
+          opacity: 1 !important;
+        }
+
         .wysiwyg-editor .ProseMirror pre.tiptap-code-block .mermaid-toggle-btn {
           opacity: 1 !important;
+        }
+
+        .wysiwyg-editor .ProseMirror pre.tiptap-code-block.mermaid-block.mermaid-block--diagram .mermaid-toolbar .code-copy-btn {
+          background: rgba(255, 255, 255, 0.9) !important;
+          border: 1px solid rgba(100, 116, 139, 0.24) !important;
+          color: #64748b !important;
+          box-shadow: 0 1px 2px rgba(15, 23, 42, 0.06) !important;
+        }
+
+        .wysiwyg-editor .ProseMirror pre.tiptap-code-block.mermaid-block.mermaid-block--diagram .mermaid-toolbar .code-copy-btn:hover {
+          background: rgba(255, 255, 255, 1) !important;
+          color: #334155 !important;
+          border-color: rgba(67, 56, 202, 0.28) !important;
+        }
+
+        .wysiwyg-editor .ProseMirror pre.tiptap-code-block.mermaid-block.mermaid-block--diagram .mermaid-toolbar .code-copy-btn:active {
+          background: rgba(238, 242, 255, 1) !important;
         }
 
         .wysiwyg-editor .ProseMirror .mermaid-rendered-diagram {
           display: flex !important;
           justify-content: center !important;
+          align-items: flex-start !important;
           padding: 16px !important;
           min-height: 60px !important;
+          max-height: 1024px !important;
+          overflow: auto !important;
+          background: #f5f7fb !important;
+          border-radius: 12px !important;
         }
 
         .wysiwyg-editor .ProseMirror .mermaid-rendered-diagram svg {
           max-width: 100% !important;
+          width: min(100%, 680px) !important;
+          max-height: calc(1024px - 32px) !important;
           height: auto !important;
+          flex-shrink: 0 !important;
         }
 
         .wysiwyg-editor .ProseMirror .mermaid-error {

--- a/extensions/ritemark/webview/src/extensions/SlashCommands.tsx
+++ b/extensions/ritemark/webview/src/extensions/SlashCommands.tsx
@@ -4,7 +4,7 @@ import Suggestion from '@tiptap/suggestion'
 import tippy from 'tippy.js'
 import type { ComponentType } from 'react'
 import { CommandsList } from './CommandsList'
-import { Heading1, Heading2, Heading3, List, ListOrdered, Code, Table, Image, CheckSquare, Quote } from 'lucide-react'
+import { Heading1, Heading2, Heading3, List, ListOrdered, Code, Table, Image, CheckSquare, Quote, GitBranch } from 'lucide-react'
 import { sendToExtension, emitInternalEvent } from '../bridge'
 
 export interface Command {
@@ -149,6 +149,19 @@ export const SlashCommands = Extension.create({
                   .focus()
                   .deleteRange(range)
                   .insertTable({ rows: 3, cols: 3, withHeaderRow: true })
+                  .run()
+              },
+            },
+            {
+              title: 'Mermaid Diagram',
+              description: 'Insert a mermaid diagram',
+              icon: GitBranch,
+              command: ({ editor, range }: any) => {
+                editor
+                  .chain()
+                  .focus()
+                  .deleteRange(range)
+                  .setCodeBlock({ language: 'mermaid' })
                   .run()
               },
             },

--- a/extensions/ritemark/webview/src/lib/mermaid.ts
+++ b/extensions/ritemark/webview/src/lib/mermaid.ts
@@ -2,7 +2,7 @@
  * Mermaid diagram rendering helper.
  * Lazily initializes mermaid on first use and exports a render function.
  *
- * @see Sprint 30: Mermaid Diagram Rendering
+ * @see Sprint 46: Mermaid Diagram Rendering
  */
 
 let mermaidModule: typeof import('mermaid') | null = null
@@ -16,6 +16,64 @@ function getTheme(): 'dark' | 'neutral' {
     : 'neutral'
 }
 
+function getMermaidConfig() {
+  const styles = getComputedStyle(document.documentElement)
+  const bodyStyles = getComputedStyle(document.body)
+  const isDark = getTheme() === 'dark'
+
+  const foreground = styles.getPropertyValue('--foreground').trim() || (isDark ? '#e5e7eb' : '#1f2937')
+  const border = styles.getPropertyValue('--border').trim() || (isDark ? '#374151' : '#d1d5db')
+  const primary = styles.getPropertyValue('--primary').trim() || '#4338ca'
+  const editorBackground = styles.getPropertyValue('--background').trim() || (isDark ? '#111827' : '#ffffff')
+  const fontFamily = bodyStyles.fontFamily || "'Sofia Sans', sans-serif"
+
+  return {
+    startOnLoad: false,
+    securityLevel: 'strict' as const,
+    theme: 'base' as const,
+    htmlLabels: false,
+    fontFamily,
+    themeVariables: {
+      fontFamily,
+      fontSize: '13px',
+      textColor: foreground,
+      lineColor: isDark ? '#8b9bb4' : '#64748b',
+      edgeLabelBackground: isDark ? '#111827' : '#ffffff',
+      primaryColor: isDark ? '#232846' : '#eef2ff',
+      primaryTextColor: isDark ? '#f8fafc' : '#27304a',
+      primaryBorderColor: isDark ? '#7c8cff' : primary,
+      secondaryColor: isDark ? '#1a2033' : '#f8fafc',
+      tertiaryColor: isDark ? '#20263a' : '#f5f3ff',
+      clusterBkg: isDark ? '#161d2d' : '#f8fafc',
+      clusterBorder: isDark ? '#4b5563' : border,
+      mainBkg: isDark ? '#232846' : '#eef2ff',
+      nodeBorder: isDark ? '#7c8cff' : primary,
+      background: editorBackground,
+    },
+    flowchart: {
+      curve: 'basis',
+    },
+  }
+}
+
+async function waitForMermaidFonts() {
+  const fonts = document.fonts
+
+  if (!fonts) {
+    return
+  }
+
+  try {
+    await fonts.ready
+    await Promise.allSettled([
+      fonts.load("13px 'Sofia Sans'"),
+      fonts.load("600 13px 'Sofia Sans'"),
+    ])
+  } catch {
+    // Fall back silently if the browser cannot resolve font readiness.
+  }
+}
+
 async function getMermaid() {
   if (!mermaidModule) {
     mermaidModule = await import('mermaid')
@@ -23,11 +81,7 @@ async function getMermaid() {
   const mermaid = mermaidModule.default
 
   if (!initialized) {
-    mermaid.initialize({
-      startOnLoad: false,
-      theme: getTheme(),
-      securityLevel: 'strict',
-    })
+    mermaid.initialize(getMermaidConfig())
     initialized = true
   }
 
@@ -39,12 +93,96 @@ async function getMermaid() {
  * Returns the SVG string, or throws on invalid syntax.
  */
 export async function renderMermaid(id: string, source: string): Promise<string> {
+  await waitForMermaidFonts()
   const mermaid = await getMermaid()
 
-  // Re-check theme each render in case user switched
-  const theme = getTheme()
-  mermaid.initialize({ startOnLoad: false, theme, securityLevel: 'strict' })
+  // Re-apply theme config in case the user switched VS Code themes.
+  mermaid.initialize(getMermaidConfig())
 
   const { svg } = await mermaid.render(id, source)
   return svg
+}
+
+/**
+ * Ensure the SVG has explicit width/height attributes so the browser
+ * reports correct naturalWidth/naturalHeight when loaded via blob URL.
+ * Mermaid SVGs often rely on CSS max-width + viewBox, which causes the
+ * Image element to fall back to 300×150 (CSS default for replaced elements).
+ */
+function ensureSvgDimensions(svg: string): string {
+  const parser = new DOMParser()
+  const doc = parser.parseFromString(svg, 'image/svg+xml')
+  const svgEl = doc.documentElement
+
+  const hasWidth = svgEl.hasAttribute('width') && !/^\s*100%\s*$/.test(svgEl.getAttribute('width') || '')
+  const hasHeight = svgEl.hasAttribute('height') && !/^\s*100%\s*$/.test(svgEl.getAttribute('height') || '')
+
+  if (hasWidth && hasHeight) {
+    return svg
+  }
+
+  // Extract dimensions from viewBox
+  const viewBox = svgEl.getAttribute('viewBox')
+  if (viewBox) {
+    const parts = viewBox.trim().split(/[\s,]+/)
+    if (parts.length === 4) {
+      const vbWidth = parseFloat(parts[2])
+      const vbHeight = parseFloat(parts[3])
+      if (vbWidth > 0 && vbHeight > 0) {
+        svgEl.setAttribute('width', String(Math.ceil(vbWidth)))
+        svgEl.setAttribute('height', String(Math.ceil(vbHeight)))
+        return new XMLSerializer().serializeToString(doc)
+      }
+    }
+  }
+
+  // Fallback: try to read style max-width
+  const style = svgEl.getAttribute('style') || ''
+  const maxWidthMatch = style.match(/max-width:\s*([\d.]+)px/)
+  if (maxWidthMatch) {
+    const w = parseFloat(maxWidthMatch[1])
+    // Mermaid often sets only max-width; use aria-roledescription or default aspect
+    const heightAttr = svgEl.getAttribute('height')
+    const h = heightAttr ? parseFloat(heightAttr) : w * 0.75
+    if (w > 0 && h > 0) {
+      svgEl.setAttribute('width', String(Math.ceil(w)))
+      svgEl.setAttribute('height', String(Math.ceil(h)))
+      return new XMLSerializer().serializeToString(doc)
+    }
+  }
+
+  return svg
+}
+
+export async function renderMermaidToPngDataUrl(svg: string): Promise<string> {
+  const fixedSvg = ensureSvgDimensions(svg)
+  const svgBlob = new Blob([fixedSvg], { type: 'image/svg+xml;charset=utf-8' })
+  const objectUrl = URL.createObjectURL(svgBlob)
+
+  try {
+    const image = await new Promise<HTMLImageElement>((resolve, reject) => {
+      const img = new Image()
+      img.onload = () => resolve(img)
+      img.onerror = () => reject(new Error('Failed to rasterize mermaid SVG'))
+      img.src = objectUrl
+    })
+
+    const scale = 2
+    const width = Math.max(1, Math.ceil((image.naturalWidth || image.width || 1) * scale))
+    const height = Math.max(1, Math.ceil((image.naturalHeight || image.height || 1) * scale))
+    const canvas = document.createElement('canvas')
+    canvas.width = width
+    canvas.height = height
+
+    const context = canvas.getContext('2d')
+    if (!context) {
+      throw new Error('Canvas 2D context unavailable')
+    }
+
+    context.scale(scale, scale)
+    context.drawImage(image, 0, 0)
+    return canvas.toDataURL('image/png')
+  } finally {
+    URL.revokeObjectURL(objectUrl)
+  }
 }

--- a/extensions/ritemark/webview/src/lib/mermaid.ts
+++ b/extensions/ritemark/webview/src/lib/mermaid.ts
@@ -1,0 +1,50 @@
+/**
+ * Mermaid diagram rendering helper.
+ * Lazily initializes mermaid on first use and exports a render function.
+ *
+ * @see Sprint 30: Mermaid Diagram Rendering
+ */
+
+let mermaidModule: typeof import('mermaid') | null = null
+let initialized = false
+
+// Detect VS Code theme from body class
+function getTheme(): 'dark' | 'neutral' {
+  return document.body.classList.contains('vscode-dark') ||
+    document.body.classList.contains('vscode-high-contrast')
+    ? 'dark'
+    : 'neutral'
+}
+
+async function getMermaid() {
+  if (!mermaidModule) {
+    mermaidModule = await import('mermaid')
+  }
+  const mermaid = mermaidModule.default
+
+  if (!initialized) {
+    mermaid.initialize({
+      startOnLoad: false,
+      theme: getTheme(),
+      securityLevel: 'strict',
+    })
+    initialized = true
+  }
+
+  return mermaid
+}
+
+/**
+ * Render a mermaid diagram source string to SVG.
+ * Returns the SVG string, or throws on invalid syntax.
+ */
+export async function renderMermaid(id: string, source: string): Promise<string> {
+  const mermaid = await getMermaid()
+
+  // Re-check theme each render in case user switched
+  const theme = getTheme()
+  mermaid.initialize({ startOnLoad: false, theme, securityLevel: 'strict' })
+
+  const { svg } = await mermaid.render(id, source)
+  return svg
+}

--- a/extensions/ritemark/webview/src/lib/mermaidExport.test.ts
+++ b/extensions/ritemark/webview/src/lib/mermaidExport.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict'
+import { inlineMermaidDiagramsForExport } from './mermaidExport'
+
+async function run() {
+  let renderedSource = ''
+
+  const html = [
+    '<h2>Doc</h2>',
+    '<pre><code class="language-mermaid">flowchart TD\nA --&gt; B</code></pre>',
+    '<pre><code class="language-ts">const x = 1;</code></pre>',
+  ].join('')
+
+  const result = await inlineMermaidDiagramsForExport(html, async (source) => {
+    renderedSource = source
+    return 'data:image/png;base64,ZmFrZQ=='
+  })
+
+  assert.equal(renderedSource, 'flowchart TD\nA --> B')
+  assert.match(result, /<img[^>]+src="data:image\/png;base64,ZmFrZQ=="/)
+  assert.doesNotMatch(result, /language-mermaid/)
+  assert.match(result, /language-ts/)
+
+  let highlightedSource = ''
+  const highlightedHtml = '<pre><code class="language-mermaid"><span class="hljs-keyword">flowchart</span> TD\nA --&gt; B</code></pre>'
+  await inlineMermaidDiagramsForExport(highlightedHtml, async (source) => {
+    highlightedSource = source
+    return 'data:image/png;base64,ZmFrZTI='
+  })
+  assert.equal(highlightedSource, 'flowchart TD\nA --> B')
+}
+
+void run()

--- a/extensions/ritemark/webview/src/lib/mermaidExport.ts
+++ b/extensions/ritemark/webview/src/lib/mermaidExport.ts
@@ -1,0 +1,61 @@
+import { renderMermaid, renderMermaidToPngDataUrl } from './mermaid'
+
+const MERMAID_BLOCK_REGEX = /<pre\b[^>]*>\s*<code\b([^>]*)>([\s\S]*?)<\/code>\s*<\/pre>/gi
+
+function htmlToText(value: string): string {
+  return value
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<\/?(span|div|p|code|pre)[^>]*>/gi, '')
+    .replace(/<[^>]+>/g, '')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+}
+
+function isMermaidCodeTagAttributes(attributes: string): boolean {
+  return /\blanguage-mermaid\b/i.test(attributes)
+}
+
+export async function inlineMermaidDiagramsForExport(
+  html: string,
+  renderDiagramToDataUrl: (source: string) => Promise<string> = async (source) => {
+    const id = `export-mermaid-${Math.random().toString(36).slice(2)}`
+    const svg = await renderMermaid(id, source)
+    return renderMermaidToPngDataUrl(svg)
+  }
+): Promise<string> {
+  const source = html || ''
+  const matches = Array.from(source.matchAll(MERMAID_BLOCK_REGEX))
+
+  if (matches.length === 0) {
+    return source
+  }
+
+  let output = source
+
+  for (const match of matches) {
+    const [fullMatch, codeAttrs = '', codeHtml = ''] = match
+    if (!isMermaidCodeTagAttributes(codeAttrs)) {
+      continue
+    }
+
+    const mermaidSource = htmlToText(codeHtml).trim()
+    if (!mermaidSource) {
+      continue
+    }
+
+    try {
+      const dataUrl = await renderDiagramToDataUrl(mermaidSource)
+      output = output.replace(
+        fullMatch,
+        `<figure class="mermaid-export-block"><img src="${dataUrl}" alt="Mermaid diagram" /></figure>`
+      )
+    } catch (error) {
+      console.error('Failed to inline mermaid export diagram:', error)
+    }
+  }
+
+  return output
+}


### PR DESCRIPTION
## Summary
- Render `mermaid` code blocks as visual SVG diagrams in the TipTap editor with Code/Diagram toggle
- Export mermaid diagrams as embedded PNG images in Word (.docx) and PDF exports
- Fix CSP, SVG dimension extraction, and image scaling for proper page-width fitting

## Changes
- **Mermaid rendering**: Lazy-loaded mermaid library renders diagrams inline with theme-aware styling (light/dark), font loading, error display, and code/diagram toggle
- **Export pipeline**: New `mermaidExport.ts` replaces `<pre><code class="language-mermaid">` with `<img src="data:image/png;base64,...">` before sending to exporters
- **SVG→PNG fix**: `ensureSvgDimensions()` extracts viewBox to set explicit width/height, preventing browser 300px default
- **CSP fix**: Added `blob:` to `img-src` for canvas rasterization path
- **Image scaling**: Both Word (600px/480px cap) and PDF (page-width/55% height cap) scale diagrams to fit without dominating layout
- **Shared `imageSource.ts`**: Handles `data:` URLs, `vscode-file://`, and local paths (replaces duplicate `tryLoadImage` in both exporters)

## Test plan
- [x] Mermaid blocks render as diagrams in editor
- [x] Code/Diagram toggle works
- [x] Copy button copies source, not SVG
- [x] Invalid mermaid shows error state
- [x] Export → Word embeds diagrams at proper page width
- [x] Export → PDF embeds diagrams with proportional scaling
- [x] Tall diagrams capped at ~50% page height
- [x] Save/reopen preserves mermaid source blocks
- [x] TypeScript compiles clean
- [x] QA validator passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)