### PR TITLE
Add Codex+Claude integration architecture audit and Windows/macOS zero‑terminal bootstrap plan

### DIFF
--- a/docs/internal/analysis/2026-04-01-codex-claude-integration-architecture-audit.md
+++ b/docs/internal/analysis/2026-04-01-codex-claude-integration-architecture-audit.md
@@ -1,0 +1,398 @@
+# Codex + Claude Integration Audit (System Architecture POV)
+
+**Date:** 2026-04-01  
+**Scope:** `ritemark-native` AI sidebar, agent runtime integration, and flow-node integration for Claude Code + Codex.  
+**Authoring mode:** codebase audit + external best-practice research.
+
+---
+
+## 1) Executive summary
+
+Ritemark currently implements a **dual-provider agent architecture** where Claude and Codex are integrated through different runtime stacks but exposed through a mostly unified sidebar UX. This is a practical and shippable design, but it creates some medium-term complexity around duplicated lifecycle logic, provider-specific edge-case handling, and inconsistent execution contracts between sidebar sessions and flow nodes.
+
+At a high level:
+
+- The **sidebar orchestration is centralized** in `UnifiedViewProvider`, which routes to Ritemark assistant, Claude session logic, or Codex app-server logic.
+- **Claude path** uses Anthropic SDK via `AgentRunner` with persistent sessions and tool/lifecycle conventions.
+- **Codex path** uses a custom JSON-RPC client over `codex app-server` with explicit request/response and approval callbacks.
+- **Flows support both providers** (`claude-code`, `codex`) but use separate executors and separate operational assumptions.
+- There is already a healthy foundation for safety controls (approval policy, sandbox mode, excluded folders, setup checks), but enforcement is mixed between prompt-time contracts and runtime controls.
+
+**Strategic recommendation:** keep the current integration for short-term velocity, but move toward a **provider-neutral agent runtime contract** with a shared event model, policy engine, and adapter layer.
+
+---
+
+## 2) Current architecture (as implemented)
+
+## 2.1 Control plane and UI boundary
+
+`UnifiedViewProvider` is the primary bridge between VS Code extension host and webview UI. It owns:
+
+- webview message routing (`ai-execute`, `ai-select-agent`, model selection, cancellation, approvals, questions)
+- provider-specific state (Claude session state and Codex app-server/auth state)
+- setup/status propagation for provider readiness
+
+This makes it a **high-centrality orchestrator** that combines transport, policy hints, provider lifecycle, and UI wiring in one place.
+
+## 2.2 Claude integration path
+
+Claude integration uses `AgentRunner` as shared runtime abstraction with two usage modes:
+
+- one-shot `runAgent()` (used by flows)
+- persistent `AgentSession` (used by sidebar)
+
+Notable traits:
+
+- Dynamic import pattern to load ESM SDK from CommonJS extension context.
+- Prompt-embedded lifecycle guardrails (AskUserQuestion / ExitPlanMode behavior).
+- Attachment handling transformed into SDK message content blocks.
+- Local safety prefix (workspace + excluded folders) added to system append.
+
+The Claude setup path (`agent/setup.ts`) additionally handles cross-platform binary discovery and Windows-specific `.cmd`/spawn nuances.
+
+## 2.3 Codex integration path
+
+Codex integration is split across:
+
+- `codexManager.ts` (binary discovery, version/compatibility, process lifecycle)
+- `codexAppServer.ts` (JSON-RPC protocol client + event emitter)
+- `codexAuth.ts` (auth + login status orchestration)
+- protocol typings in `codexProtocol.ts`
+
+Notable traits:
+
+- Direct app-server session semantics (initialize → thread/start → turn/start).
+- Runtime handling of server-initiated approval requests and `request_user_input` responses.
+- Explicit capability compatibility checks and diagnostics surfaced to UI.
+
+## 2.4 Flows integration
+
+Flows define both agent node types in `flows/types.ts` and use:
+
+- `ClaudeCodeNodeExecutor.ts` for Claude
+- `CodexNodeExecutor.ts` for Codex
+
+Current divergence:
+
+- Codex flow executor auto-approves all server requests in flow context.
+- Claude flow executor goes through Claude runner semantics and maps richer progress into a simplified progress contract.
+
+This is workable but creates policy asymmetry and inconsistent observability.
+
+## 2.5 Agent/command discovery boundary
+
+`agent/discovery.ts` scans `.claude/agents`, `.claude/commands`, `.claude/skills` and exposes these to webview UX (mentions/slash command affordances). This means Claude ecosystem metadata currently acts as a broader “agent capability catalog”, even when Codex is selected.
+
+---
+
+## 3) Architecture strengths
+
+1. **Clear provider isolation at runtime process layer** (Claude SDK vs Codex app-server), reducing blast radius of provider-specific failures.
+2. **Good operator ergonomics** via diagnostics, setup status, and repair command hints.
+3. **Safety controls exposed in settings** (approval policy, sandbox mode, excluded folders), improving user-governed trust boundaries.
+4. **Progressive multi-agent UX** with shared chat interface and provider-specific handling beneath.
+5. **Compatibility introspection** for Codex versions (pragmatic guard against protocol drift).
+
+---
+
+## 4) Key risks and architectural debt
+
+## 4.1 Orchestrator concentration risk
+
+`UnifiedViewProvider` is becoming a “god orchestrator”: transport broker + policy adapter + lifecycle manager + state coordinator. This reduces change safety and testability when adding more providers/features.
+
+## 4.2 Contract drift between providers
+
+Claude uses prompt-level lifecycle constraints and SDK semantics; Codex uses protocol-level events and explicit responses. Same user intent (plan, question, approval) is implemented differently, which risks UX inconsistency and subtle regressions.
+
+## 4.3 Sidebar vs Flows policy mismatch
+
+Auto-approval behavior in Codex flow execution can diverge from user expectations configured in sidebar settings. This is a policy-layer inconsistency, not just an executor detail.
+
+## 4.4 Discovery model tied to `.claude` conventions
+
+Agent/command discovery assumes Claude filesystem conventions. As multi-provider strategy grows, this can become an accidental dependency and make cross-provider capability portability harder.
+
+## 4.5 Provider protocol evolution risk
+
+Codex protocol is vendored in local TS types and partially generated/simplified. Any upstream protocol drift can break event parsing, approval handshakes, or auth flow behavior unless version-gated and contract-tested.
+
+---
+
+## 5) External best-practice research (online)
+
+> Note: these recommendations synthesize published guidance and map it to this codebase. Where provider behavior is inferred from product docs rather than formal API contracts, treat as directional.
+
+## 5.1 Best-practice themes
+
+1. **Policy enforcement should be runtime, not only prompt text.**
+   - Prompt contracts are useful but should backstop—not replace—hard policy gates.
+
+2. **Use least-privilege execution with explicit escalation paths.**
+   - Sandbox defaults and command/file-change approvals should align with execution mode (chat vs flow automation).
+
+3. **Separate provider adapters from product lifecycle state machine.**
+   - Keep one canonical turn lifecycle contract and map provider events into that model.
+
+4. **Treat tool invocation as untrusted boundary.**
+   - Prompt-injection-resistant controls should include allowlists, workspace boundary checks, and output sanitization.
+
+5. **Versioned protocol contracts + compatibility tests.**
+   - Protocol clients should be validated against fixed fixtures and smoke tests for server-request callbacks.
+
+## 5.2 Sources consulted
+
+- Anthropic docs (Claude Code / agent SDK guidance): https://docs.anthropic.com/
+- OpenAI Codex product/docs hub: https://openai.com/codex/
+- OpenAI developer docs (agent/tooling patterns): https://platform.openai.com/docs
+- Model Context Protocol site/spec references: https://modelcontextprotocol.io/
+- OWASP Top 10 for LLM Applications (agent/tool/prompt-injection risks): https://owasp.org/www-project-top-10-for-large-language-model-applications/
+
+---
+
+## 6) Refactor strategy options by budget scenario
+
+## Scenario 1 — Near-limitless time + budget
+
+**Goal:** Build a durable multi-provider agent platform inside Ritemark.
+
+### What to refactor
+
+1. **Introduce Agent Runtime Core (ARC)**
+   - New internal module owning canonical lifecycle states:
+     `idle -> planning -> awaiting_input -> awaiting_approval -> executing -> completed/failed/interrupted`
+   - Provider adapters emit normalized domain events into ARC.
+
+2. **Provider Adapter Interface**
+   - `IProviderAdapter` for Claude, Codex (and future providers).
+   - Responsibilities: session init, turn start/interrupt, auth status, capability reporting, event translation.
+
+3. **Unified Policy Engine**
+   - Central policy service for approvals, sandbox rules, workspace boundaries, and flow-vs-sidebar policy profiles.
+   - Hard enforcement before tool execution responses are sent.
+
+4. **Capability Registry & Feature Negotiation**
+   - Provider declares capabilities (`supportsStructuredQuestions`, `supportsPlanEvents`, `supportsPatchApprovalScopes`, etc.).
+   - UI and flow executors bind to capability flags instead of provider `if/else` logic.
+
+5. **Protocol Contract Test Harness**
+   - JSON-RPC replay fixtures for Codex; SDK event fixtures for Claude.
+   - Golden lifecycle tests proving same user-level behavior across providers.
+
+6. **Telemetry & SLOs**
+   - Structured traces per turn + per tool with provider-neutral keys.
+   - Operational dashboards for auth failures, approval loops, timeout rates, context overflow rates.
+
+### Expected outcomes
+
+- High reliability and provider portability.
+- Faster future integration of additional agent backends.
+- Lower regression risk from protocol/provider changes.
+
+### Trade-offs
+
+- Significant up-front architecture and migration cost.
+- Needs strict rollout governance and dual-run compatibility window.
+
+---
+
+## Scenario 2 — Medium time + budget
+
+**Goal:** Reduce most architectural risk without full platform rewrite.
+
+### What to refactor
+
+1. **Extract lifecycle reducer from `UnifiedViewProvider`**
+   - Keep existing providers, but move turn-state transitions to shared state machine module.
+
+2. **Add thin adapter wrappers (not full platform)**
+   - `ClaudeAdapter` and `CodexAdapter` expose same minimal interface for sidebar operations.
+
+3. **Unify policy behavior for Flows + Sidebar**
+   - Reuse same approval policy resolver in both executors.
+   - Replace Codex flow “auto-approve all” with explicit execution profile (e.g., `automation-safe`, `interactive`, `dry-run`).
+
+4. **Strengthen compatibility guards**
+   - Add startup contract checks + warning downgrade mode when unsupported Codex protocol capabilities are detected.
+
+5. **Consolidate discovery abstraction**
+   - Keep `.claude` scan support, but introduce provider-neutral discovery schema in UI-facing contract.
+
+### Expected outcomes
+
+- Noticeably better consistency and maintainability.
+- Lower migration risk than full rewrite.
+- Fits incremental sprint delivery.
+
+### Trade-offs
+
+- Some duplication remains.
+- May need another refactor in 1–2 major releases if provider count increases.
+
+---
+
+## Scenario 3 — Very tight budget
+
+**Goal:** Improve safety + maintainability with minimal churn.
+
+### What to refactor
+
+1. **Add explicit architecture boundary docs + invariants tests**
+   - Document lifecycle invariants and approval semantics.
+   - Add smoke tests that assert Claude and Codex both trigger question/plan/approval UX correctly.
+
+2. **Patch highest-risk inconsistency only**
+   - Remove unconditional Codex flow auto-approval or gate it behind explicit setting with clear warning.
+
+3. **Reduce `UnifiedViewProvider` complexity surgically**
+   - Extract only Codex auth/status polling and request routing helpers into small focused modules.
+
+4. **Protocol drift guardrail**
+   - On Codex init, validate required RPC methods/capabilities; fail fast with actionable diagnostics.
+
+### Expected outcomes
+
+- Lower operational risk quickly.
+- Keeps velocity for feature work.
+
+### Trade-offs
+
+- Technical debt remains.
+- Future provider expansion still expensive.
+
+---
+
+## 7) Suggested phased plan (pragmatic)
+
+1. **Phase A (immediate, low risk):** policy alignment + contract tests (Scenario 3 baseline).
+2. **Phase B (next):** lifecycle extraction + thin adapters (Scenario 2 core).
+3. **Phase C (strategic):** optional ARC platformization if roadmap includes more providers/automation depth.
+
+---
+
+## 8) Concrete recommendations (priority-ordered)
+
+1. **P0:** unify approval semantics between sidebar and flows.
+2. **P0:** add provider-agnostic lifecycle contract tests (plan/question/approval/interruption).
+3. **P1:** split `UnifiedViewProvider` into coordinator + provider services.
+4. **P1:** codify capability negotiation and fallback UX.
+5. **P2:** introduce provider-neutral discovery and command metadata model.
+6. **P2:** centralize telemetry schema for both provider runtimes.
+
+---
+
+## 9) Final audit verdict
+
+The current system is **functionally strong for a two-provider experimental-to-production transition stage**, but its architecture is at the point where incremental complexity will compound quickly. If the product intent is sustained multi-agent depth (and especially if adding providers/tooling), investing now in a normalized runtime contract and policy layer will produce strong long-term leverage.
+
+
+
+---
+
+## 10) Follow-up coverage gaps and continuation
+
+After review, the biggest under-covered area is the desktop onboarding dependency funnel (Windows + macOS) for non-technical users (terminal-averse setup). This is now tracked in a dedicated continuation audit with concrete architecture and implementation sequencing:
+
+- `docs/internal/analysis/2026-04-01-windows-zero-terminal-bootstrap-plan.md`
+
+Priority order for continuation:
+
+1. P0: Desktop (Windows + macOS) zero-terminal bootstrap and blocker-specific one-click recovery, with explicit handling for Node runtime mismatch (VS Code runtime vs terminal), architecture mismatch, and PATH/shim conflicts.
+2. P1: Sidebar vs flow approval policy unification and migration safety.
+3. P2: Provider lifecycle contract tests and protocol-drift fixtures.
+4. P3: Onboarding telemetry schema and measurable setup SLOs.
+
+---
+
+## 11) Provider update scenarios (Codex + Claude) — missing depth now covered
+
+This section focuses on what happens when provider CLIs/protocols/auth behaviors change between releases, and how Ritemark should remain stable for non-technical users.
+
+### 11.1 Scenario matrix (by blast radius)
+
+## S1 — Routine CLI patch/minor updates (low blast radius)
+
+- **Trigger examples**
+  - Codex CLI global package updated.
+  - Claude Code auto-update applies in background.
+- **Primary risk**
+  - New diagnostics text or minor auth prompts break brittle parsing/UI assumptions.
+- **Required handling**
+  - Tolerant parsing; avoid string-fragile state transitions.
+  - Keep user state in `ready` unless hard capability checks fail.
+
+## S2 — Protocol/event schema evolution (medium blast radius)
+
+- **Trigger examples**
+  - Codex app-server adds/renames fields or changes event ordering.
+  - Claude SDK event shape/semantics for plan/question/tool updates evolve.
+- **Primary risk**
+  - Sidebar turn lifecycle drifts; approvals/questions may stall.
+- **Required handling**
+  - Versioned adapter contract + fixture replay tests per provider.
+  - Capability negotiation at session start, with graceful feature downgrade.
+
+## S3 — Runtime/install channel shifts (high blast radius for onboarding)
+
+- **Trigger examples**
+  - CLI install method changes (native installer vs npm path assumptions).
+  - Node runtime requirements advance.
+- **Primary risk**
+  - Existing repair/install flows become incorrect, especially on Windows/macOS non-technical installs.
+- **Required handling**
+  - Installer-channel detection in setup status.
+  - Blocker mapper uses channel-aware remediation, not one command for all users.
+
+## S4 — Auth/session policy changes (high blast radius for trust)
+
+- **Trigger examples**
+  - Login token format/expiry behavior changes.
+  - Browser callback behavior changes or stricter security prompts.
+- **Primary risk**
+  - Repeated login loops or false “ready” state.
+- **Required handling**
+  - Distinct states for `needs-auth`, `auth-in-progress`, `auth-stale`, `auth-failed`.
+  - Recheck with bounded retries and user-facing explanation.
+
+## S5 — Breaking major releases (highest blast radius)
+
+- **Trigger examples**
+  - Codex/Claude major version with incompatible behavior.
+- **Primary risk**
+  - Hard startup failures, broken flows, support surge.
+- **Required handling**
+  - Compatibility gate at startup + explicit minimum/maximum supported ranges.
+  - Controlled rollout and rollback toggles.
+
+### 11.2 Update-safe architecture requirements
+
+1. **Provider version fingerprinting** on every session bootstrap (binary version, install channel, arch/runtime hints).
+2. **Adapter-level compatibility verdict**: `supported | degraded | unsupported` with structured reasons.
+3. **State-machine invariant tests** proving plan/question/approval/cancel parity across providers on upgraded fixtures.
+4. **Release ring strategy** (internal -> beta -> stable) for provider-related updates.
+5. **Fast rollback path**: disable affected capability without disabling the full provider when possible.
+
+### 11.3 UX contract during update incompatibility
+
+When an update breaks compatibility, user experience must:
+
+- stay explicit (“Codex update changed a required capability” rather than generic failure)
+- present one safe next action (reload, repair, sign-in, or wait-for-update)
+- avoid terminal-first commands for default path
+- keep technical payload in expandable details for support workflows
+
+### 11.4 Test plan additions for update scenarios
+
+Add provider update regression suite:
+
+1. Codex protocol fixture versions `vN`, `vN+1` (added/unknown fields).
+2. Claude event ordering variants (question before plan, plan deltas interleaved with tool output).
+3. Auth loop prevention tests after simulated token invalidation.
+4. Startup compatibility gate tests: supported/degraded/unsupported mapping.
+5. Rollback behavior tests (feature toggle off -> provider still usable in reduced mode).
+
+### 11.5 Priority execution (next two increments)
+
+- **Increment A**: fingerprint + compatibility verdict + user-facing degraded mode.
+- **Increment B**: fixture replay CI gate + release-ring telemetry dashboards.
+

--- a/docs/internal/analysis/2026-04-01-windows-zero-terminal-bootstrap-plan.md
+++ b/docs/internal/analysis/2026-04-01-windows-zero-terminal-bootstrap-plan.md
@@ -1,0 +1,348 @@
+# Desktop Dependency Bootstrap Audit + Zero-Terminal Strategy (Windows + macOS)
+
+**Date:** 2026-04-01  
+**Priority:** P0 (requested by product owner)  
+**Scope:** New desktop users (Windows and macOS) failing AI dependency setup, especially when install paths fall back to terminal-oriented guidance.
+
+---
+
+## 1) Why this is now the most important gap
+
+The prior follow-up correctly focused on Windows, but onboarding risk is cross-platform for non-technical users. macOS users can also hit CLI/auth/bootstrap friction (install scripts, PATH/reload states, shell assumptions). The product requirement should therefore be **desktop-wide zero-terminal onboarding** with OS-specific recovery actions.
+
+---
+
+## 2) Areas previously under-covered (ranked by importance)
+
+## P0 — First-run dependency funnel for non-technical desktop users
+
+Missing depth in earlier docs:
+- no unified Windows + macOS setup funnel model
+- no explicit “no-terminal-first” contract for either OS
+- no shared blocker taxonomy spanning CLI missing, binary unrunnable, reload needed, auth needed
+
+## P1 — Runtime policy consistency between sidebar and flow automation
+
+- insufficient migration sequencing for replacing implicit flow auto-approval
+- missing rollout guardrails for existing user workflows
+
+## P2 — Provider lifecycle contract test matrix
+
+- no explicit fixture strategy for Codex JSON-RPC evolution + Claude SDK event evolution
+- no CI gate spec for compatibility drift checks
+
+## P3 — Operational telemetry and onboarding analytics
+
+- no baseline event schema for setup drop-offs by OS/provider
+- no measurable SLOs for install-success latency
+
+---
+
+## 3) Start covering P0 now: Zero-Terminal Desktop Bootstrap architecture
+
+## 3.1 Product requirement (new)
+
+For non-technical Windows **and** macOS users, setup should satisfy:
+
+- **No copy-paste terminal commands required** for normal install/recovery.
+- **Single primary CTA per blocker** (“Install Git”, “Install Claude”, “Reload app”, “Sign in”).
+- **Deterministic status model** with plain-language cause + next action.
+- **OS-aware recovery UX** while preserving one shared mental model.
+
+## 3.2 Current-state constraints in codebase
+
+The codebase already has building blocks:
+- Windows prerequisite checks (`git`, `powershell.exe`) and Claude installer outcomes.
+- Codex binary compatibility diagnostics and repair guidance.
+- Setup UI surfaces (`SetupWizard`, `CodexSetupView`) that can render richer blocker-driven actions.
+
+Gap: recovery is still too diagnostics/CLI-oriented for non-technical onboarding.
+
+## 3.3 Target shared model
+
+```ts
+type BootstrapBlocker =
+  | 'missing-git'
+  | 'missing-powershell'
+  | 'missing-xcode-cli'
+  | 'missing-claude-cli'
+  | 'missing-codex-cli'
+  | 'binary-unrunnable'
+  | 'reload-required'
+  | 'auth-required'
+  | 'unknown';
+
+interface BootstrapStatus {
+  os: 'windows' | 'macos';
+  provider: 'claude' | 'codex';
+  ready: boolean;
+  blocker: BootstrapBlocker | null;
+  userMessage: string;
+  actionLabel: string | null;
+  actionId: 'install-git' | 'install-xcode-cli' | 'repair-cli' | 'reload' | 'login' | 'open-help' | null;
+  diagnostics: string[];
+}
+```
+
+## 3.4 OS-specific action resolver
+
+Introduce `BootstrapActionService` in extension host:
+
+- Windows actions
+  - `install-git` → open Git for Windows installer page + recheck loop
+  - `repair-cli` → provider-specific guided install/login
+- macOS actions
+  - `install-git` / `install-xcode-cli` → guided install flow with plain-language prompts
+  - `repair-cli` → guided provider install/login
+- Shared actions
+  - `reload`, `login`, `open-help`
+
+Rule: hide raw shell commands by default; allow optional advanced disclosure.
+
+## 3.5 UI contract (single-CTA recovery)
+
+Both setup surfaces should render from the same DTO:
+- one blocker headline
+- one primary action
+- “Show technical details” disclosure for advanced users
+- automatic recheck after action completion
+
+---
+
+## 4) Implementation plan (repo-specific)
+
+## Phase 1 (fastest impact)
+
+1. Add shared `BootstrapStatus` mapper from existing Claude/Codex/environment status.
+2. Publish bootstrap status to webview regardless of selected provider.
+3. Update `SetupWizard` + `CodexSetupView` to single-CTA blocker rendering.
+4. Add telemetry:
+   - `bootstrap.blocker_detected`
+   - `bootstrap.action_clicked`
+   - `bootstrap.ready`
+   - with `os` and `provider` dimensions.
+
+## Phase 2 (stability)
+
+1. Add debounced post-action health recheck.
+2. Add blocker-specific copy for common Windows and macOS signatures.
+3. Add provider availability gating in selector with clear “why unavailable” copy.
+
+## Phase 3 (hardening)
+
+1. Add signed helper flows where legal/security permits.
+2. Add dashboard + cohorts for onboarding blockers by OS/provider.
+
+---
+
+## 5) Online references informing this plan
+
+- Microsoft WinGet docs (`install`, `settings`, configurations):
+  - https://learn.microsoft.com/windows/package-manager/winget/install
+  - https://learn.microsoft.com/windows/package-manager/winget/settings
+  - https://learn.microsoft.com/windows/package-manager/configuration/create
+- Apple developer docs for command line tools distribution paths (Xcode CLT):
+  - https://developer.apple.com/xcode/resources/
+- Electron/electron-builder packaging and updater guidance:
+  - https://www.electron.build/nsis.html
+  - https://www.electron.build/squirrel-windows.html
+  - https://www.electron.build/auto-update.html
+
+---
+
+## 6) Decisions to make tomorrow
+
+1. Should zero-terminal mode be default on both Windows and macOS?
+2. Should unavailable providers be disabled in selector or shown with blocked-state cards?
+3. Are external installer handoffs acceptable as first-class CTA actions?
+4. Should advanced “copy command” mode be opt-in only?
+
+---
+
+## 7) Immediate next coding tasks
+
+1. Extract bootstrap-state mapper from `setupStatus` + `environmentStatus` + Codex status.
+2. Add extension→webview message for normalized bootstrap status.
+3. Refactor setup components to blocker/action rendering (Windows + macOS copy variants).
+4. Add tests for blocker mapping and CTA rendering behavior.
+
+
+---
+
+## 8) Deep edge-case coverage (expanded from your feedback)
+
+Your specific example (Node environment mismatch between VS Code runtime and external terminal runtime) is a real P0/P1 failure mode and is already partially visible in current diagnostics. We should treat it as a first-class blocker family, not as generic “broken install”.
+
+### 8.1 Edge-case taxonomy for non-technical onboarding
+
+## Tier A — Prevents setup completion (must be single-CTA recoverable)
+
+1. **Runtime Node mismatch (inside app vs terminal)**
+   - Symptom: Codex/Claude installed under one Node runtime (e.g., nvm-managed v20 in terminal), while Ritemark uses another runtime path/version.
+   - Existing signal in code: mismatch diagnostics and install-node-version extraction exist for Codex.
+   - Risk: user sees “installed but broken” loops and does not understand version manager context.
+
+2. **Architecture mismatch on Apple Silicon**
+   - Symptom: x64 install under Rosetta, arm64 runtime in app (or inverse).
+   - Existing signal in code: Apple Silicon + x64 install diagnostic line already exists.
+   - Risk: wrong native package variant, repeated repair prompts.
+
+3. **Windows shell wrapper path ambiguity**
+   - Symptom: `.cmd` wrapper selected where raw JS/exe path is needed (or extensionless shim is selected first).
+   - Existing signal in code: explicit comments and logic around `where` returning extensionless shims, and `.cmd` execution behavior.
+   - Risk: binary “exists” but fails to execute correctly.
+
+4. **PATH refresh/reload stale state**
+   - Symptom: install succeeds but app process PATH is stale until reload.
+   - Existing signal in code: `repairAction === 'reload'`, environment `restartRequired` diagnostics.
+   - Risk: users think install failed.
+
+## Tier B — Allows completion but causes high confusion/drop-off
+
+5. **Provider auth state drift**
+   - Symptom: login opened in browser but callback/session not recognized in app yet.
+   - Risk: users re-run login repeatedly.
+
+6. **Offline/filtered network during auth**
+   - Symptom: auth-required UI shown but internet/corporate network blocks callback endpoints.
+   - Risk: silent looping between sign-in and error.
+
+7. **Multi-version manager shadowing (nvm/fnm/volta/choco/homebrew)**
+   - Symptom: “node -v” differs by shell/profile; app process has different PATH order than user terminal.
+   - Risk: repair command fixes one shell but not app runtime assumptions.
+
+## Tier C — Secondary, but important for support burden
+
+8. **Restricted PowerShell execution policy / enterprise lock-down (Windows)**
+9. **Command Line Tools not present or partial install (macOS)**
+10. **Security tools quarantining fresh CLI binary**
+
+### 8.2 Concrete blocker model extension
+
+Extend blocker set to represent these edge cases explicitly:
+
+- `node-runtime-mismatch`
+- `arch-mismatch`
+- `path-shadowing`
+- `shell-wrapper-mismatch`
+- `network-auth-blocked`
+
+And include a machine-readable evidence payload:
+
+```ts
+interface BootstrapEvidence {
+  runtimeNodeVersion?: string;
+  installNodeVersion?: string;
+  runtimeArch?: string;
+  installArch?: string;
+  machineArch?: string;
+  binaryPath?: string;
+  pathSource?: 'where' | 'which' | 'manual';
+  stalePathLikely?: boolean;
+  networkReachable?: boolean;
+  authEndpointReachable?: boolean;
+}
+```
+
+### 8.3 Single-CTA actions for hard edge cases
+
+For non-technical users, each advanced blocker still maps to one plain action:
+
+- `node-runtime-mismatch` → **“Repair with Ritemark runtime”**
+  - Runs managed repair path that aligns install with app runtime, then auto-rechecks.
+- `arch-mismatch` → **“Reinstall correct architecture”**
+  - Runs architecture-safe repair flow (especially macOS arm64).
+- `path-shadowing` / `shell-wrapper-mismatch` → **“Fix CLI path”**
+  - Guides/automates preferred binary selection and records chosen path.
+- `network-auth-blocked` → **“Open connection help”**
+  - Opens targeted help and retry flow with endpoint diagnostics.
+
+Advanced details remain behind disclosure, but primary flow stays single-choice and reversible.
+
+### 8.4 Detection reliability requirements
+
+To avoid false positives/false negatives on these blockers:
+
+1. Evaluate status from a **single extension-host health probe** (not mixed ad hoc probes from webview + extension).
+2. Persist last successful runtime fingerprint to compare against newly detected install context.
+3. Add confidence grading (`high | medium | low`) when diagnosing mismatch from partial evidence.
+4. If confidence is low, default CTA should be **safe diagnostic collection**, not destructive reinstall.
+
+### 8.5 Tests to add immediately (high value)
+
+1. **Node mismatch matrix tests**
+   - runtime v20/install v22; runtime v22/install v20; same versions; missing install version.
+2. **Arch matrix tests**
+   - macOS arm64 machine + x64 install; arm64 install; Intel machine cases.
+3. **PATH/shim precedence tests**
+   - Windows `where` returns extensionless shim + `.cmd`; ensure expected path chosen.
+4. **Reload transition tests**
+   - install success -> reload-required -> ready after simulated restart.
+5. **UI mapping tests**
+   - each new blocker maps to exactly one primary CTA and one user-facing explanation.
+
+---
+
+## 9) “Start covering now” execution plan (next pass)
+
+### 9.1 What to implement first (smallest safe sequence)
+
+1. Add `BootstrapEvidence` + blocker extensions in shared setup typing.
+2. Normalize existing Codex diagnostics into structured evidence (node/arch/path).
+3. Add a provider-neutral mapper:
+   - inputs: setup status + codex status + env status + health probe
+   - outputs: `BootstrapStatus` + `BootstrapEvidence`
+4. Update setup views to consume blocker+action first, technical details second.
+5. Add matrix tests for node/arch/path and UI CTA mapping.
+
+### 9.2 Success criteria (must be measured)
+
+- First-run completion rate for Windows and macOS (new users) increases.
+- “Installed but broken” repeat loop rate decreases.
+- Median time-to-ready drops.
+- Support tickets mentioning `node`, `PATH`, `nvm`, `PowerShell`, or `Rosetta` reduce over 2 releases.
+
+### 9.3 Rollout guardrails
+
+- Feature-flag blocker-driven setup mapper.
+- Keep old setup rendering fallback for one release.
+- Emit side-by-side telemetry (`legacy_state`, `new_blocker`) during migration.
+
+
+---
+
+## 10) Update scenarios in onboarding (Codex + Claude)
+
+To prevent regressions after provider updates, onboarding should classify update-related failures separately from fresh-install failures.
+
+### 10.1 New blocker candidates for update transitions
+
+- `provider-update-incompatible`
+- `provider-update-auth-reset`
+- `provider-update-reload-required`
+- `provider-update-repair-required`
+
+### 10.2 Minimal DTO extension
+
+```ts
+interface BootstrapStatus {
+  // existing fields...
+  updateState?: 'none' | 'detected' | 'degraded' | 'blocked';
+  providerVersion?: string;
+  compatibilityVerdict?: 'supported' | 'degraded' | 'unsupported';
+}
+```
+
+### 10.3 Non-technical user CTA mapping for updates
+
+- `provider-update-reload-required` → **Reload Ritemark**
+- `provider-update-auth-reset` → **Sign in again**
+- `provider-update-repair-required` → **Repair provider**
+- `provider-update-incompatible` → **Use compatible mode** (temporary degraded mode until app/provider alignment)
+
+### 10.4 Guardrails
+
+1. Never silently downgrade trust/safety settings during update fallback.
+2. If compatibility is `degraded`, disable only unsupported capabilities (not full provider) when safe.
+3. Emit telemetry separating `first_install` vs `post_update` failures.
+


### PR DESCRIPTION
### Motivation

- Capture an architecture-level review of the current dual-provider agent integration (Claude SDK vs Codex app-server) and recommend a path to reduce provider-specific contract drift. 
- Provide a concrete, prioritized plan to remove terminal-first onboarding friction for non-technical desktop users on Windows and macOS. 
- Surface gaps in lifecycle, policy, discovery, and protocol drift handling so future work can target high-risk areas first.

### Description

- Add `docs/internal/analysis/2026-04-01-codex-claude-integration-architecture-audit.md` which documents current runtime flows, strengths, risks, external best-practice research, and three refactor scenarios plus a phased migration and concrete P0/P1/P2 recommendations. 
- Add `docs/internal/analysis/2026-04-01-windows-zero-terminal-bootstrap-plan.md` which defines a `BootstrapStatus`/`BootstrapEvidence` model, a `BootstrapActionService` concept, a single-CTA UI contract, an OS-aware blocker taxonomy (including `node-runtime-mismatch`, `arch-mismatch`, `path-shadowing`), and a rollout plan with phased implementation tasks. 
- Both docs include prioritized test matrices and telemetry events to add (for example `bootstrap.blocker_detected`, `bootstrap.action_clicked`, and provider protocol fixture tests) and prescribe concrete next coding tasks such as adding a bootstrap-state mapper and webview messaging for normalized bootstrap status. 
- No production code behavior changes are introduced; these are repository documentation and design artifacts intended to guide subsequent implementation work.

### Testing

- Ran markdown lint and the documentation build pipeline locally and in CI, and the docs lint/build steps completed without errors. 
- No unit/integration code tests were modified or required because the change only adds documentation artifacts. 
- The audit prescribes a list of automated tests to be added in follow-up work, and those test cases are enumerated in the new documents.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69cc61afc8b4832985188b60cc8aed18)