### PR TITLE
fix: prevent unwanted Codex plan mode

### DIFF
--- a/docs/WISHLIST.md
+++ b/docs/WISHLIST.md
@@ -62,6 +62,11 @@ In-app help system accessible from activity bar:
 
 - [x] Advanced Claude Code harness in AI sidebar → **Sprint 33** (multi-turn sessions, model selector, image paste, clickable file paths)
 - [x] **Chat font size setting** - User-adjustable font size for AI chat interface (easier reading, accessibility) → **Sprint 37**
+- [ ] **Agent Mode Picker** (Cursor-style) - Dropdown next to input to select agent behavior mode
+  - [ ] Write (default) — agent executes directly, no plan approval gate
+  - [ ] Plan — agent plans first, waits for user approval before executing
+  - [ ] Ask — conversational only, no file edits
+  - [ ] Mode persists per session, resets on new chat
 - [ ] Memories
 - [ ] Customization (CLAUDE.md, Agents.md support)
 - [ ] AI image generation via command palette - \[ \] Opens dialog to configure Google API key - \[ \] Uses Gemini API to generate images

--- a/extensions/ritemark/package.json
+++ b/extensions/ritemark/package.json
@@ -204,6 +204,12 @@
             "description": "Claude model to use (e.g. claude-sonnet-4-5, claude-opus-4, haiku)",
             "scope": "application"
           },
+          "ritemark.ai.debugTrace": {
+            "type": "boolean",
+            "default": false,
+            "description": "Enable runtime trace logging for AI agents (written to temp directory). Restart required after changing.",
+            "scope": "application"
+          },
           "ritemark.ai.hasSeenClaudeWelcome": {
             "type": "boolean",
             "default": false,

--- a/extensions/ritemark/src/settings/RitemarkSettingsProvider.ts
+++ b/extensions/ritemark/src/settings/RitemarkSettingsProvider.ts
@@ -360,6 +360,7 @@ export class RitemarkSettingsProvider implements vscode.WebviewPanelSerializer {
 
         // Agent
         agentTimeout: config.get('ai.agentTimeout', 15),
+        debugTrace: config.get('ai.debugTrace', false),
 
         // Chat appearance
         chatFontSize: config.get('chat.fontSize', 13),

--- a/extensions/ritemark/src/utils/runtimeTrace.ts
+++ b/extensions/ritemark/src/utils/runtimeTrace.ts
@@ -54,7 +54,7 @@ export function createRuntimeTrace(outputChannelName: string, logFileName: strin
   let channel: OutputChannelLike | null = null;
   const traceLogPath = path.join(os.tmpdir(), logFileName);
   let enabled: boolean | null = null;
-  let rotationChecked = false;
+  let writesSinceRotationCheck = 0;
 
   function tryCreateOutputChannel(): OutputChannelLike | null {
     try {
@@ -83,9 +83,9 @@ export function createRuntimeTrace(outputChannelName: string, logFileName: strin
       return;
     }
 
-    // Rotate on first write per session
-    if (!rotationChecked) {
-      rotationChecked = true;
+    // Check rotation periodically (every 500 writes) to keep cap effective
+    if (++writesSinceRotationCheck >= 500) {
+      writesSinceRotationCheck = 0;
       rotateIfNeeded(traceLogPath);
     }
 

--- a/extensions/ritemark/src/utils/runtimeTrace.ts
+++ b/extensions/ritemark/src/utils/runtimeTrace.ts
@@ -7,6 +7,8 @@ type OutputChannelLike = {
   show: (preserveFocus?: boolean) => void;
 };
 
+const MAX_LOG_SIZE = 5 * 1024 * 1024; // 5 MB
+
 function safeSerialize(value: unknown): string {
   try {
     const text = JSON.stringify(value);
@@ -19,13 +21,43 @@ function safeSerialize(value: unknown): string {
   }
 }
 
+function isTraceEnabled(): boolean {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-implied-eval
+    const dynamicRequire = new Function('name', 'return require(name)') as (name: string) => { workspace?: { getConfiguration?: (section: string) => { get?: (key: string, defaultValue?: unknown) => unknown } } };
+    const vscode = dynamicRequire('vscode');
+    return vscode?.workspace?.getConfiguration?.('ritemark.ai')?.get?.('debugTrace', false) === true;
+  } catch {
+    return false;
+  }
+}
+
+function rotateIfNeeded(logPath: string): void {
+  try {
+    const stat = fs.statSync(logPath);
+    if (stat.size > MAX_LOG_SIZE) {
+      // Keep last ~1MB, discard the rest
+      const content = fs.readFileSync(logPath, 'utf8');
+      const keepFrom = content.length - 1024 * 1024;
+      const newlineAfterCut = content.indexOf('\n', keepFrom);
+      const trimmed = newlineAfterCut >= 0
+        ? `[... log rotated at ${new Date().toISOString()} ...]\n${content.slice(newlineAfterCut + 1)}`
+        : `[... log rotated at ${new Date().toISOString()} ...]\n`;
+      fs.writeFileSync(logPath, trimmed, 'utf8');
+    }
+  } catch {
+    // File doesn't exist yet or can't stat — that's fine.
+  }
+}
+
 export function createRuntimeTrace(outputChannelName: string, logFileName: string) {
   let channel: OutputChannelLike | null = null;
   const traceLogPath = path.join(os.tmpdir(), logFileName);
+  let enabled: boolean | null = null;
+  let rotationChecked = false;
 
   function tryCreateOutputChannel(): OutputChannelLike | null {
     try {
-      // Avoid hard dependency on the vscode module in plain node test runs.
       // eslint-disable-next-line @typescript-eslint/no-implied-eval
       const dynamicRequire = new Function('name', 'return require(name)') as (name: string) => { window?: { createOutputChannel?: (name: string) => OutputChannelLike } };
       const vscode = dynamicRequire('vscode');
@@ -43,6 +75,20 @@ export function createRuntimeTrace(outputChannelName: string, logFileName: strin
   }
 
   function trace(scope: string, message: string, payload?: unknown): void {
+    // Check setting once, then cache (re-checked on show())
+    if (enabled === null) {
+      enabled = isTraceEnabled();
+    }
+    if (!enabled) {
+      return;
+    }
+
+    // Rotate on first write per session
+    if (!rotationChecked) {
+      rotationChecked = true;
+      rotateIfNeeded(traceLogPath);
+    }
+
     const timestamp = new Date().toISOString();
     const suffix = payload === undefined ? '' : ` ${safeSerialize(payload)}`;
     const line = `[${timestamp}] [${scope}] ${message}${suffix}`;
@@ -55,6 +101,8 @@ export function createRuntimeTrace(outputChannelName: string, logFileName: strin
   }
 
   function show(): void {
+    // Re-check setting when explicitly showing trace
+    enabled = isTraceEnabled();
     getTraceChannel()?.show(true);
   }
 

--- a/extensions/ritemark/webview/src/components/ai-sidebar/CodexView.tsx
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/CodexView.tsx
@@ -141,9 +141,14 @@ function CodexTurn({
   const lastActivity = hasActivities ? turn.activities[turn.activities.length - 1] : null;
   const rawPlanText = turn.planText || ((turn.result && !turn.result.error) ? turn.streamingText : '');
   const displayPlanText = extractPlanDisplayText(rawPlanText);
-  const showPlanCard = Boolean((turn.planSteps && turn.planSteps.length > 0) || displayPlanText);
+  // Only show plan cards when the user explicitly requested plan mode.
+  // Codex sends plan updates autonomously — these clutter the conversation.
+  const showPlanCard = Boolean(
+    turn.requestedPlanMode
+    && ((turn.planSteps && turn.planSteps.length > 0) || displayPlanText)
+  );
   const needsPlanReview = Boolean(showPlanCard && turn.result && !turn.result.error && turn.requiresPlanReview && !turn.planHandled);
-  const shouldHideStreamingBubble = Boolean(displayPlanText)
+  const shouldHideStreamingBubble = Boolean(showPlanCard && displayPlanText)
     && turn.streamingText.trim().length > 0
     && rawPlanText.trim() === turn.streamingText.trim();
 
@@ -217,19 +222,11 @@ function CodexTurn({
         </div>
       )}
 
-      {/* Success */}
-      {turn.result && !turn.result.error && turn.result.status === 'completed' && (
+      {/* Plan-specific status (only when plan mode was explicitly requested) */}
+      {turn.result && !turn.result.error && needsPlanReview && (
         <div className="flex items-center gap-2 text-xs text-[var(--vscode-testing-iconPassed)] pl-2">
           <Check size={12} />
-          <span>
-            {needsPlanReview
-              ? 'Waiting for plan review'
-              : turn.planHandled
-              ? turn.planDecision === 'approved'
-                ? 'Plan approved; continuation started below'
-                : 'Plan discarded'
-              : 'Done'}
-          </span>
+          <span>Waiting for plan review</span>
         </div>
       )}
     </div>

--- a/extensions/ritemark/webview/src/components/ai-sidebar/lifecycle.ts
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/lifecycle.ts
@@ -118,9 +118,12 @@ export function applyCodexPlanUpdate(
     planText: turn.planText || '',
     planExplanation: update.explanation || undefined,
     planSteps: update.plan,
-    requiresPlanReview: turn.executionContinuation ? false : true,
-    planHandled: turn.executionContinuation ? turn.planHandled : false,
-    planDecision: turn.executionContinuation ? turn.planDecision : undefined,
+    // Only require plan review if the user explicitly requested plan mode.
+    // Codex may send plan updates autonomously — these should be shown as
+    // progress indicators, not as blocking approval gates.
+    requiresPlanReview: turn.executionContinuation ? false : turn.requestedPlanMode,
+    planHandled: turn.executionContinuation ? turn.planHandled : (turn.requestedPlanMode ? false : turn.planHandled),
+    planDecision: turn.executionContinuation ? turn.planDecision : (turn.requestedPlanMode ? undefined : turn.planDecision),
   };
 }
 

--- a/extensions/ritemark/webview/src/components/settings/RitemarkSettings.tsx
+++ b/extensions/ritemark/webview/src/components/settings/RitemarkSettings.tsx
@@ -45,6 +45,7 @@ interface SettingsData {
   aiModel: string;
   availableModels: ModelInfo[];
   agentTimeout: number;
+  debugTrace: boolean;
   openaiKey: string;
   openaiKeyConfigured: boolean;
   googleKey: string;
@@ -913,6 +914,15 @@ export function RitemarkSettings() {
             Claude will be stopped if it produces no activity for this duration.
             Increase if the agent times out on complex tasks. Default: 15 minutes.
           </p>
+
+          <div className="mt-4 pt-4 border-t border-[var(--vscode-panel-border)]">
+            <ToggleRow
+              label="Debug Trace Logging"
+              description="Log AI agent activity to a temporary file for troubleshooting. Reload window after changing."
+              checked={settings?.debugTrace ?? false}
+              onChange={(v) => handleToggle('ai.debugTrace', v)}
+            />
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
## Summary
- Fix Codex always entering plan mode and showing "Codex plan" cards even when user didn't request it
- Add `ritemark.ai.debugTrace` setting to control runtime trace logging (was always-on)
- Add 5MB log rotation to prevent unbounded trace file growth
- Remove redundant "Done" status text after completed Codex turns

## Root Cause
`applyCodexPlanUpdate()` in `lifecycle.ts` set `requiresPlanReview: true` whenever Codex sent autonomous plan updates, regardless of whether the user requested plan mode. The `PlanCard` component in `CodexView.tsx` also rendered for any turn with plan text, not just plan-mode turns.

## Fix
- Gate `requiresPlanReview` on `turn.requestedPlanMode` in both `applyCodexPlanUpdate` and `CodexView`
- Gate `showPlanCard` on `turn.requestedPlanMode` so autonomous plan updates don't clutter the UI
- Trace logging now respects `ritemark.ai.debugTrace` setting (default: off)

## Test plan
- [x] New Codex chat with normal message — no "Codex plan" card shown
- [x] Codex with "work in plan mode: ..." — should show plan review card
- [x] "Done" text no longer appears after completed turns
- [ ] Debug Trace toggle visible in Settings page
- [ ] Trace log only written when setting is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)