### PR TITLE
fix(theme): make gitignored Explorer entries readable

### DIFF
--- a/extensions/ritemark/themes/ritemark-dark.json
+++ b/extensions/ritemark/themes/ritemark-dark.json
@@ -197,7 +197,7 @@
 		"gitDecoration.addedResourceForeground": "#94a3b8",
 		"gitDecoration.deletedResourceForeground": "#64748b",
 		"gitDecoration.conflictingResourceForeground": "#f87171",
-		"gitDecoration.ignoredResourceForeground": "#475569",
+		"gitDecoration.ignoredResourceForeground": "#CBD5E1",
 		"gitDecoration.submoduleResourceForeground": "#475569",
 		"gitDecoration.stageModifiedResourceForeground": "#94a3b8",
 		"gitDecoration.stageDeletedResourceForeground": "#64748b"

--- a/extensions/ritemark/themes/ritemark-light.json
+++ b/extensions/ritemark/themes/ritemark-light.json
@@ -197,7 +197,7 @@
 		"gitDecoration.addedResourceForeground": "#64748b",
 		"gitDecoration.deletedResourceForeground": "#94a3b8",
 		"gitDecoration.conflictingResourceForeground": "#ef4444",
-		"gitDecoration.ignoredResourceForeground": "#cbd5e1",
+		"gitDecoration.ignoredResourceForeground": "#475569",
 		"gitDecoration.submoduleResourceForeground": "#cbd5e1",
 		"gitDecoration.stageModifiedResourceForeground": "#64748b",
 		"gitDecoration.stageDeletedResourceForeground": "#94a3b8"


### PR DESCRIPTION
## Summary
- `gitDecoration.ignoredResourceForeground` was nearly invisible: `#cbd5e1` (slate-300) on light, `#475569` (slate-600) on dark — whole gitignored subtrees (`docs-internal/`, `node_modules/`, build outputs) faded out of the Explorer.
- Match the value to `sideBar.foreground` in each theme so ignored files look identical to tracked ones; user prefers no visual distinction at all for ignored files.
- Light: `#cbd5e1` → `#475569`
- Dark:  `#475569` → `#CBD5E1`

No code, build, or patch changes — runtime theme JSON only.

## Test plan
- [x] JSON syntax valid in both theme files
- [x] Diff is exactly 2 files / 2 lines
- [x] New colors match `sideBar.foreground` in respective themes
- [ ] Reload Ritemark dev mode → confirm `docs-internal/`, `node_modules/`, build outputs render with the same tone as tracked files in both Light and Dark themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)