### PR TITLE
feat(agent-library): Phosphor icons and color palette for agent items

### DIFF
--- a/branding/ATTRIBUTION.md
+++ b/branding/ATTRIBUTION.md
@@ -1,0 +1,38 @@
+# Third-Party Attribution
+
+## Phosphor Icons
+
+Ritemark Native bundles a curated subset of [Phosphor Icons](https://phosphoricons.com)
+regular-weight SVG content in `extensions/ritemark/src/agent/iconPack.ts`.
+Phosphor is the only icon library used in Ritemark — see
+`.claude/skills/ritemark-design/references/iconography.md`.
+
+Phosphor is distributed under the MIT licence.
+
+### MIT Licence
+
+```
+MIT License
+
+Copyright (c) 2023 Phosphor Icons
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
+Source: <https://github.com/phosphor-icons/core/blob/main/LICENSE>

--- a/docs/development/sprints/sprint-61-agent-library-icons/sprint-plan.md
+++ b/docs/development/sprints/sprint-61-agent-library-icons/sprint-plan.md
@@ -1,0 +1,137 @@
+# Sprint 61 — Agent Library ikoonid ja värvid
+
+**Status:** Phase 3 — IMPLEMENT (started 2026-05-04)
+**Approval:** Jarmo confirmed plan in conversation 2026-05-04
+
+## Context
+
+Praegune Agent Library UI ([AgentLibraryViewProvider.ts](../../../../extensions/ritemark/src/views/AgentLibraryViewProvider.ts)) näeb välja nagu failipuu: monospace path'id (`.claude/agents/pr-reviewer.md`), ainult tekst, ei ole visuaalset hierarhiat. ChatGPT GPT store'i värvilised, ümarad ikoonid teevad agendi-nimekirja kohe sõbralikumaks ja "tootelikumaks" — kasutaja näeb ühe pilguga "see on review-tööriist" (sinine kontroll-linnukene) vs "see on disaini-tööriist" (lilla pintsel).
+
+**Eesmärk:** asendada praegune tekstipõhine list ikoon + nimi + kirjeldus rea struktuuriga; ikoon ja värv on agendi/skilli `.md` frontmatter'is; kui frontmatter'is pole, siis heuristika pakub vaikimisi. Skoop = ainult see üks UI surface.
+
+**Kasutaja valikud (kinnitatud):**
+- Stiil: **Phosphor ikoonid + värviline ümar chip-taust**
+- Storage: **agendi/skilli `.md` frontmatter** (`icon: clipboard-text`, `color: blue`)
+- Scope: **ainult Agent Library list**
+- Auto-pick: **jah** — nime/kirjelduse põhjal heuristika, kasutaja saab override'da frontmatter'is
+
+* * *
+
+## Ulatus
+
+| Sees | Väljas |
+|---|---|
+| Agent Library webview (üks fail) | VS Code statusbar, command palette, @-mention picker |
+| Frontmatter `icon` + `color` lugemine | UI ikoonivalija kasutajale (frontmatter editeerimine = manual) |
+| Auto-suggest heuristika | Custom-uploaded ikoonid, emoji backend |
+| ~32 curated Phosphor ikooni inline SVG | Phosphor kogu pakett (~1000 ikooni) |
+| 8 brand-värvi paletti | Vabavärvi picker |
+
+* * *
+
+## Disainiotsused
+
+### Ikoonisüsteem
+
+Inline SVG path'id JS-objektina otse webview HTML-is — **ei** lisa Phosphor npm-paketti, sest webview on string-template ja `AgentLibraryViewProvider.ts:376` ei ole bundlitud. ~32 ikooni × ~200B path = ~6KB lisa, vastuvõetav.
+
+**Curated set (33 ikooni, Phosphor regular weight 400):**
+
+| Kategooria | Ikoonid (Phosphor nimi) |
+|---|---|
+| Code/Build | `code`, `terminal-window`, `git-branch`, `package`, `wrench` |
+| Writing/Docs | `file-text`, `pen-nib`, `book-open`, `feather` |
+| Review/QA | `clipboard-text`, `shield-check`, `bug`, `magnifying-glass` |
+| Data/Analysis | `chart-bar`, `database`, `table`, `function` |
+| Design/UI | `palette`, `layout`, `sparkle`, `magic-wand` |
+| Communication | `chat-circle`, `megaphone`, `envelope`, `users` |
+| AI/Agents | `robot`, `brain`, `cpu`, `lightning` |
+| Productivity | `calendar-blank`, `target`, `flag`, `rocket-launch` |
+
+### Värvipalett (8)
+
+`indigo` (default), `blue`, `green`, `amber`, `red`, `purple`, `pink`, `slate` — joondatud `ritemark-design` tokens'iga. Iga värv = `{ bg, fg }` paar.
+
+### Frontmatter laiendus
+
+```yaml
+---
+name: pr-reviewer
+description: Reviews pull requests
+icon: clipboard-text     # optional — auto-pick fallback
+color: blue              # optional — auto-pick fallback
+---
+```
+
+Backwards compat: ilma `icon`/`color`'ita agendid saavad heuristika kaudu defaultid.
+
+### Auto-suggest heuristika
+
+| Keyword (nime või kirjelduse sees) | Ikoon | Värv |
+|---|---|---|
+| `review`, `validator`, `qa` | `clipboard-text` | blue |
+| `release`, `ship`, `deploy` | `rocket-launch` | green |
+| `sprint`, `plan`, `manager` | `flag` | amber |
+| `marketer`, `marketing`, `content` | `megaphone` | pink |
+| `ux`, `design`, `ui` | `palette` | purple |
+| `vscode`, `build`, `compile` | `wrench` | slate |
+| `webview`, `react`, `tiptap` | `layout` | indigo |
+| `flow`, `workflow` | `git-branch` | blue |
+| `feature-flag`, `flags` | `flag` | amber |
+| `knowledge`, `docs`, `skill` | `book-open` | indigo |
+| (default) | `sparkle` | indigo |
+
+CLAUDE.md (peaagent) saab `robot` + indigo. Praegune tärni-staatus (★) jääb eraldi badge'ina.
+
+### UI rida (uus layout)
+
+```
+[🟦 📖]  Knowledge Builder
+         Meta-agent for creating new Claude Code skills…
+```
+
+- Ikoonichip: 32×32px, border-radius 8px, värvitaust 12% opacity
+- Title: `font-weight: 500`
+- Description (frontmatter `description`): teine rida, väiksem, muted, truncate 2 reaga
+- Failipath → tooltip (hover) ja context menu Reveal
+- Star (★) ja Warning (⚠) badge'id rea paremas ääres
+
+* * *
+
+## Failid
+
+| Fail | Muudatus |
+|---|---|
+| `extensions/ritemark/src/agent/discovery.ts` | Loe `icon`, `color` frontmatter'ist; lisa väljad interface'idesse; kutsu `resolveIconAndColor()` |
+| `extensions/ritemark/src/agent/iconPack.ts` | **UUS** — ikooni-SVG-d, värvipalett, heuristika |
+| `extensions/ritemark/src/views/AgentLibraryViewProvider.ts` | Uus rea-template (chip + name + description); CSS lisad; SVG renderdus |
+| `branding/ATTRIBUTION.md` | Phosphor MIT attribution |
+
+* * *
+
+## Verifitseerimine
+
+1. `cd extensions/ritemark && yarn compile`
+2. `./scripts/code.sh` (vt `rundev` skill)
+3. Avage Agent Library sidebar:
+   - Iga rida näitab värvilist ikoonichip'i
+   - Hover ikoonil = tooltip näitab failipath'i
+   - Project tab projekti agentidega, User tab `~/.claude/` omadega
+   - Search töötab (nime + ID + path järgi)
+   - Star (★) CLAUDE.md peaagendil
+   - Warning (⚠) agendil ilma `description` frontmatter'ita
+4. Heuristika test:
+   - `pr-reviewer` ilma frontmatter'ita → clipboard-text + blue
+   - `release-manager` → rocket-launch + green
+   - `random-thing` → sparkle + indigo (default)
+5. Override test: lisa `icon: bug`, `color: red` → reload → red bug ikoon
+6. Theme test: light ↔ dark, kontrolli loetavust
+7. Performance: 12 agents + 7 skills = 19 SVG-d, ei tohi olla lag'i
+
+* * *
+
+## Riskid
+
+- **Phosphor path'ide kopeerimine käsitsi:** ~30 min käsitööd 32 ikooni jaoks. Alternatiiv (npm bundle) ei sobi sest webview pole bundlitud.
+- **Värvipalett:** kasutame hardcoded brand-värve (mitte VS Code teemamuutujaid), sest design language on Ritemark.
+- **Frontmatter validatsioon:** invaliidne `icon: nonexistent-name` → silent fallback auto-suggest'ile.

--- a/extensions/ritemark/src/agent/discovery.ts
+++ b/extensions/ritemark/src/agent/discovery.ts
@@ -8,6 +8,7 @@
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
+import { ColorName, IconName, resolveIconAndColor } from './iconPack';
 
 export type ItemScope = 'project' | 'user';
 
@@ -20,6 +21,8 @@ export interface DiscoveredAgent {
   hasFrontmatter: boolean;
   isMainAgent: boolean;
   modifiedAt: number;
+  icon: IconName;
+  color: ColorName;
 }
 
 export interface DiscoveredCommand {
@@ -31,6 +34,8 @@ export interface DiscoveredCommand {
   scope: ItemScope;
   hasFrontmatter: boolean;
   modifiedAt: number;
+  icon: IconName;
+  color: ColorName;
 }
 
 function safeMtime(filePath: string): number {
@@ -119,15 +124,19 @@ function discoverAgentsInRoot(claudeRoot: string, scope: ItemScope): DiscoveredA
     try {
       const content = fs.readFileSync(claudeMdPath, 'utf-8');
       const frontmatter = parseFrontmatter(content);
+      const description = frontmatter.description || 'Main agent configuration';
+      const { icon, color } = resolveIconAndColor(frontmatter, 'CLAUDE.md', description, true);
       agents.push({
         id: 'CLAUDE',
         name: 'CLAUDE.md',
-        description: frontmatter.description || 'Main agent configuration',
+        description,
         filePath: claudeMdPath,
         scope,
         hasFrontmatter: hasFrontmatterBlock(content),
         isMainAgent: true,
         modifiedAt: safeMtime(claudeMdPath),
+        icon,
+        color,
       });
     } catch {
       // Skip
@@ -148,6 +157,8 @@ function discoverAgentsInRoot(claudeRoot: string, scope: ItemScope): DiscoveredA
         const id = frontmatter.name || path.basename(file, '.md');
         const name = toDisplayName(id);
         const description = frontmatter.description || '';
+        const isMain = isClaudeMd(filePath);
+        const { icon, color } = resolveIconAndColor(frontmatter, name, description, isMain);
 
         agents.push({
           id,
@@ -156,8 +167,10 @@ function discoverAgentsInRoot(claudeRoot: string, scope: ItemScope): DiscoveredA
           filePath,
           scope,
           hasFrontmatter: hasFm && !!description,
-          isMainAgent: isClaudeMd(filePath),
+          isMainAgent: isMain,
           modifiedAt: safeMtime(filePath),
+          icon,
+          color,
         });
       } catch {
         // Skip files that can't be read
@@ -207,16 +220,21 @@ function discoverCommandsInRoot(claudeRoot: string, scope: ItemScope): Discovere
           const hasFm = hasFrontmatterBlock(content);
           const frontmatter = parseFrontmatter(content);
           const id = frontmatter.name || path.basename(file, '.md');
+          const displayName = toDisplayName(id);
+          const description = frontmatter.description || extractFirstLine(content);
+          const { icon, color } = resolveIconAndColor(frontmatter, displayName, description);
 
           commands.push({
             id,
-            name: toDisplayName(id),
-            description: frontmatter.description || extractFirstLine(content),
+            name: displayName,
+            description,
             source: 'commands',
             filePath,
             scope,
             hasFrontmatter: hasFm && !!(frontmatter.description),
             modifiedAt: safeMtime(filePath),
+            icon,
+            color,
           });
         } catch {
           // Skip
@@ -250,15 +268,21 @@ function discoverCommandsInRoot(claudeRoot: string, scope: ItemScope): Discovere
 
           if (frontmatter['user-invocable'] === 'false') continue;
 
+          const displayName = toDisplayName(id);
+          const description = frontmatter.description || extractFirstLine(content);
+          const { icon, color } = resolveIconAndColor(frontmatter, displayName, description);
+
           commands.push({
             id,
-            name: toDisplayName(id),
-            description: frontmatter.description || extractFirstLine(content),
+            name: displayName,
+            description,
             source: 'skills',
             filePath: skillFile,
             scope,
             hasFrontmatter: hasFm && !!(frontmatter.description),
             modifiedAt: safeMtime(skillFile),
+            icon,
+            color,
           });
         } catch {
           // Skip

--- a/extensions/ritemark/src/agent/iconPack.ts
+++ b/extensions/ritemark/src/agent/iconPack.ts
@@ -1,0 +1,161 @@
+/**
+ * Icon and color pack for the Agent Library UI.
+ *
+ * Inline Phosphor regular-weight icon SVGs (MIT licence — see branding/ATTRIBUTION.md).
+ * Phosphor is the only icon library used in Ritemark — see
+ * `.claude/skills/ritemark-design/references/iconography.md`.
+ *
+ * Colors use rgba alpha for backgrounds so they tint both light and dark themes.
+ */
+
+export type IconName =
+  | 'code' | 'terminal-window' | 'git-branch' | 'package' | 'wrench'
+  | 'file-text' | 'pen-nib' | 'book-open' | 'feather'
+  | 'clipboard-text' | 'shield-check' | 'bug' | 'magnifying-glass'
+  | 'chart-bar' | 'database' | 'table' | 'function'
+  | 'palette' | 'layout' | 'sparkle' | 'magic-wand'
+  | 'chat-circle' | 'megaphone' | 'envelope' | 'users'
+  | 'robot' | 'brain' | 'cpu' | 'lightning'
+  | 'calendar-blank' | 'target' | 'flag' | 'rocket-launch';
+
+export type ColorName =
+  | 'indigo' | 'blue' | 'green' | 'amber'
+  | 'red' | 'purple' | 'pink' | 'slate';
+
+export const DEFAULT_ICON: IconName = 'sparkle';
+export const DEFAULT_COLOR: ColorName = 'indigo';
+
+/** Native viewBox of Phosphor icons. */
+export const ICON_VIEWBOX = '0 0 256 256';
+
+/** Phosphor regular-weight icon contents (inner SVG only, no <svg> wrapper). */
+export const ICONS: Record<IconName, string> = {
+  'code': '<polyline points="64 88 16 128 64 168" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><polyline points="192 88 240 128 192 168" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="160" y1="40" x2="96" y2="216" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'terminal-window': '<polyline points="80 96 120 128 80 160" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="136" y1="160" x2="176" y2="160" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><rect x="32" y="48" width="192" height="160" rx="8" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'git-branch': '<path d="M80,168V144a16,16,0,0,1,16-16h88a16,16,0,0,0,16-16V88" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="80" y1="88" x2="80" y2="168" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><circle cx="80" cy="64" r="24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><circle cx="200" cy="64" r="24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><circle cx="80" cy="192" r="24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'package': '<line x1="128" y1="129.09" x2="128" y2="231.97" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><polyline points="32.7 76.92 128 129.08 223.3 76.92" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M219.84,182.84l-88,48.18a8,8,0,0,1-7.68,0l-88-48.18a8,8,0,0,1-4.16-7V80.18a8,8,0,0,1,4.16-7l88-48.18a8,8,0,0,1,7.68,0l88,48.18a8,8,0,0,1,4.16,7v95.64A8,8,0,0,1,219.84,182.84Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><polyline points="81.56 48.31 176 100 176 152" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'wrench': '<path d="M104,126.94a64,64,0,0,1,80-90.29L144,80l5.66,26.34L176,112l43.35-40a64,64,0,0,1-90.29,80L73,217A24,24,0,0,1,39,183Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'file-text': '<path d="M200,224H56a8,8,0,0,1-8-8V40a8,8,0,0,1,8-8h96l56,56V216A8,8,0,0,1,200,224Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><polyline points="152 32 152 88 208 88" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="96" y1="136" x2="160" y2="136" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="96" y1="168" x2="160" y2="168" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'pen-nib': '<circle cx="124" cy="132" r="20" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="40.01" y1="216" x2="109.86" y2="146.14" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M40,216l139.45-23.24a8,8,0,0,0,6.17-5.08L208,128,128,48,68.32,70.38a8,8,0,0,0-5.08,6.17Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M208,128l29.66-29.66a8,8,0,0,0,0-11.31L169,18.34a8,8,0,0,0-11.31,0L128,48" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'book-open': '<path d="M128,88a32,32,0,0,1,32-32h72V200H160a32,32,0,0,0-32,32" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M24,200H96a32,32,0,0,1,32,32V88A32,32,0,0,0,96,56H24Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'feather': '<line x1="184" y1="72" x2="32" y2="224" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M146.34,189.66a8,8,0,0,1-5.65,2.34H64V115.31a8,8,0,0,1,2.34-5.65L136.4,40.4a56,56,0,0,1,79.2,79.2Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="112" y1="64.52" x2="112" y2="144" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="136" y1="120" x2="215.2" y2="120" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'clipboard-text': '<line x1="96" y1="152" x2="160" y2="152" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="96" y1="120" x2="160" y2="120" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M160,40h40a8,8,0,0,1,8,8V216a8,8,0,0,1-8,8H56a8,8,0,0,1-8-8V48a8,8,0,0,1,8-8H96" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M88,72V64a40,40,0,0,1,80,0v8Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'shield-check': '<path d="M216,112V56a8,8,0,0,0-8-8H48a8,8,0,0,0-8,8v56c0,96,88,120,88,120S216,208,216,112Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><polyline points="88 136 112 160 168 104" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'bug': '<circle cx="156" cy="92" r="12"/><circle cx="100" cy="92" r="12"/><line x1="128" y1="128" x2="128" y2="224" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M208,144a80,80,0,0,1-160,0V112a80,80,0,0,1,160,0Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="232" y1="184" x2="203.18" y2="171.41" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="232" y1="72" x2="203.18" y2="84.59" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="24" y1="72" x2="52.82" y2="84.59" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="24" y1="184" x2="52.82" y2="171.41" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="16" y1="128" x2="240" y2="128" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'magnifying-glass': '<circle cx="112" cy="112" r="80" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="168.57" y1="168.57" x2="224" y2="224" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'chart-bar': '<polyline points="48 208 48 136 96 136" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="224" y1="208" x2="32" y2="208" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><polyline points="96 208 96 88 152 88" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><polyline points="152 208 152 40 208 40 208 208" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'database': '<ellipse cx="128" cy="80" rx="88" ry="48" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M40,80v48c0,26.51,39.4,48,88,48s88-21.49,88-48V80" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M40,128v48c0,26.51,39.4,48,88,48s88-21.49,88-48V128" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'table': '<path d="M32,56H224a0,0,0,0,1,0,0V192a8,8,0,0,1-8,8H40a8,8,0,0,1-8-8V56A0,0,0,0,1,32,56Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="32" y1="104" x2="224" y2="104" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="32" y1="152" x2="224" y2="152" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="88" y1="104" x2="88" y2="200" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'function': '<line x1="72" y1="128" x2="184" y2="128" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M56,216H85.29a32,32,0,0,0,31.49-26.28L139.22,66.28A32,32,0,0,1,170.71,40H200" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'palette': '<path d="M128,192a24,24,0,0,1,24-24h46.21a24,24,0,0,0,23.4-18.65A96.48,96.48,0,0,0,224,127.17c-.45-52.82-44.16-95.7-97-95.17a96,96,0,0,0-95,96c0,41.81,26.73,73.44,64,86.61A24,24,0,0,0,128,192Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><circle cx="128" cy="76" r="12"/><circle cx="84" cy="100" r="12"/><circle cx="84" cy="156" r="12"/><circle cx="172" cy="100" r="12"/>',
+  'layout': '<line x1="104" y1="104" x2="104" y2="208" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="32" y1="104" x2="224" y2="104" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><rect x="32" y="48" width="192" height="160" rx="8" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'sparkle': '<path d="M84.27,171.73l-55.09-20.3a7.92,7.92,0,0,1,0-14.86l55.09-20.3,20.3-55.09a7.92,7.92,0,0,1,14.86,0l20.3,55.09,55.09,20.3a7.92,7.92,0,0,1,0,14.86l-55.09,20.3-20.3,55.09a7.92,7.92,0,0,1-14.86,0Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="176" y1="16" x2="176" y2="64" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="224" y1="72" x2="224" y2="104" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="152" y1="40" x2="200" y2="40" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="208" y1="88" x2="240" y2="88" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'magic-wand': '<line x1="216" y1="128" x2="216" y2="176" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="192" y1="152" x2="240" y2="152" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="80" y1="40" x2="80" y2="88" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="56" y1="64" x2="104" y2="64" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="168" y1="184" x2="168" y2="216" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="152" y1="200" x2="184" y2="200" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="144" y1="80" x2="176" y2="112" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><rect x="21.49" y="105.37" width="213.02" height="45.25" rx="8" transform="translate(-53.02 128) rotate(-45)" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'chat-circle': '<path d="M79.93,211.11a96,96,0,1,0-35-35h0L32.42,213.46a8,8,0,0,0,10.12,10.12l37.39-12.47Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'megaphone': '<path d="M160,80V200.67a8,8,0,0,0,3.56,6.65l11,7.33a8,8,0,0,0,12.2-4.72L200,160" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M40,200a8,8,0,0,0,13.15,6.12C105.55,162.16,160,160,160,160h40a40,40,0,0,0,0-80H160S105.55,77.84,53.15,33.89A8,8,0,0,0,40,40Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'envelope': '<polyline points="224 56 128 144 32 56" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M32,56H224a0,0,0,0,1,0,0V192a8,8,0,0,1-8,8H40a8,8,0,0,1-8-8V56A0,0,0,0,1,32,56Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="110.55" y1="128" x2="34.47" y2="197.74" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="221.53" y1="197.74" x2="145.45" y2="128" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'users': '<circle cx="84" cy="108" r="52" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M10.23,200a88,88,0,0,1,147.54,0" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M172,160a87.93,87.93,0,0,1,73.77,40" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M152.69,59.7A52,52,0,1,1,172,160" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'robot': '<rect x="32" y="56" width="192" height="160" rx="24" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><rect x="72" y="144" width="112" height="40" rx="20" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="148" y1="144" x2="148" y2="184" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="108" y1="144" x2="108" y2="184" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="128" y1="56" x2="128" y2="16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><circle cx="84" cy="108" r="12"/><circle cx="172" cy="108" r="12"/>',
+  'brain': '<path d="M88,136a40,40,0,1,1-40,40v-6.73" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M168,136a40,40,0,1,0,40,40v-6.73" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M72,172H64A48,48,0,0,1,48,78.73V72a40,40,0,0,1,80,0V176" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M184,172h8a48,48,0,0,0,16-93.27V72a40,40,0,0,0-80,0" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M200,112h-4a28,28,0,0,1-28-28V80" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M56,112h4A28,28,0,0,0,88,84V80" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'cpu': '<rect x="104" y="104" width="48" height="48" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><rect x="48" y="48" width="160" height="160" rx="8" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="208" y1="104" x2="232" y2="104" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="208" y1="152" x2="232" y2="152" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="24" y1="104" x2="48" y2="104" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="24" y1="152" x2="48" y2="152" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="152" y1="208" x2="152" y2="232" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="104" y1="208" x2="104" y2="232" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="152" y1="24" x2="152" y2="48" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="104" y1="24" x2="104" y2="48" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'lightning': '<polygon points="160 16 144 96 208 120 96 240 112 160 48 136 160 16" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'calendar-blank': '<rect x="40" y="40" width="176" height="176" rx="8" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="176" y1="24" x2="176" y2="56" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="80" y1="24" x2="80" y2="56" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><line x1="40" y1="88" x2="216" y2="88" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'target': '<line x1="128" y1="128" x2="224" y2="32" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M195.88,60.12a95.88,95.88,0,1,0,18.77,26.49" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M161.94,94.06a48,48,0,1,0,14,31.2" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'flag': '<line x1="48" y1="224" x2="48" y2="56" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M48,176c64-55.43,112,55.43,176,0V56C160,111.43,112,.57,48,56" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+  'rocket-launch': '<path d="M191.11,112.89c24-24,25.5-52.55,24.75-65.28a8,8,0,0,0-7.47-7.47c-12.73-.75-41.26.73-65.28,24.75L80,128l48,48Z" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M136,72H74.35a8,8,0,0,0-5.65,2.34L34.35,108.69a8,8,0,0,0,4.53,13.57L80,128" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M184,120v61.65a8,8,0,0,1-2.34,5.65l-34.35,34.35a8,8,0,0,1-13.57-4.53L128,176" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/><path d="M94.56,187.82C90.69,196.31,77.65,216,40,216c0-37.65,19.69-50.69,28.18-54.56" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="16"/>',
+};
+
+/** Color palette: { bg, fg } pairs. bg uses rgba alpha so it works in light & dark themes. */
+export const COLORS: Record<ColorName, { bg: string; fg: string }> = {
+  indigo: { bg: 'rgba(99, 102, 241, 0.15)',  fg: '#6366f1' },
+  blue:   { bg: 'rgba(59, 130, 246, 0.15)',  fg: '#3b82f6' },
+  green:  { bg: 'rgba(16, 185, 129, 0.15)',  fg: '#10b981' },
+  amber:  { bg: 'rgba(245, 158, 11, 0.18)',  fg: '#d97706' },
+  red:    { bg: 'rgba(239, 68, 68, 0.15)',   fg: '#ef4444' },
+  purple: { bg: 'rgba(168, 85, 247, 0.15)',  fg: '#a855f7' },
+  pink:   { bg: 'rgba(236, 72, 153, 0.15)',  fg: '#ec4899' },
+  slate:  { bg: 'rgba(100, 116, 139, 0.18)', fg: '#64748b' },
+};
+
+interface HeuristicRule {
+  keywords: string[];
+  icon: IconName;
+  color: ColorName;
+}
+
+/** Keyword heuristics; first match wins, order matters (more specific first). */
+const HEURISTICS: HeuristicRule[] = [
+  { keywords: ['review', 'validator', 'qa'], icon: 'clipboard-text', color: 'blue' },
+  { keywords: ['release', 'ship', 'deploy', 'publish'], icon: 'rocket-launch', color: 'green' },
+  { keywords: ['marketer', 'marketing', 'content', 'pr ', 'press'], icon: 'megaphone', color: 'pink' },
+  { keywords: ['ux', 'design', 'ui'], icon: 'palette', color: 'purple' },
+  { keywords: ['vscode', 'build', 'compile'], icon: 'wrench', color: 'slate' },
+  { keywords: ['webview', 'react', 'tiptap', 'editor'], icon: 'layout', color: 'indigo' },
+  { keywords: ['flow', 'workflow', 'pipeline'], icon: 'git-branch', color: 'blue' },
+  { keywords: ['feature-flag', 'flags'], icon: 'flag', color: 'amber' },
+  { keywords: ['sprint', 'plan', 'manager'], icon: 'flag', color: 'amber' },
+  { keywords: ['knowledge', 'docs', 'skill'], icon: 'book-open', color: 'indigo' },
+  { keywords: ['security', 'audit'], icon: 'shield-check', color: 'green' },
+  { keywords: ['debug', 'bug', 'fix'], icon: 'bug', color: 'red' },
+  { keywords: ['test'], icon: 'magnifying-glass', color: 'green' },
+  { keywords: ['data', 'analytics', 'metrics'], icon: 'chart-bar', color: 'blue' },
+  { keywords: ['ai', 'agent', 'llm'], icon: 'robot', color: 'indigo' },
+  { keywords: ['terminal', 'shell', 'cli'], icon: 'terminal-window', color: 'slate' },
+  { keywords: ['code', 'refactor'], icon: 'code', color: 'blue' },
+];
+
+function isIconName(value: string): value is IconName {
+  return Object.prototype.hasOwnProperty.call(ICONS, value);
+}
+
+function isColorName(value: string): value is ColorName {
+  return Object.prototype.hasOwnProperty.call(COLORS, value);
+}
+
+/** Suggest an icon + color from the agent name and description. */
+export function autoSuggest(name: string, description: string): { icon: IconName; color: ColorName } {
+  const haystack = `${name} ${description}`.toLowerCase();
+  for (const rule of HEURISTICS) {
+    for (const kw of rule.keywords) {
+      if (haystack.includes(kw)) {
+        return { icon: rule.icon, color: rule.color };
+      }
+    }
+  }
+  return { icon: DEFAULT_ICON, color: DEFAULT_COLOR };
+}
+
+/**
+ * Resolve final icon + color for an item. Frontmatter wins; invalid values
+ * silently fall back to auto-suggest. CLAUDE.md gets a robot/indigo default.
+ */
+export function resolveIconAndColor(
+  frontmatter: Record<string, string>,
+  name: string,
+  description: string,
+  isMainAgent = false,
+): { icon: IconName; color: ColorName } {
+  const fmIcon = frontmatter.icon?.trim();
+  const fmColor = frontmatter.color?.trim();
+
+  let icon: IconName | undefined;
+  let color: ColorName | undefined;
+
+  if (fmIcon && isIconName(fmIcon)) icon = fmIcon;
+  if (fmColor && isColorName(fmColor)) color = fmColor;
+
+  if (icon && color) return { icon, color };
+
+  if (isMainAgent) {
+    return { icon: icon ?? 'robot', color: color ?? 'indigo' };
+  }
+
+  const suggested = autoSuggest(name, description);
+  return { icon: icon ?? suggested.icon, color: color ?? suggested.color };
+}
+
+/** Render an inline SVG string for the given icon. */
+export function renderIconSvg(icon: IconName, sizePx = 18): string {
+  const inner = ICONS[icon] ?? ICONS[DEFAULT_ICON];
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="${sizePx}" height="${sizePx}" viewBox="${ICON_VIEWBOX}" aria-hidden="true">${inner}</svg>`;
+}

--- a/extensions/ritemark/src/views/AgentLibraryViewProvider.ts
+++ b/extensions/ritemark/src/views/AgentLibraryViewProvider.ts
@@ -4,6 +4,7 @@ import * as os from 'os';
 import * as path from 'path';
 import { discoverAgents, discoverCommands } from '../agent/discovery';
 import type { DiscoveredAgent, DiscoveredCommand, ItemScope } from '../agent/discovery';
+import { COLORS, ICONS } from '../agent/iconPack';
 
 type HelperType = 'skill' | 'agent';
 
@@ -510,8 +511,8 @@ export class AgentLibraryViewProvider implements vscode.WebviewViewProvider {
 
     /* === List items === */
     .item {
-      display: flex; align-items: flex-start;
-      padding: 8px 12px 8px 20px;
+      display: flex; align-items: flex-start; gap: 10px;
+      padding: 8px 12px 8px 14px;
       cursor: pointer;
       border-left: 2px solid transparent;
       transition: background-color 0.1s;
@@ -522,23 +523,62 @@ export class AgentLibraryViewProvider implements vscode.WebviewViewProvider {
       border-left-color: var(--r-accent);
     }
     .item.selected .item-name { font-weight: 600; }
-    .item-content { flex: 1; min-width: 0; }
+    .item-icon-chip {
+      flex-shrink: 0;
+      width: 32px; height: 32px;
+      display: inline-flex; align-items: center; justify-content: center;
+      border-radius: 8px;
+      margin-top: 1px;
+    }
+    .item-icon-chip svg {
+      width: 18px; height: 18px;
+      display: block;
+    }
+    .item-content { flex: 1; min-width: 0; padding-top: 1px; }
     .item-name {
-      font-size: 13px; font-weight: 500; line-height: 1.4;
+      font-size: 13px; font-weight: 500; line-height: 1.35;
       overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
     }
-    .item-path {
+    .item-description {
       font-size: 11px; color: var(--r-ink-muted);
-      overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
-      margin-top: 3px;
+      line-height: 1.4;
+      margin-top: 2px;
+      overflow: hidden;
+      display: -webkit-box;
+      -webkit-line-clamp: 2;
+      -webkit-box-orient: vertical;
+      word-break: break-word;
     }
-    .item-path.has-warning { color: #F59E0B; }
+    .item-description.placeholder { font-style: italic; opacity: 0.65; }
     .item-icon {
-      flex-shrink: 0; margin-left: 6px; margin-top: 3px;
+      flex-shrink: 0; margin-left: 6px; margin-top: 6px;
       font-size: 11px; line-height: 1;
     }
     .item-icon.star { color: var(--r-accent); }
     .item-icon.warning { color: #F59E0B; cursor: help; }
+    .item-more-btn {
+      flex-shrink: 0;
+      width: 22px; height: 22px;
+      margin-left: 4px;
+      margin-top: 4px;
+      display: inline-flex; align-items: center; justify-content: center;
+      border-radius: 4px;
+      background: transparent;
+      border: none;
+      padding: 0;
+      cursor: pointer;
+      color: var(--r-ink-muted);
+      opacity: 0;
+      transition: opacity 0.1s, background-color 0.1s, color 0.1s;
+    }
+    .item:hover .item-more-btn,
+    .item.selected .item-more-btn,
+    .item-more-btn.menu-open { opacity: 1; }
+    .item-more-btn:hover {
+      background: var(--r-accent-soft);
+      color: var(--r-accent);
+    }
+    .item-more-btn svg { width: 14px; height: 14px; display: block; }
     .item-hint {
       font-size: 10px; line-height: 1.3;
       color: #F59E0B; padding: 2px 0 0; opacity: 0.85;
@@ -739,6 +779,21 @@ export class AgentLibraryViewProvider implements vscode.WebviewViewProvider {
   <script nonce="${nonce}">
     const vscode = acquireVsCodeApi();
 
+    const ICON_PATHS = ${JSON.stringify(ICONS)};
+    const ICON_COLORS = ${JSON.stringify(COLORS)};
+    const DEFAULT_ICON = 'sparkle';
+    const DEFAULT_COLOR = 'indigo';
+
+    function renderIconChip(iconName, colorName) {
+      const path = ICON_PATHS[iconName] || ICON_PATHS[DEFAULT_ICON];
+      const palette = ICON_COLORS[colorName] || ICON_COLORS[DEFAULT_COLOR];
+      const style = 'background:' + palette.bg + ';color:' + palette.fg + ';';
+      return '<span class="item-icon-chip" style="' + style + '" aria-hidden="true">' +
+        '<svg viewBox="0 0 256 256">' +
+        path +
+        '</svg></span>';
+    }
+
     let agents = [];
     let skills = [];
     let commands = [];
@@ -859,7 +914,7 @@ export class AgentLibraryViewProvider implements vscode.WebviewViewProvider {
     }
 
     // === Context menu ===
-    function showContextMenu(x, y, item) {
+    function showContextMenu(x, y, item, alignRightX) {
       const isMainAgent = !!item.isMainAgent;
       const itemScope = item.scope;
       const moveLabel = itemScope === 'project' ? 'Move to User scope' : 'Move to Project scope';
@@ -899,10 +954,12 @@ export class AgentLibraryViewProvider implements vscode.WebviewViewProvider {
       contextMenuEl.style.top = y + 'px';
       contextMenuEl.classList.add('open');
 
-      // Adjust if it would overflow viewport
+      // Adjust if it would overflow viewport, or right-align to a given anchor
       requestAnimationFrame(() => {
         const rect = contextMenuEl.getBoundingClientRect();
-        if (rect.right > window.innerWidth - 4) {
+        if (typeof alignRightX === 'number') {
+          contextMenuEl.style.left = Math.max(4, alignRightX - rect.width) + 'px';
+        } else if (rect.right > window.innerWidth - 4) {
           contextMenuEl.style.left = Math.max(4, window.innerWidth - rect.width - 4) + 'px';
         }
         if (rect.bottom > window.innerHeight - 4) {
@@ -968,10 +1025,12 @@ export class AgentLibraryViewProvider implements vscode.WebviewViewProvider {
     function matches(item) {
       if (!filter) return true;
       const rel = displayPath(item);
+      const desc = (item.description || '').toLowerCase();
       return (
         item.name.toLowerCase().includes(filter) ||
         item.id.toLowerCase().includes(filter) ||
-        rel.toLowerCase().includes(filter)
+        rel.toLowerCase().includes(filter) ||
+        desc.includes(filter)
       );
     }
 
@@ -1054,12 +1113,16 @@ export class AgentLibraryViewProvider implements vscode.WebviewViewProvider {
         const main = !!item.isMainAgent;
         const warn = !main && !item.hasFrontmatter;
         const rel = displayPath(item);
-        html += '<div class="item' + sel + '" data-filepath="' + escapeHtml(item.filePath) + '">';
+        const desc = (item.description || '').trim();
+        const descText = desc || (main ? 'Main agent configuration' : 'No description in frontmatter');
+        const descClass = desc ? 'item-description' : 'item-description placeholder';
+        html += '<div class="item' + sel + '" data-filepath="' + escapeHtml(item.filePath) + '" title="' + escapeHtml(rel) + '">';
+        html += renderIconChip(item.icon, item.color);
         html += '<div class="item-content">';
         html += '<div class="item-name">' + escapeHtml(item.name) + '</div>';
-        html += '<div class="item-path' + (warn ? ' has-warning' : '') + '">' + escapeHtml(rel) + '</div>';
+        html += '<div class="' + descClass + '">' + escapeHtml(descText) + '</div>';
         if (warn) {
-          html += '<div class="item-hint">Add a description in frontmatter — open file and click ⓘ</div>';
+          html += '<div class="item-hint">Add a description in frontmatter — open file and click \\u24D8</div>';
         }
         html += '</div>';
         if (main) {
@@ -1067,6 +1130,10 @@ export class AgentLibraryViewProvider implements vscode.WebviewViewProvider {
         } else if (warn) {
           html += '<span class="item-icon warning" title="Missing or empty description field in frontmatter.">\\u26A0</span>';
         }
+        html += '<button class="item-more-btn" data-more="1" title="More actions" aria-label="More actions">' +
+          '<svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">' +
+          '<circle cx="12" cy="12" r="1" /><circle cx="19" cy="12" r="1" /><circle cx="5" cy="12" r="1" />' +
+          '</svg></button>';
         html += '</div>';
       }
       return html;
@@ -1083,7 +1150,8 @@ export class AgentLibraryViewProvider implements vscode.WebviewViewProvider {
 
     function wireRowHandlers() {
       contentEl.querySelectorAll('.item').forEach((el) => {
-        el.addEventListener('click', () => {
+        el.addEventListener('click', (e) => {
+          if (e.target && e.target.closest && e.target.closest('.item-more-btn')) return;
           const fp = el.dataset.filepath;
           if (!fp) return;
           selectedPath = fp;
@@ -1098,6 +1166,19 @@ export class AgentLibraryViewProvider implements vscode.WebviewViewProvider {
           if (!item) return;
           showContextMenu(e.clientX, e.clientY, item);
         });
+        const moreBtn = el.querySelector('.item-more-btn');
+        if (moreBtn) {
+          moreBtn.addEventListener('click', (e) => {
+            e.stopPropagation();
+            e.preventDefault();
+            const fp = el.dataset.filepath;
+            if (!fp) return;
+            const item = findItemByFilePath(fp);
+            if (!item) return;
+            const rect = moreBtn.getBoundingClientRect();
+            showContextMenu(rect.right, rect.bottom + 2, item, rect.right);
+          });
+        }
       });
     }
 


### PR DESCRIPTION
## Summary
- New `iconPack` module bundles 33 Phosphor regular-weight icons + 8 brand colors inline in the Agent Library webview
- Frontmatter `icon` / `color` per-item overrides; sensible auto-suggest heuristics for legacy agents
- Replaced file-path-as-second-line layout with icon chip + name + description; file path moves to tooltip
- Hover "more" button opens the same context menu as right-click, anchored to button's right edge
- Search now also matches description text

Closes sprint 61.

## Test plan
- [x] `yarn compile` clean
- [x] `.claude/hooks/pre-commit-validator.sh` passes
- [x] qa-validator gate green
- [x] Manual UX in dev mode (Jarmo): icons render, hover tooltip, search, context menu, more-button alignment all work
- [ ] Light/dark theme contrast spot check post-merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)
