### PR TITLE
Prevent sending while offline and allow composing in ChatInput

### DIFF
--- a/extensions/ritemark/webview/src/components/ai-sidebar/ChatInput.tsx
+++ b/extensions/ritemark/webview/src/components/ai-sidebar/ChatInput.tsx
@@ -171,7 +171,7 @@ export function ChatInput() {
 
   const handleSend = useCallback(() => {
     const prompt = buildFinalPrompt();
-    if (!prompt || isLoading || (isCodex && codexStatus.state !== 'ready')) return;
+    if (!prompt || !isOnline || isLoading || (isCodex && codexStatus.state !== 'ready')) return;
 
     if (isCodex) {
       sendCodexMessage(prompt, attachments.length > 0 ? attachments : undefined);
@@ -190,7 +190,7 @@ export function ChatInput() {
     if (textareaRef.current) {
       textareaRef.current.style.height = 'auto';
     }
-  }, [buildFinalPrompt, attachments, isLoading, isClaudeCode, isCodex, codexStatus.state, hideActiveFile, sendAgentMessage, sendCodexMessage, sendChatMessage]);
+  }, [buildFinalPrompt, attachments, isOnline, isLoading, isClaudeCode, isCodex, codexStatus.state, hideActiveFile, sendAgentMessage, sendCodexMessage, sendChatMessage]);
 
   const clearChat = useAISidebarStore((s) => s.clearChat);
   const startNewConversation = useAISidebarStore((s) => s.startNewConversation);
@@ -793,7 +793,7 @@ export function ChatInput() {
           onKeyDown={handleKeyDown}
           onPaste={handlePaste}
           placeholder={placeholder}
-          disabled={isLoading || !isOnline}
+          disabled={isLoading}
           rows={1}
           className="flex-1 resize-none rounded px-2.5 py-1.5 leading-relaxed bg-[var(--vscode-input-background)] text-[var(--vscode-input-foreground)] border border-[var(--vscode-input-border)] outline-none focus:border-[var(--vscode-focusBorder)] disabled:opacity-50 disabled:cursor-not-allowed"
           style={{ fontSize: 'var(--chat-font-size, 13px)' }}


### PR DESCRIPTION
### Motivation
- Prevent attempts to send messages when the extension is offline to avoid errors and wasted agent requests.
- Allow users to keep composing messages while offline by not disabling the input textarea.
- Ensure the `handleSend` callback dependencies are correct to avoid stale closures.

### Description
- Added an `!isOnline` guard to the `handleSend` early-return so messages are not sent when offline (`if (!prompt || !isOnline || isLoading ...)`).
- Included `isOnline` in the `handleSend` `useCallback` dependency array to keep the callback up to date.
- Re-enabled the textarea while offline by removing `!isOnline` from the `disabled` prop so users can compose messages even when offline.

### Testing
- Ran the TypeScript build (`tsc`) and it completed successfully.
- Ran lint checks (`eslint`) and they passed without errors.
- Ran the automated unit test suite and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_69d34a69c53083299ae6d73a635fb3ea)