### PR TITLE
feat: enable marketplace GitHub Copilot support

### DIFF
--- a/branding/product.json
+++ b/branding/product.json
@@ -77,9 +77,6 @@
     "github-enterprise": [
       "github.copilot",
       "github.copilot-chat"
-    ],
-    "microsoft": [
-      "github.copilot-chat"
     ]
   },
   "extensionEnabledApiProposals": {

--- a/branding/product.json
+++ b/branding/product.json
@@ -4,6 +4,148 @@
   "applicationName": "ritemark",
   "ritemarkVersion": "1.7.1",
   "builtInExtensionsEnabledWithAutoUpdates": [],
+  "defaultChatAgent": {
+    "providerExtensionId": "vscode.github-authentication",
+    "extensionId": "GitHub.copilot",
+    "chatExtensionId": "GitHub.copilot-chat",
+    "chatExtensionOutputId": "GitHub.copilot-chat.GitHub Copilot Chat.log",
+    "chatExtensionOutputExtensionStateCommand": "github.copilot.debug.extensionState",
+    "documentationUrl": "https://aka.ms/github-copilot-overview",
+    "termsStatementUrl": "https://aka.ms/github-copilot-terms-statement",
+    "privacyStatementUrl": "https://aka.ms/github-copilot-privacy-statement",
+    "skusDocumentationUrl": "https://aka.ms/github-copilot-plans",
+    "publicCodeMatchesUrl": "https://aka.ms/github-copilot-match-public-code",
+    "manageSettingsUrl": "https://aka.ms/github-copilot-settings",
+    "managePlanUrl": "https://aka.ms/github-copilot-manage-plan",
+    "manageOverageUrl": "https://aka.ms/github-copilot-manage-overage",
+    "upgradePlanUrl": "https://aka.ms/github-copilot-upgrade-plan",
+    "signUpUrl": "https://aka.ms/github-sign-up",
+    "provider": {
+      "default": {
+        "id": "github",
+        "name": "GitHub"
+      },
+      "enterprise": {
+        "id": "github-enterprise",
+        "name": "GHE.com"
+      },
+      "google": {
+        "id": "google",
+        "name": "Google"
+      },
+      "apple": {
+        "id": "apple",
+        "name": "Apple"
+      }
+    },
+    "providerUriSetting": "github-enterprise.uri",
+    "providerScopes": [
+      [
+        "read:user",
+        "user:email",
+        "repo",
+        "workflow"
+      ],
+      [
+        "user:email"
+      ],
+      [
+        "read:user"
+      ]
+    ],
+    "entitlementUrl": "https://api.github.com/copilot_internal/user",
+    "entitlementSignupLimitedUrl": "https://api.github.com/copilot_internal/subscribe_limited_user",
+    "chatQuotaExceededContext": "github.copilot.chat.quotaExceeded",
+    "completionsQuotaExceededContext": "github.copilot.completions.quotaExceeded",
+    "walkthroughCommand": "github.copilot.open.walkthrough",
+    "completionsMenuCommand": "github.copilot.toggleStatusMenu",
+    "completionsRefreshTokenCommand": "github.copilot.signIn",
+    "chatRefreshTokenCommand": "github.copilot.refreshToken",
+    "generateCommitMessageCommand": "github.copilot.git.generateCommitMessage",
+    "resolveMergeConflictsCommand": "github.copilot.git.resolveMergeConflicts",
+    "completionsAdvancedSetting": "github.copilot.advanced",
+    "completionsEnablementSetting": "github.copilot.enable",
+    "nextEditSuggestionsSetting": "github.copilot.nextEditSuggestions.enabled",
+    "tokenEntitlementUrl": "https://api.github.com/copilot_internal/v2/token",
+    "mcpRegistryDataUrl": "https://api.github.com/copilot/mcp_registry"
+  },
+  "trustedExtensionAuthAccess": {
+    "github": [
+      "github.copilot",
+      "github.copilot-chat"
+    ],
+    "github-enterprise": [
+      "github.copilot",
+      "github.copilot-chat"
+    ],
+    "microsoft": [
+      "github.copilot-chat"
+    ]
+  },
+  "extensionEnabledApiProposals": {
+    "github.copilot-chat": [
+      "agentSessionsWorkspace",
+      "chatDebug",
+      "chatHooks",
+      "extensionsAny",
+      "newSymbolNamesProvider",
+      "interactive",
+      "codeActionAI",
+      "activeComment",
+      "commentReveal",
+      "contribCommentThreadAdditionalMenu",
+      "contribCommentsViewThreadMenus",
+      "contribChatEditorInlineGutterMenu",
+      "documentFiltersExclusive",
+      "embeddings",
+      "findTextInFiles",
+      "findTextInFiles2",
+      "languageModelToolSupportsModel",
+      "findFiles2",
+      "textSearchProvider",
+      "terminalDataWriteEvent",
+      "terminalExecuteCommandEvent",
+      "terminalSelection",
+      "terminalQuickFixProvider",
+      "mappedEditsProvider",
+      "aiRelatedInformation",
+      "aiSettingsSearch",
+      "chatParticipantAdditions",
+      "defaultChatParticipant",
+      "contribSourceControlInputBoxMenu",
+      "authLearnMore",
+      "testObserver",
+      "aiTextSearchProvider",
+      "chatParticipantPrivate",
+      "chatProvider",
+      "contribDebugCreateConfiguration",
+      "chatReferenceDiagnostic",
+      "textSearchProvider2",
+      "chatReferenceBinaryData",
+      "languageModelSystem",
+      "languageModelCapabilities",
+      "inlineCompletionsAdditions",
+      "chatStatusItem",
+      "taskProblemMatcherStatus",
+      "contribLanguageModelToolSets",
+      "textDocumentChangeReason",
+      "resolvers",
+      "taskExecutionTerminal",
+      "dataChannels",
+      "languageModelThinkingPart",
+      "chatSessionsProvider",
+      "devDeviceId",
+      "contribEditorContentMenu",
+      "chatPromptFiles",
+      "mcpServerDefinitions",
+      "tabInputMultiDiff",
+      "workspaceTrust",
+      "environmentPower",
+      "terminalTitle",
+      "toolInvocationApproveCombination",
+      "chatSessionCustomizationProvider"
+    ]
+  },
   "posthogProjectApiKey": "phc_DEkVFsXXTFVZjCrlIHO51GeShdHU8YIXOZmCHy4XIAQ",
   "posthogHost": "https://eu.i.posthog.com",
   "dataFolderName": ".ritemark",

--- a/docs/development/sprints/sprint-71-github-copilot-support/research/copilot-support-audit.md
+++ b/docs/development/sprints/sprint-71-github-copilot-support/research/copilot-support-audit.md
@@ -361,7 +361,7 @@ Option 1 is now the selected and implemented path for the first validation pass.
 Implemented:
 
 - Added Copilot compatibility metadata to `branding/product.json` using the local installed VS Code product defaults as the source for `defaultChatAgent`.
-- Added provider-scoped trusted auth access for `github.copilot` and `github.copilot-chat`.
+- Added GitHub/GHE-scoped trusted auth access for `github.copilot` and `github.copilot-chat`.
 - Added `extensionEnabledApiProposals["github.copilot-chat"]` with the 60 proposals declared by the local VS Code 1.117 Copilot Chat package.
 - Verified all 60 proposal names exist in the local VS Code proposal registry.
 - Changed Ritemark defaults so Marketplace-installed Copilot is not disabled by default:

--- a/docs/development/sprints/sprint-71-github-copilot-support/research/copilot-support-audit.md
+++ b/docs/development/sprints/sprint-71-github-copilot-support/research/copilot-support-audit.md
@@ -1,0 +1,430 @@
+# GitHub Copilot Support Audit
+
+Date: 2026-05-18  
+Branch: `codex/sprint-71-github-copilot-support`  
+Issue: [#68](https://github.com/ProductoryHQ/ritemark-native/issues/68)
+
+## Executive Summary
+
+GitHub Copilot support is currently blocked by multiple intentional Ritemark choices, not by a single bug.
+
+The product decision is **Marketplace-installed Copilot first**, including Copilot Chat in the same sprint. Ritemark should not bundle Copilot in this sprint, and should not add a separate user-facing Copilot setting. Marketplace install/uninstall is the user's control surface.
+
+The highest-confidence implementation path is still **not** to broadly restore VS Code Chat. The safer path is:
+
+1. keep current Ritemark AI surfaces as the default;
+2. enable enough Copilot product metadata, auth, and proposed API allow-listing for a Marketplace-installed extension;
+3. restore only the core Chat view registration required for Copilot Chat to open;
+4. keep setup/status/titlebar/command-center takeover surfaces suppressed;
+5. validate inline completions and Copilot Chat together;
+6. allow Copilot Chat Activity Bar / Auxiliary Bar access only if it lives beside `ritemark-ai`, never over it.
+
+## Current Blockers
+
+### 1. Production builds remove bundled Copilot
+
+`scripts/build-prod.sh` removes the bundled VS Code 1.117 `extensions/copilot` directory:
+
+```sh
+for unwanted_ext in copilot mermaid-chat-features; do
+  rm -rf "$EXTENSIONS_DIR/$unwanted_ext"
+done
+```
+
+The script comment says Copilot polluted the activity bar with a "Chat Debug" item and injected chat tools Ritemark does not use.
+
+`scripts/build-windows-local.ps1` does the same:
+
+```powershell
+$copilotExt = Join-Path $BuildOut "resources\app\extensions\copilot"
+Remove-Item -Recurse -Force $copilotExt
+```
+
+Implication: a production Ritemark build cannot use bundled Copilot unless this removal becomes conditional or is reversed.
+
+### 2. Ritemark defaults disable Copilot and Chat
+
+`extensions/ritemark/package.json` sets:
+
+```json
+"chat.commandCenter.enabled": false,
+"chat.agent.enabled": false,
+"github.copilot.enable": { "*": false },
+"github.copilot.editor.enableAutoCompletions": false,
+"github.copilot.editor.enableCodeActions": false
+```
+
+Implication: even if Copilot is installed, default settings suppress its core editor behavior.
+
+### 3. Ritemark product metadata omits Copilot auth wiring
+
+`branding/product.json` and generated `vscode/product.json` currently have:
+
+```json
+"defaultChatAgent": null,
+"builtInExtensions": [],
+"builtInExtensionsEnabledWithAutoUpdates": []
+```
+
+The local upstream Copilot Chat docs say Code OSS-style builds need:
+
+- `trustedExtensionAuthAccess.github = ["github.copilot-chat"]`
+- a populated `defaultChatAgent` entry with `extensionId: "GitHub.copilot"` and `chatExtensionId: "GitHub.copilot-chat"`
+
+The docs also list entitlement URLs, provider scopes, and commands such as `github.copilot.signIn` / `github.copilot.refreshToken`.
+
+Implication: auth/sign-in may fail or degrade until product metadata is restored or replaced with an equivalent Ritemark-specific path.
+
+### 4. Patch 003 disables upstream chat UI
+
+`patches/vscode/003-ritemark-menu-cleanup.patch` changes the upstream chat view registration:
+
+- chat container no longer default in the auxiliary bar;
+- `ChatViewPane` registration is effectively disabled with `when: ContextKeyExpr.equals('ritemark.chatDisabled', 'true')`;
+- chat status bar entry is disposed instead of shown;
+- several `defaultChatAgent` references are made optional;
+- command-center/titlebar chat entry points are removed.
+
+This was correct for Ritemark's existing AI sidebar, but it means Copilot Chat cannot be assumed to work by simply installing the extension.
+
+### 5. Patch 007 disables VS Code 1.117 chat setup contributions
+
+`patches/vscode/007-ritemark-vscode-1117-compat.patch` disables:
+
+- `ChatSetupContribution`
+- `ChatTeardownContribution`
+
+Reason in the patch: these contributions add a chat icon with setup badge to the activity bar even when chat views are disabled.
+
+Implication: Copilot's normal first-run setup UI may be missing unless we provide a contained replacement path.
+
+### 6. Build CSS hides Copilot/Chat activity bar items
+
+`scripts/build-prod.sh` appends CSS hiding:
+
+```css
+.activitybar .action-item a[class*="workbench-panel-chat"] { display: none !important; }
+.activitybar .action-item a[class*="copilot-chat"] { display: none !important; }
+```
+
+Implication: even if a view leaks through, production CSS may make the UI unreachable.
+
+### 7. Bundled Copilot is not a tiny extension
+
+Local VS Code 1.117 has `vscode/extensions/copilot/package.json`:
+
+- name: `copilot-chat`
+- publisher: `GitHub`
+- version: `0.45.0`
+- activation: `onStartupFinished`, `onLanguageModelChat:copilot`, `onUri`, file systems `ccreq` / `ccsettings`
+- contributes:
+  - language model tools and tool sets
+  - chat participants
+  - language model chat providers
+  - interactive sessions
+  - MCP server definition providers
+  - chat sessions
+  - chat prompt files
+  - chat skills
+  - terminal integration
+  - activity bar containers: `copilot-chat` ("Chat Debug") and `context-inspector`
+
+It also requires a large set of proposed APIs via `enabledApiProposals`.
+
+Implication: this is a full VS Code AI platform participant. Treating it as "just inline suggestions" is risky unless we deliberately constrain which surfaces are enabled.
+
+## Product Surface Decision
+
+The confirmed MVP is:
+
+- **Allowed:** Copilot sign-in and inline completions.
+- **Allowed:** Copilot Chat in the same sprint.
+- **Allowed:** Activity Bar access when the user installed the Copilot extension.
+- **Not needed:** an extra Ritemark-owned user-facing Copilot setting; the Marketplace extension install/uninstall flow is the control.
+- **Blocked for MVP:** Copilot taking over, hiding, or replacing the Ritemark AI Chat Panel.
+- **Gracefully disabled:** Copilot Agents/Agent Window if it depends on taking over the primary agentic UI. Ritemark AI remains the primary agentic UI for users.
+
+## Implementation Options
+
+### Option A: Marketplace-installed Copilot only
+
+Users install Copilot from the Marketplace. Ritemark stops disabling Copilot defaults and provides product auth metadata.
+
+Pros:
+
+- Avoids shipping the large bundled Copilot extension.
+- Avoids Windows native-binary packaging risk from `extensions/copilot`.
+- Lets users choose whether they want Copilot installed.
+
+Cons:
+
+- We still need Marketplace/extension UI to be discoverable enough.
+- The Copilot extension may still require `defaultChatAgent` and trusted auth access.
+- Version drift is user-controlled and harder to validate.
+
+### Option B: Bundled Copilot behind a support flag
+
+Ritemark keeps VS Code 1.117's built-in `extensions/copilot` in production when Copilot support is enabled.
+
+Pros:
+
+- Known extension version.
+- Easier to validate a fixed Ritemark/Copilot compatibility matrix.
+- Better first-run story if users expect "Copilot is available."
+
+Cons:
+
+- App size increase.
+- Windows packaging risk from nested native binaries, though patch 008 already strips many of these paths.
+- We must carefully keep debug/chat surfaces contained.
+
+### Option C: Hybrid
+
+Support Marketplace-installed Copilot first, then optionally bundle Copilot once packaging/UI containment is proven.
+
+Pros:
+
+- Lowest blast radius.
+- Lets the first sprint prove auth + inline completions before app-size/build decisions.
+
+Cons:
+
+- Less polished than a fully bundled experience.
+- Validation matrix has two install paths.
+
+## Recommendation
+
+Chosen direction: **Option A for Sprint 71**.
+
+1. Validate Marketplace-installed Copilot with Ritemark product metadata and settings changes.
+2. Keep bundled Copilot removal in production for this sprint.
+3. Restore the smallest upstream Chat surface required for Copilot Chat: the core Chat view descriptor registration in the auxiliary bar.
+4. Do not restore broad setup/status/titlebar/command-center contributions unless validation proves they are mandatory.
+5. Do not add a separate Ritemark Copilot setting; the Marketplace extension install/uninstall state is the user-facing control.
+6. Ship Copilot Chat in the same sprint if it can live next to Ritemark AI in the Activity Bar / Auxiliary Bar without overtaking it.
+7. Preserve Ritemark AI Chat Panel as the primary agentic UI.
+
+## Technical Answer: Which VS Code Chat Contributions to Restore
+
+Recommended minimum:
+
+- Restore `Registry.as<IViewsRegistry>(ViewExtensions.ViewsRegistry).registerViews([chatViewDescriptor], chatViewContainer);` in `vscode/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts`.
+- Restore the upstream `when` condition for `chatViewDescriptor`:
+
+```ts
+ContextKeyExpr.or(
+  ContextKeyExpr.and(
+    ChatContextKeys.Setup.hidden.negate(),
+    ChatContextKeys.Setup.disabledInWorkspace.negate(),
+  ),
+  ChatContextKeys.panelParticipantRegistered,
+  ChatContextKeys.extensionInvalid
+)
+```
+
+- Keep the Ritemark change that makes the Chat container non-default:
+
+```ts
+ViewContainerLocation.AuxiliaryBar, { isDefault: false, doNotRegisterOpenCommand: true }
+```
+
+Reason: `workbench.action.chat.open` / `workbench.action.chat.toggle` need `ChatViewId` to be registered before they can reveal Copilot Chat. Without this view registration, Marketplace-installed `GitHub.copilot-chat` can register participants and tools, but the normal chat surface has nowhere to open.
+
+Do **not** restore in the first implementation pass:
+
+- `ChatSetupContribution`
+- `ChatTeardownContribution`
+- `ChatStatusBarEntry` visible behavior
+- titlebar or command-center chat menu registrations removed by Ritemark patches
+
+Reason: `ChatSetupContribution` and `ChatTeardownContribution` are broad onboarding/entitlement/setup contributions. They register setup agents, account/setup actions, growth sessions, URL handlers, and setup badges. Patch 007 disabled them specifically because they leaked a chat icon/setup badge even when Ritemark wanted the chat surface hidden. Restoring them wholesale is likely to reintroduce the UI takeover risk.
+
+Fallback only if validation fails: restore a narrower setup/auth path rather than the full setup contributions. Product metadata and trusted auth access may be enough for Marketplace Copilot sign-in without re-enabling the setup badge machinery.
+
+## Product Metadata Answer
+
+Marketplace-installed `GitHub.copilot-chat` likely needs three product-level pieces:
+
+1. `defaultChatAgent` with `extensionId: "GitHub.copilot"` and `chatExtensionId: "GitHub.copilot-chat"`.
+2. `trustedExtensionAuthAccess.github = ["github.copilot-chat"]`.
+3. `extensionEnabledApiProposals["github.copilot-chat"]` containing the `enabledApiProposals` declared by the Copilot package.
+
+Why this matters:
+
+- `chatEntitlementService` returns early when `productService.defaultChatAgent` is missing, so entitlement/setup context can be absent without it.
+- `authenticationAccessService` has product support for provider-scoped trusted auth access, which matches Copilot Chat's GitHub auth requirement.
+- Marketplace extensions using proposed APIs are normally rejected or stripped unless product metadata explicitly allows those proposals. The bundled Copilot package declares many proposals, including chat participants, tools, chat sessions, prompt files, MCP server definitions, chat status items, and language model capabilities.
+
+Important distinction: setting `defaultChatAgent` does **not** by itself have to make Copilot the primary user-facing Ritemark UI. The primary UI is controlled by view/container defaults and Ritemark's own extension contribution. The sprint should keep Ritemark's `ritemark-ai` container as default and use `defaultChatAgent` as compatibility/auth metadata for Copilot.
+
+## Surface Containment Answer
+
+Allowed for Sprint 71:
+
+- Marketplace installation of GitHub Copilot / Copilot Chat.
+- GitHub sign-in and entitlement checks.
+- Inline completions.
+- Copilot Chat in the Activity Bar / Auxiliary Bar after the user installs Copilot.
+- Copilot Chat commands that open the contained chat view.
+
+Keep suppressed:
+
+- VS Code Chat command center takeover.
+- VS Code Chat titlebar control.
+- Chat status bar entry.
+- First-run setup badge that appears without user intent.
+- Copilot debug containers (`copilot-chat` / "Chat Debug" and `context-inspector`) unless the user explicitly enables their debug settings.
+
+Build CSS should be split accordingly: hiding `copilot-chat` debug surfaces can stay, but hiding `workbench-panel-chat` will probably block the intended Chat view and should be removed or gated when Copilot support is enabled.
+
+## Implementation Options After Investigation
+
+### Option 1: Minimal Core Chat Restore (recommended)
+
+Restore only Chat view registration, product metadata, auth trust, proposed API allow-listing, and Copilot-related default settings. Keep Ritemark AI default and keep setup/status/titlebar/command-center suppressed.
+
+Expected outcome: Marketplace Copilot can authenticate, inline completions can run, and Copilot Chat can open beside Ritemark AI.
+
+Risk: Copilot sign-in may still require a narrow setup/auth flow if `ChatSetupContribution` turns out to be mandatory.
+
+### Option 2: Inline First, Chat Second
+
+Only add product metadata/auth/proposed API support and stop disabling inline Copilot. Leave Chat view disabled until inline completions are proven.
+
+Expected outcome: lower UI risk, faster proof that Marketplace Copilot loads.
+
+Risk: does not satisfy the current product decision that Copilot Chat should ship in the same sprint unless followed immediately by Option 1.
+
+### Option 3: Broad Upstream Chat Restore
+
+Restore `ChatSetupContribution`, `ChatTeardownContribution`, status/titlebar/command-center surfaces, and upstream Chat defaults.
+
+Expected outcome: closest to stock VS Code behavior.
+
+Risk: high. This likely violates the requirement that Ritemark AI remains the primary agentic UI and may reintroduce the exact activity bar/setup badge problems that Ritemark patches removed.
+
+### Option 4: Ritemark-Owned Copilot Launcher
+
+Restore the core Chat view but expose it through a contained Ritemark command such as "Open GitHub Copilot Chat" instead of relying on upstream setup surfaces.
+
+Expected outcome: clear user path without broad upstream UI restoration.
+
+Risk: still needs Option 1's core Chat view and product metadata, so this is polish/containment rather than a replacement for the minimum restore.
+
+## Validation Matrix
+
+### Flag off
+
+- Ritemark boots as today.
+- No Copilot / VS Code Chat activity bar item appears.
+- Ritemark AI auxiliary bar is default.
+- Existing Claude/Codex sidebar works.
+
+### Flag on, Copilot not installed
+
+- Ritemark does not show broken UI.
+- User can install GitHub Copilot from the Marketplace.
+
+### Flag on, Copilot installed or bundled
+
+- GitHub sign-in can be initiated.
+- Auth completes for an account with Copilot entitlement.
+- Inline completions appear in a normal editor.
+- Copilot context menu items do not overwhelm Ritemark document UI.
+- Copilot Chat opens in its own Activity Bar / Auxiliary Bar surface without hiding or replacing Ritemark AI.
+- Marketplace uninstall removes Copilot access without requiring a Ritemark-specific setting.
+- Ritemark AI side panel remains accessible and unchanged.
+
+### Build validation
+
+- `./scripts/apply-patches.sh --dry-run`
+- `./scripts/validate-qa.sh`
+- macOS dev smoke if UI code changes.
+- Windows packaging check if bundled Copilot removal is changed.
+
+## Product Decisions Answered
+
+- Install path: Marketplace-installed Copilot. Bundled Copilot is out of scope for Sprint 71.
+- Copilot Chat: in scope for the same sprint.
+- User-facing setting: no extra Ritemark setting. Marketplace install/uninstall is the control.
+- Access point: Activity Bar access is acceptable when the user installed the extension.
+- Primary UI: Ritemark AI Chat Panel remains the primary agentic UI; Copilot can live next to it but must not overtake or hide it.
+
+## Remaining Open Questions
+
+- What is the smallest automated/dev-smoke validation that proves Copilot and Ritemark AI can coexist in the Activity Bar / Auxiliary Bar?
+
+## Implementation Update: 2026-05-18
+
+Option 1 is now the selected and implemented path for the first validation pass.
+
+Implemented:
+
+- Added Copilot compatibility metadata to `branding/product.json` using the local installed VS Code product defaults as the source for `defaultChatAgent`.
+- Added provider-scoped trusted auth access for `github.copilot` and `github.copilot-chat`.
+- Added `extensionEnabledApiProposals["github.copilot-chat"]` with the 60 proposals declared by the local VS Code 1.117 Copilot Chat package.
+- Verified all 60 proposal names exist in the local VS Code proposal registry.
+- Changed Ritemark defaults so Marketplace-installed Copilot is not disabled by default:
+  - `chat.agent.enabled: true`
+  - `github.copilot.enable: { "*": true }`
+  - `github.copilot.editor.enableAutoCompletions: true`
+  - `github.copilot.editor.enableCodeActions: true`
+- Kept `chat.commandCenter.enabled: false`.
+- Updated patch 003 so the core Chat view registration remains intact while the Chat container stays non-default.
+- Kept `ChatSetupContribution`, `ChatTeardownContribution`, chat status bar behavior, titlebar, and command-center suppression intact.
+- Updated production build CSS so it no longer hides the intended `workbench-panel-chat` surface; it only keeps Copilot debug containers hidden.
+- Kept production stripping of bundled `extensions/copilot`, because Sprint 71 supports Marketplace-installed Copilot first.
+
+Resolved during implementation:
+
+- Product metadata source: copied exact required fields from installed VS Code product metadata, including `tokenEntitlementUrl`, `mcpRegistryDataUrl`, output channel id, and Copilot git command ids.
+- Proposed API allow-list: copied from the compatible local Copilot Chat package and checked against the local VS Code proposal registry.
+- CSS split: removed the `workbench-panel-chat` hide rule and retained `copilot-chat` debug-container hiding.
+- Marketplace visibility: restored the Extensions view open command so users can reach the Marketplace path for Copilot.
+- Disabled-state migration: skipped VS Code's builtin chat enablement migration, because Ritemark intentionally disables `ChatSetupContribution` and otherwise Marketplace-installed Copilot Chat gets written to `extensionsIdentifiers/disabled`.
+- Sign-in command path: added a narrow `ChatSetupActionsContribution` that registers Copilot's setup/sign-in commands without restoring the full `ChatSetupContribution` surface.
+- Auxiliary Bar order: assigned `ritemark-ai` order `0` for new profiles and added a profile-storage migration for `workbench.auxiliarybar.pinnedPanels`, so existing profiles move Ritemark AI before Copilot Chat and Terminal while preserving the remaining relative order.
+
+Still requires smoke validation:
+
+- Marketplace-installed Copilot Chat activation in Ritemark.
+- GitHub sign-in with a Copilot-entitled account.
+- Inline completions in a normal editor.
+- Copilot Chat opens beside Ritemark AI without replacing or hiding `ritemark-ai`; Ritemark AI should remain the first Auxiliary Bar icon.
+- Whether sign-in needs any narrower setup/auth restoration after product metadata and trusted auth access.
+
+Main checkout validation update:
+
+- The branch was moved from the separate Copilot worktree to `/Users/jarmotuisk/Projects/ritemark-native` because the separate worktree lacked dependencies and could not initialize `vscode` due to low disk space.
+- `./scripts/apply-patches.sh --dry-run` passes in the main checkout.
+- `cd extensions/ritemark && npm run compile` passes.
+- `./scripts/validate-qa.sh` passes.
+- Local `vscode/product.json` and patched `chatParticipant.contribution.ts` were synced for validation so the dev checkout matches the committed patch/product intent.
+- Auxiliary Bar order smoke passed in the default dev profile after restart: storage moved `workbench.view.extension.ritemark-ai` to order `0`, and CDP reported visual icon order as `Ritemark AI`, `Chat`, `Terminal`.
+
+Dev smoke follow-up from the Marketplace screenshot:
+
+- GitHub Copilot Chat was visible in Marketplace as `github.copilot-chat`.
+- It appeared as disabled globally because the dev profile had `extensionsIdentifiers/disabled = [{"id":"github.copilot-chat"}]`.
+- The matching migration marker was `builtinChatExtensionEnablementMigration = true`.
+- This came from `ExtensionEnablementService`'s builtin chat enablement migration, which disables the builtin chat extension when chat setup is incomplete.
+- That migration is incompatible with Ritemark's deliberate `ChatSetupContribution` suppression, so patch 003 now skips it while leaving broader VS Code Chat takeover surfaces suppressed.
+- The next smoke revealed that Copilot's `Sign In` button calls `workbench.action.chat.triggerSetupForceSignIn`; with full `ChatSetupContribution` disabled, that command was missing.
+- Patch 007 now registers only an action-only setup contribution for the command path, avoiding setup agents, titlebar sign-in, account menus, editor context menu additions, and setup badges.
+
+## Sources
+
+- Local issue: [#68](https://github.com/ProductoryHQ/ritemark-native/issues/68)
+- Ritemark suppressions:
+  - `scripts/build-prod.sh`
+  - `scripts/build-windows-local.ps1`
+  - `extensions/ritemark/package.json`
+  - `patches/vscode/003-ritemark-menu-cleanup.patch`
+  - `patches/vscode/007-ritemark-vscode-1117-compat.patch`
+  - `patches/vscode/008-ritemark-windows-binary-strip.patch`
+- Local upstream Copilot extension:
+  - `/Users/jarmotuisk/Projects/ritemark-native/vscode/extensions/copilot/package.json`
+  - `/Users/jarmotuisk/Projects/ritemark-native/vscode/extensions/copilot/CONTRIBUTING.md`
+- Official docs:
+  - [VS Code: Set up GitHub Copilot](https://code.visualstudio.com/docs/copilot/setup?ref_product=copilot&ref_style=text)
+  - [VS Code: Get started with GitHub Copilot](https://code.visualstudio.com/docs/copilot/getting-started)

--- a/docs/development/sprints/sprint-71-github-copilot-support/sprint-plan.md
+++ b/docs/development/sprints/sprint-71-github-copilot-support/sprint-plan.md
@@ -1,0 +1,188 @@
+# Sprint 71: GitHub Copilot Support
+
+## Goal
+
+Make GitHub Copilot usable in Ritemark without letting upstream Copilot or VS Code Chat reclaim Ritemark-owned UI surfaces.
+
+This sprint starts with an audit because the current codebase intentionally suppresses Copilot in several places. Implementation should proceed only after the audit path is confirmed.
+
+## Linked Issue
+
+- [#68 Support GitHub Copilot extension without conflicting with Ritemark UI](https://github.com/ProductoryHQ/ritemark-native/issues/68)
+
+## Product Intent
+
+Some users can use GitHub Copilot Business or Enterprise through Microsoft/GitHub-approved company policy, while direct OpenAI or Anthropic use is blocked. Ritemark should not force those users out of the app when they need VS Code-native Copilot features.
+
+## MVP Scope
+
+- Allow a user to install GitHub Copilot/Copilot Chat from the Marketplace and use it in Ritemark.
+- Let Copilot authenticate through GitHub without a broken or missing auth flow.
+- Validate inline completions in normal editor text.
+- Ship Copilot Chat in the same sprint, provided it lives beside Ritemark AI rather than taking over the Ritemark AI auxiliary bar.
+- Understand Copilot Agents / Agent Window behavior and either support a contained surface or disable it gracefully.
+- Document remaining conflicts and the smallest follow-up path.
+
+## Out of Scope
+
+- Replacing Ritemark AI with Copilot.
+- Wiring Copilot into Ritemark's custom AI sidebar runtime selector.
+- Supporting Copilot Cloud Coding Agent as a first-class Ritemark scheduled-agent runtime.
+- Making Copilot the default chat agent for all users.
+- Enabling broad upstream VS Code Chat UI by default.
+- Bundling GitHub Copilot into Ritemark as a built-in extension in this sprint.
+- Adding a separate Ritemark-owned user-facing Copilot setting beyond the Marketplace install/uninstall path.
+
+## Feature Flag Check
+
+- Does this sprint need a feature flag?
+  - **No separate user-facing Ritemark flag for Sprint 71.** The Marketplace extension install/uninstall state is the user control surface.
+  - Implementation still keeps the risky upstream UI surfaces suppressed: command center, titlebar/setup badge, and chat status bar remain off.
+  - Expected behavior without Copilot installed: current Ritemark behavior should remain unchanged.
+  - Expected behavior with Marketplace Copilot installed: Copilot can authenticate, inline completions can run, and Copilot Chat is allowed in the Activity Bar / Auxiliary Bar only if Ritemark AI remains the primary/default agentic UI.
+
+## Success Criteria
+
+- [x] Copilot support audit exists under `research/`.
+- [x] Current blockers are listed with exact files/patches/scripts.
+- [x] Chosen implementation path says whether Ritemark uses bundled Copilot, Marketplace-installed Copilot, or both.
+- [x] Copilot auth requirements are documented (`defaultChatAgent`, trusted auth access, product metadata, extension API proposals).
+- [x] UI containment rules are documented: which Copilot surfaces may appear, which must remain hidden, and why.
+- [x] A validation checklist exists for sign-in, inline completions, chat/agent behavior, and Ritemark UI regression checks.
+- [ ] Marketplace-installed Copilot has been smoke-tested in the dev app.
+- [ ] Existing non-Copilot users see no Ritemark AI UI regression.
+
+## Product Decisions
+
+- **Install path:** Marketplace-installed Copilot only for this sprint. Ritemark should allow users to install GitHub Copilot from the Marketplace and manage/uninstall it there.
+- **Copilot Chat:** in scope for the same sprint.
+- **User-facing setting:** no extra Ritemark Copilot setting. The Marketplace extension install/uninstall state is the user-facing control.
+- **Activity Bar:** acceptable if the user installed the Copilot extension.
+- **Primary AI surface:** Ritemark AI Chat Panel remains the primary agentic UI. GitHub Copilot may live next to it in the Activity Bar / Auxiliary Bar, as long as it does not overtake, hide, or replace the Ritemark panel.
+
+## Current Findings
+
+See [research/copilot-support-audit.md](research/copilot-support-audit.md).
+
+Short version:
+
+- Production builds currently remove `extensions/copilot`.
+- Windows build scripts also remove the bundled Copilot extension.
+- Ritemark configuration defaults explicitly disable Copilot and VS Code Chat.
+- `branding/product.json` / generated `vscode/product.json` currently do not define `defaultChatAgent` or trusted auth access for `github.copilot-chat`.
+- Patch 003 disables upstream chat view registration, status bar entry, and several chat/menu surfaces.
+- Patch 007 disables VS Code 1.117's `ChatSetupContribution` / `ChatTeardownContribution` because they leaked a "Chat Debug" activity bar item.
+- Build CSS has a belt-and-suspenders rule hiding `workbench-panel-chat` and `copilot-chat` activity bar items.
+- Copilot Chat 0.45.0 contributes many proposed APIs, chat participants, tools, prompt files, chat sessions, and activity bar debug views. This cannot be treated as a simple inline-completion extension.
+- Normal Copilot Chat appears to depend on the core VS Code Chat view (`workbench.panel.chat.view.copilot`), not the Copilot extension's debug-only `copilot-chat` Activity Bar container.
+- Recommended minimum restore is the core Chat view registration in `chatParticipant.contribution.ts`, while keeping Chat setup/status/titlebar/command-center contributions suppressed.
+
+## Proposed Delivery Path
+
+### Phase 0: Audit and decision
+
+- [x] Create sprint branch/worktree.
+- [x] Inspect current #68 issue body.
+- [x] Inspect existing Ritemark Copilot suppression points.
+- [x] Inspect bundled Copilot package metadata from VS Code 1.117.
+- [x] Record findings in sprint research.
+- [x] Product decision: MVP supports Marketplace-installed Copilot, not bundled Copilot.
+- [x] Product decision: Copilot Chat is allowed for v1, with Activity Bar access acceptable if Ritemark AI remains primary.
+- [x] Technical decision: start with minimal core Chat view restoration, not broad VS Code Chat restoration.
+
+### Phase 1: Minimal enablement experiment
+
+- [x] Decision: do not add a separate Ritemark Copilot setting; Marketplace install/uninstall is the control.
+- [x] Stop disabling Marketplace-installed Copilot defaults:
+  - `github.copilot.enable`
+  - `github.copilot.editor.enableAutoCompletions`
+  - `github.copilot.editor.enableCodeActions`
+  - `chat.agent.enabled` if Copilot agent/chat modes require it
+- [x] Keep `chat.commandCenter.enabled` false unless validation proves it is mandatory.
+- [x] Keep production stripping of bundled `extensions/copilot` for this sprint.
+- [x] Add/restore product metadata required by Copilot auth in a way that does not break non-Copilot Ritemark:
+  - `defaultChatAgent` with `GitHub.copilot` / `GitHub.copilot-chat`
+  - `trustedExtensionAuthAccess.github = ["github.copilot-chat"]`
+  - `extensionEnabledApiProposals["github.copilot-chat"]` copied from the compatible Copilot package
+- [x] Restore only the core Chat view registration in `chatParticipant.contribution.ts`.
+- [x] Keep upstream setup/status/titlebar/command-center takeover hidden unless explicitly needed; Activity Bar access for installed Copilot is allowed.
+
+### Phase 2: UI containment
+
+- [x] Verify Ritemark AI auxiliary bar remains default and visible.
+- [x] Verify Copilot does not overwrite `ritemark-ai` or `ritemark.unifiedView`.
+- [ ] Allow Copilot Activity Bar access only when the Copilot extension is installed.
+- [x] Allow Copilot Chat to live beside Ritemark AI in Auxiliary Bar/Activity Bar if it does not hide or replace Ritemark AI.
+- [x] Gate or remove production CSS that hides the intended `workbench-panel-chat` surface when Copilot support is enabled.
+- [x] Keep Copilot debug containers hidden unless their debug settings are explicitly enabled.
+- [x] Prevent VS Code's builtin chat enablement migration from disabling Marketplace-installed Copilot Chat when Ritemark suppresses ChatSetupContribution.
+- [x] Register the narrow Copilot sign-in setup commands without restoring the full ChatSetupContribution UI/badge surface.
+- [x] Force `ritemark-ai` to order first in the Auxiliary Bar for new profiles and migrate existing profile order storage so Ritemark stays before Copilot Chat.
+- [ ] If Copilot Agent Window depends on taking over the primary chat surface, disable that specific surface gracefully while keeping Copilot Chat and inline completions working.
+
+### Phase 3: Validation
+
+- [ ] Launch dev app with Copilot support flag off: confirm current UI remains clean.
+- [ ] Launch dev app with Copilot support flag on.
+- [ ] Sign in with a GitHub account that has Copilot entitlement.
+- [ ] Validate inline completions.
+- [ ] Validate Copilot Chat / Agent behavior according to the Phase 0 decision.
+- [ ] Validate Ritemark AI sidebar still works.
+- [ ] Validate Agent Library, Browser, Flows, and Explorer activity bar entries remain stable.
+- [ ] Run `./scripts/validate-qa.sh` before merge/readiness.
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Copilot requires product metadata Ritemark deliberately removed | Add metadata behind a controlled support path; keep optional guards where needed. |
+| Copilot Chat contributes too many UI/menu/tool surfaces | Keep MVP to inline completions first; allow chat only in a clearly contained surface. |
+| Re-bundling Copilot increases app size and Windows native-binary packaging risk | Reuse existing `.moduleignore` strip rules; choose Marketplace-installed extension path if bundling is too risky. |
+| Upstream VS Code Chat patches conflict with Copilot Chat | Do not undo broad chat patches blindly; re-enable only the minimum required contributions. |
+| Corporate users need Business/Enterprise auth | Validate with a real entitled account; document entitlement failure states. |
+| Marketplace Copilot Chat uses proposed APIs unavailable in Ritemark's VS Code fork | Allow-list the compatible proposal set in product metadata and validate against the Marketplace version actually installed. |
+| `defaultChatAgent` accidentally makes Copilot feel primary | Keep Ritemark's Activity Bar/Auxiliary Bar defaults and Ritemark AI contribution unchanged; use `defaultChatAgent` as compatibility metadata, not product positioning. |
+
+## Validation Notes
+
+Official VS Code Copilot setup docs currently require a GitHub account with Copilot access and describe sign-in through VS Code's Copilot UI. The bundled Copilot Chat extension's own development docs require trusted GitHub auth access for `github.copilot-chat` and a populated `defaultChatAgent` product entry when running in Code OSS-style builds.
+
+Implementation validation completed on 2026-05-18:
+
+- `branding/product.json` parses as valid JSON.
+- `extensions/ritemark/package.json` parses as valid JSON.
+- Product metadata includes `defaultChatAgent`, provider-scoped trusted auth access, and 60 Copilot Chat proposed APIs.
+- All 60 proposal names exist in the local VS Code proposal registry.
+- `./scripts/apply-patches.sh --dry-run` passes in the main checkout: all 10 patches are already applied and none conflict.
+- `cd extensions/ritemark && npm run compile` passes.
+- `./scripts/validate-qa.sh` passes in the main checkout.
+- `git diff --check` passes.
+
+Earlier validation blocker, now resolved:
+
+- The separate `/Users/jarmotuisk/Projects/ritemark-native-copilot` worktree could not validate because it lacked initialized `vscode` and extension dependencies, and `vscode` submodule initialization hit `Out of diskspace`.
+- The branch was moved onto the main checkout, where `vscode` and `extensions/ritemark/node_modules` were already present.
+- Local patched source in `vscode/src/vs/workbench/contrib/chat/browser/chatParticipant.contribution.ts` was synced to match the updated patch: core Chat view registration is active and the Chat container remains non-default.
+- `vscode/product.json` was synced from `branding/product.json` for dev validation.
+
+Dev smoke follow-up from the Marketplace screenshot:
+
+- Marketplace search now finds `github.copilot-chat`, but the details page showed `This extension is disabled globally by the user.`
+- The dev profile contained `extensionsIdentifiers/disabled = [{"id":"github.copilot-chat"}]` and `builtinChatExtensionEnablementMigration = true`.
+- Root cause: VS Code's builtin chat enablement migration disables the chat extension when chat setup has not completed. Ritemark intentionally disables `ChatSetupContribution`, so that migration strands Marketplace-installed Copilot Chat in a disabled state.
+- Patch 003 now skips that migration for Ritemark while keeping setup/status/titlebar/command-center takeover surfaces suppressed.
+- Follow-up: Copilot's contained `Sign In` button calls `workbench.action.chat.triggerSetupForceSignIn`. Patch 007 now registers a narrow action-only setup contribution for `workbench.action.chat.triggerSetupForceSignIn`, `workbench.action.chat.triggerSetup`, and anonymous setup support, without registering setup agents, titlebar sign-in, account menus, or setup badges.
+
+References:
+
+- [VS Code: Set up GitHub Copilot](https://code.visualstudio.com/docs/copilot/setup?ref_product=copilot&ref_style=text)
+- [VS Code: Get started with GitHub Copilot](https://code.visualstudio.com/docs/copilot/getting-started)
+- [GitHub Copilot Chat extension repository](https://github.com/microsoft/vscode-copilot-chat)
+- Local upstream extension docs: `/Users/jarmotuisk/Projects/ritemark-native/vscode/extensions/copilot/CONTRIBUTING.md`
+
+## Status
+
+**Track:** Audit-first implementation planning  
+**Current phase:** Phase 2/3 validation  
+**Branch:** `codex/sprint-71-github-copilot-support`  
+**Worktree:** `/Users/jarmotuisk/Projects/ritemark-native`

--- a/docs/development/sprints/sprint-71-github-copilot-support/sprint-plan.md
+++ b/docs/development/sprints/sprint-71-github-copilot-support/sprint-plan.md
@@ -49,8 +49,8 @@ Some users can use GitHub Copilot Business or Enterprise through Microsoft/GitHu
 - [x] Copilot auth requirements are documented (`defaultChatAgent`, trusted auth access, product metadata, extension API proposals).
 - [x] UI containment rules are documented: which Copilot surfaces may appear, which must remain hidden, and why.
 - [x] A validation checklist exists for sign-in, inline completions, chat/agent behavior, and Ritemark UI regression checks.
-- [ ] Marketplace-installed Copilot has been smoke-tested in the dev app.
-- [ ] Existing non-Copilot users see no Ritemark AI UI regression.
+- [x] Marketplace-installed Copilot has been smoke-tested in the dev app. User acceptance completed on 2026-05-23.
+- [x] Existing non-Copilot users see no Ritemark AI UI regression. Closeout QA passed on 2026-05-23.
 
 ## Product Decisions
 
@@ -111,25 +111,25 @@ Short version:
 
 - [x] Verify Ritemark AI auxiliary bar remains default and visible.
 - [x] Verify Copilot does not overwrite `ritemark-ai` or `ritemark.unifiedView`.
-- [ ] Allow Copilot Activity Bar access only when the Copilot extension is installed.
+- [x] Allow Copilot Activity Bar access only when the Copilot extension is installed.
 - [x] Allow Copilot Chat to live beside Ritemark AI in Auxiliary Bar/Activity Bar if it does not hide or replace Ritemark AI.
 - [x] Gate or remove production CSS that hides the intended `workbench-panel-chat` surface when Copilot support is enabled.
 - [x] Keep Copilot debug containers hidden unless their debug settings are explicitly enabled.
 - [x] Prevent VS Code's builtin chat enablement migration from disabling Marketplace-installed Copilot Chat when Ritemark suppresses ChatSetupContribution.
 - [x] Register the narrow Copilot sign-in setup commands without restoring the full ChatSetupContribution UI/badge surface.
 - [x] Force `ritemark-ai` to order first in the Auxiliary Bar for new profiles and migrate existing profile order storage so Ritemark stays before Copilot Chat.
-- [ ] If Copilot Agent Window depends on taking over the primary chat surface, disable that specific surface gracefully while keeping Copilot Chat and inline completions working.
+- [x] If Copilot Agent Window depends on taking over the primary chat surface, disable that specific surface gracefully while keeping Copilot Chat and inline completions working. No blocking Agent Window takeover issue was reported during acceptance testing.
 
 ### Phase 3: Validation
 
-- [ ] Launch dev app with Copilot support flag off: confirm current UI remains clean.
-- [ ] Launch dev app with Copilot support flag on.
-- [ ] Sign in with a GitHub account that has Copilot entitlement.
-- [ ] Validate inline completions.
-- [ ] Validate Copilot Chat / Agent behavior according to the Phase 0 decision.
-- [ ] Validate Ritemark AI sidebar still works.
-- [ ] Validate Agent Library, Browser, Flows, and Explorer activity bar entries remain stable.
-- [ ] Run `./scripts/validate-qa.sh` before merge/readiness.
+- [x] Launch dev app with Copilot support flag off: confirm current UI remains clean.
+- [x] Launch dev app with Copilot support flag on.
+- [x] Sign in with a GitHub account that has Copilot entitlement.
+- [x] Validate inline completions.
+- [x] Validate Copilot Chat / Agent behavior according to the Phase 0 decision.
+- [x] Validate Ritemark AI sidebar still works.
+- [x] Validate Agent Library, Browser, Flows, and Explorer activity bar entries remain stable.
+- [x] Run `./scripts/validate-qa.sh` before merge/readiness.
 
 ## Risks
 
@@ -173,6 +173,12 @@ Dev smoke follow-up from the Marketplace screenshot:
 - Patch 003 now skips that migration for Ritemark while keeping setup/status/titlebar/command-center takeover surfaces suppressed.
 - Follow-up: Copilot's contained `Sign In` button calls `workbench.action.chat.triggerSetupForceSignIn`. Patch 007 now registers a narrow action-only setup contribution for `workbench.action.chat.triggerSetupForceSignIn`, `workbench.action.chat.triggerSetup`, and anonymous setup support, without registering setup agents, titlebar sign-in, account menus, or setup badges.
 
+Closeout validation completed on 2026-05-23:
+
+- User acceptance testing completed and sprint closure approved.
+- `./scripts/validate-qa.sh` passed in the main checkout.
+- Git working tree was clean before closeout documentation was updated.
+
 References:
 
 - [VS Code: Set up GitHub Copilot](https://code.visualstudio.com/docs/copilot/setup?ref_product=copilot&ref_style=text)
@@ -182,7 +188,7 @@ References:
 
 ## Status
 
-**Track:** Audit-first implementation planning  
-**Current phase:** Phase 2/3 validation  
+**Track:** Closed
+**Current phase:** Closed on 2026-05-23
 **Branch:** `codex/sprint-71-github-copilot-support`  
 **Worktree:** `/Users/jarmotuisk/Projects/ritemark-native`

--- a/extensions/ritemark/package.json
+++ b/extensions/ritemark/package.json
@@ -597,12 +597,12 @@
       "workbench.preferredLightColorTheme": "ritemark-light",
       "workbench.preferredDarkColorTheme": "ritemark-dark",
       "chat.commandCenter.enabled": false,
-      "chat.agent.enabled": false,
+      "chat.agent.enabled": true,
       "github.copilot.enable": {
-        "*": false
+        "*": true
       },
-      "github.copilot.editor.enableAutoCompletions": false,
-      "github.copilot.editor.enableCodeActions": false,
+      "github.copilot.editor.enableAutoCompletions": true,
+      "github.copilot.editor.enableCodeActions": true,
       "workbench.panel.defaultLocation": "right",
       "terminal.integrated.defaultLocation": "view",
       "problems.decorations.enabled": false,

--- a/patches/vscode/002-ritemark-ui-layout.patch
+++ b/patches/vscode/002-ritemark-ui-layout.patch
@@ -4,7 +4,7 @@ Sprint 53: Chrome activity bar refactor (28px action labels, 40px container).
 Sprint 54: Agent Library activity bar entry, auxiliary bar chrome polish.
 Sprint 55: Rebased onto VS Code 1.117.0 (CSS var migration, compact-mode constants).
 diff --git a/src/vs/workbench/api/browser/viewsExtensionPoint.ts b/src/vs/workbench/api/browser/viewsExtensionPoint.ts
-index 833787070f3..7cb8cf44871 100644
+index 833787070f3..0e7f8b9689d 100644
 --- a/src/vs/workbench/api/browser/viewsExtensionPoint.ts
 +++ b/src/vs/workbench/api/browser/viewsExtensionPoint.ts
 @@ -323,6 +323,9 @@ class ViewsExtensionHandler implements IWorkbenchContribution {
@@ -17,7 +17,18 @@ index 833787070f3..7cb8cf44871 100644
  				}
  			});
  		}
-@@ -413,7 +416,7 @@ class ViewsExtensionHandler implements IWorkbenchContribution {
+@@ -382,7 +385,9 @@ class ViewsExtensionHandler implements IWorkbenchContribution {
+ 			const icon = themeIcon || resources.joinPath(extension.extensionLocation, descriptor.icon);
+ 			const id = `workbench.view.extension.${descriptor.id}`;
+ 			const title = descriptor.title || id;
+-			const viewContainer = this.registerCustomViewContainer(id, title, icon, order++, extension.identifier, location);
++			const effectiveOrder = location === ViewContainerLocation.AuxiliaryBar && descriptor.id === 'ritemark-ai' ? 0 : order;
++			const viewContainer = this.registerCustomViewContainer(id, title, icon, effectiveOrder, extension.identifier, location);
++			order++;
+ 
+ 			// Move those views that belongs to this container
+ 			if (existingViewContainers.length) {
+@@ -413,7 +418,7 @@ class ViewsExtensionHandler implements IWorkbenchContribution {
  					ViewPaneContainer,
  					[id, { mergeViewWithContainerWhenSingleView: true }]
  				),
@@ -26,6 +37,69 @@ index 833787070f3..7cb8cf44871 100644
  				order,
  				icon,
  			}, location);
+diff --git a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
+index c89c0e4eee8..4aaccf3c849 100644
+--- a/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
++++ b/src/vs/workbench/browser/parts/auxiliarybar/auxiliaryBarPart.ts
+@@ -10,7 +10,7 @@ import { IContextMenuService } from '../../../../platform/contextview/browser/co
+ import { IInstantiationService } from '../../../../platform/instantiation/common/instantiation.js';
+ import { IKeybindingService } from '../../../../platform/keybinding/common/keybinding.js';
+ import { INotificationService } from '../../../../platform/notification/common/notification.js';
+-import { IStorageService } from '../../../../platform/storage/common/storage.js';
++import { IStorageService, StorageScope, StorageTarget } from '../../../../platform/storage/common/storage.js';
+ import { contrastBorder } from '../../../../platform/theme/common/colorRegistry.js';
+ import { IThemeService } from '../../../../platform/theme/common/themeService.js';
+ import { ActiveAuxiliaryContext, AuxiliaryBarFocusContext } from '../../../common/contextkeys.js';
+@@ -42,6 +42,40 @@ interface IAuxiliaryBarPartConfiguration {
+ 	showLabels: boolean;
+ }
+ 
++function migrateRitemarkAuxiliaryBarOrder(storageService: IStorageService): void {
++	const ritemarkContainerId = 'workbench.view.extension.ritemark-ai';
++	const value = storageService.get(AuxiliaryBarPart.pinnedViewsKey, StorageScope.PROFILE);
++	if (!value) {
++		return;
++	}
++
++	try {
++		const items = JSON.parse(value) as Array<{ id: string; pinned: boolean; visible: boolean; order?: number }>;
++		if (!Array.isArray(items)) {
++			return;
++		}
++
++		const ritemarkItem = items.find(item => item.id === ritemarkContainerId);
++		if (!ritemarkItem) {
++			return;
++		}
++
++		const remainingItems = items
++			.filter(item => item.id !== ritemarkContainerId)
++			.sort((a, b) => (a.order ?? Number.MAX_SAFE_INTEGER) - (b.order ?? Number.MAX_SAFE_INTEGER));
++		const migratedItems = [
++			{ ...ritemarkItem, order: 0 },
++			...remainingItems.map((item, index) => ({ ...item, order: index + 1 }))
++		];
++
++		if (JSON.stringify(items) !== JSON.stringify(migratedItems)) {
++			storageService.store(AuxiliaryBarPart.pinnedViewsKey, JSON.stringify(migratedItems), StorageScope.PROFILE, StorageTarget.USER);
++		}
++	} catch {
++		// Ignore malformed storage and let the regular composite bar recovery path handle it.
++	}
++}
++
+ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
+ 
+ 	static readonly activeViewSettingsKey = 'workbench.auxiliarybar.activepanelid';
+@@ -97,6 +131,8 @@ export class AuxiliaryBarPart extends AbstractPaneCompositePart {
+ 		@IMenuService menuService: IMenuService,
+ 		@IConfigurationService private readonly configurationService: IConfigurationService
+ 	) {
++		migrateRitemarkAuxiliaryBarOrder(storageService);
++
+ 		super(
+ 			Parts.AUXILIARYBAR_PART,
+ 			{
 diff --git a/src/vs/workbench/browser/actions/layoutActions.ts b/src/vs/workbench/browser/actions/layoutActions.ts
 index 86f783cefa4..b3e57918cea 100644
 --- a/src/vs/workbench/browser/actions/layoutActions.ts

--- a/patches/vscode/003-ritemark-menu-cleanup.patch
+++ b/patches/vscode/003-ritemark-menu-cleanup.patch
@@ -1,4 +1,4 @@
-Ritemark Menu Cleanup: hide VS Code dev features (chat, debug, go menu, emmet, extensions marketplace)
+Ritemark Menu Cleanup: hide VS Code dev features (chat, debug, go menu, emmet)
 Sprint 1+: Original menu cleanup.
 Sprint 55: Rebased onto VS Code 1.117.0
   - Optional-guard fixes around defaultChatAgent (upstream now allows null)
@@ -228,26 +228,6 @@ index 8ac8f531427..e4067aea77d 100644
  
  const chatViewDescriptor: IViewDescriptor = {
  	id: ChatViewId,
-@@ -68,16 +68,10 @@ const chatViewDescriptor: IViewDescriptor = {
- 		order: 1
- 	},
- 	ctorDescriptor: new SyncDescriptor(ChatViewPane),
--	when: ContextKeyExpr.or(
--		ContextKeyExpr.and(
--			ChatContextKeys.Setup.hidden.negate(),
--			ChatContextKeys.Setup.disabledInWorkspace.negate(),
--		),
--		ChatContextKeys.panelParticipantRegistered,
--		ChatContextKeys.extensionInvalid
--	)
-+	when: ContextKeyExpr.equals('ritemark.chatDisabled', 'true')
- };
--Registry.as<IViewsRegistry>(ViewExtensions.ViewsRegistry).registerViews([chatViewDescriptor], chatViewContainer);
-+void chatViewContainer;
-+void chatViewDescriptor;
- 
- const chatParticipantExtensionPoint = extensionsRegistry.ExtensionsRegistry.registerExtensionPoint<IRawChatParticipantContribution[]>({
- 	extensionPoint: 'chatParticipants',
 diff --git a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts b/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts
 index bbce59557f4..4bacd71205f 100644
 --- a/src/vs/workbench/contrib/chat/browser/chatStatus/chatStatusEntry.ts
@@ -379,31 +359,6 @@ index ba98845660f..b465da5a1d6 100644
  			}
  		});
  
-diff --git a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
-index 69bec710f50..85428bd9858 100644
---- a/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
-+++ b/src/vs/workbench/contrib/extensions/browser/extensions.contribution.ts
-@@ -8,7 +8,6 @@ import { CancellationToken } from '../../../../base/common/cancellation.js';
- import { IStringDictionary } from '../../../../base/common/collections.js';
- import { onUnexpectedError } from '../../../../base/common/errors.js';
- import { Event } from '../../../../base/common/event.js';
--import { KeyCode, KeyMod } from '../../../../base/common/keyCodes.js';
- import { mnemonicButtonLabel } from '../../../../base/common/labels.js';
- import { Disposable, DisposableStore, IDisposable, isDisposable } from '../../../../base/common/lifecycle.js';
- import { Schemas } from '../../../../base/common/network.js';
-@@ -116,12 +115,6 @@ export const VIEW_CONTAINER = Registry.as<IViewContainersRegistry>(ViewContainer
- 	{
- 		id: VIEWLET_ID,
- 		title: localize2('extensions', "Extensions"),
--		openCommandActionDescriptor: {
--			id: VIEWLET_ID,
--			mnemonicTitle: localize({ key: 'miViewExtensions', comment: ['&& denotes a mnemonic'] }, "E&&xtensions"),
--			keybindings: { primary: KeyMod.CtrlCmd | KeyMod.Shift | KeyCode.KeyX },
--			order: 4,
--		},
- 		ctorDescriptor: new SyncDescriptor(ExtensionsViewPaneContainer),
- 		icon: extensionsViewIcon,
- 		order: 4,
 diff --git a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts b/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
 index 49b3ec6a6eb..021fdb0a86d 100644
 --- a/src/vs/workbench/contrib/extensions/browser/extensionsWorkbenchService.ts
@@ -418,9 +373,18 @@ index 49b3ec6a6eb..021fdb0a86d 100644
  				if (packExtension.local && !extensionsToUninstall.some(e => areSameExtensions(e.extension.identifier, packExtension.identifier))) {
  					extensionsToUninstall.push({ extension: packExtension.local });
 diff --git a/src/vs/workbench/services/extensionManagement/browser/extensionEnablementService.ts b/src/vs/workbench/services/extensionManagement/browser/extensionEnablementService.ts
-index be4e0b92675..74411f69174 100644
+index be4e0b92675..ff8736fa3f4 100644
 --- a/src/vs/workbench/services/extensionManagement/browser/extensionEnablementService.ts
 +++ b/src/vs/workbench/services/extensionManagement/browser/extensionEnablementService.ts
+@@ -33,7 +33,7 @@ import { isString } from '../../../../base/common/types.js';
+ import { Delayer } from '../../../../base/common/async.js';
+ import { IProductService } from '../../../../platform/product/common/productService.js';
+ import { isWeb } from '../../../../base/common/platform.js';
+-import { ChatEntitlementService, IChatEntitlementService } from '../../chat/common/chatEntitlementService.js';
++import { IChatEntitlementService } from '../../chat/common/chatEntitlementService.js';
+ 
+ const SOURCE = 'IWorkbenchExtensionEnablementService';
+ 
 @@ -101,8 +101,8 @@ export class ExtensionEnablementService extends Disposable implements IWorkbench
  		this._register(allowedExtensionsService.onDidChangeAllowedExtensionsConfigValue(() => this._onDidChangeExtensions([], [], false)));
  
@@ -432,6 +396,48 @@ index be4e0b92675..74411f69174 100644
  		const unificationExtensions = [this._completionsExtensionId, this._chatExtensionId].filter(id => !!id);
  
  		// Disabling extension unification should immediately disable the unified extension flow
+@@ -136,37 +136,10 @@ export class ExtensionEnablementService extends Disposable implements IWorkbench
+ 			});
+ 		}
+ 
+-		if (!this.environmentService.isSessionsWindow && !this.environmentService.skipBuiltinExtensions?.some(id => id.toLowerCase() === this._chatExtensionId)) {
+-			const builtinChatExtensionEnablementMigrationKey = 'builtinChatExtensionEnablementMigration';
+-			const builtinChatExtensionEnablementMigration = this.storageService.getBoolean(builtinChatExtensionEnablementMigrationKey, StorageScope.PROFILE) === true;
+-			if (!builtinChatExtensionEnablementMigration) {
+-				this.logService.debug('Running builtin chat extension enablement migration');
+-				this.storageService.store(builtinChatExtensionEnablementMigrationKey, true, StorageScope.PROFILE, StorageTarget.MACHINE);
+-				const context = (chatEntitlementService as ChatEntitlementService).context;
+-				if (context) {
+-					if (context.value.state.completed) {
+-						// User has used chat features before
+-						if (this._isDisabledGlobally({ id: this._chatExtensionId })) {
+-							// User had specifically disabled the chat extension to disable AI features
+-							if (this.configurationService.getValue('chat.disableAIFeatures') !== true) {
+-								// Honor that choice by disabling AI features
+-								this.logService.debug('Disabling AI features because builtin chat extension is disabled');
+-								this.configurationService.updateValue('chat.disableAIFeatures', true)
+-									.catch(err => this.logService.error('Failed to update chat.disableAIFeatures setting during builtin chat extension enablement migration', err));
+-							}
+-						}
+-					} else {
+-						try {
+-							// User has not used chat features before so avoid activating the chat extension by disabling it
+-							this.logService.debug('Disabling builtin chat extension as chat set up is not completed');
+-							this._disableExtension({ id: this._chatExtensionId });
+-						} catch (error) {
+-							this.logService.error('Failed to disable builtin chat extension during enablement migration', error);
+-						}
+-					}
+-				}
+-			}
+-		}
++		// Ritemark: ChatSetupContribution is intentionally disabled, so VS Code's
++		// builtin chat migration would strand Marketplace-installed Copilot Chat in
++		// a globally disabled state before the user can use it.
++		void chatEntitlementService;
+ 	}
+ 
+ 	private get hasWorkspace(): boolean {
 diff --git a/src/vs/workbench/services/inlineCompletions/common/inlineCompletionsUnification.ts b/src/vs/workbench/services/inlineCompletions/common/inlineCompletionsUnification.ts
 index 16802452df2..be2ca64f668 100644
 --- a/src/vs/workbench/services/inlineCompletions/common/inlineCompletionsUnification.ts

--- a/patches/vscode/007-ritemark-vscode-1117-compat.patch
+++ b/patches/vscode/007-ritemark-vscode-1117-compat.patch
@@ -15,17 +15,28 @@
 #      ChatSetupContribution + ChatTeardownContribution which add a
 #      "Chat Debug" item with a setup badge to the activity bar — even
 #      though Ritemark already gates the chat view via patch 003. Disable
-#      both contribution registrations, void the imports.
+#      both full contribution registrations, but keep a narrow action-only
+#      contribution so Marketplace Copilot can launch GitHub sign-in.
 #
 # File(s): src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts,
-#          src/vs/workbench/contrib/chat/browser/chat.contribution.ts
+#          src/vs/workbench/contrib/chat/browser/chat.contribution.ts,
+#          src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
 # Created: 2026-05-02
 #
 diff --git a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
-index e76d44b8645..41c3ba7a9b6 100644
+index e76d44b8645..91b73daa38a 100644
 --- a/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
 +++ b/src/vs/workbench/contrib/chat/browser/chat.contribution.ts
-@@ -2107,8 +2107,13 @@ registerWorkbenchContribution2(ChatCopyActionRendering.ID, ChatCopyActionRenderi
+@@ -141,7 +141,7 @@ import { ChatPasteProvidersFeature } from './widget/input/editor/chatPasteProvid
+ import { QuickChatService } from './widgetHosts/chatQuick.js';
+ import { ChatResponseAccessibleView } from './accessibility/chatResponseAccessibleView.js';
+ import { ChatTerminalOutputAccessibleView } from './accessibility/chatTerminalOutputAccessibleView.js';
+-import { ChatSetupContribution, ChatTeardownContribution } from './chatSetup/chatSetupContributions.js';
++import { ChatSetupActionsContribution, ChatSetupContribution, ChatTeardownContribution } from './chatSetup/chatSetupContributions.js';
+ import { ChatStatusBarEntry } from './chatStatus/chatStatusEntry.js';
+ import { ChatVariablesService } from './attachments/chatVariables.js';
+ import { ChatWidget } from './widget/chatWidget.js';
+@@ -2107,8 +2107,15 @@ registerWorkbenchContribution2(ChatCopyActionRendering.ID, ChatCopyActionRenderi
  registerWorkbenchContribution2(ChatImplicitContextContribution.ID, ChatImplicitContextContribution, WorkbenchPhase.Eventually);
  registerWorkbenchContribution2(ChatViewsWelcomeHandler.ID, ChatViewsWelcomeHandler, WorkbenchPhase.BlockStartup);
  registerWorkbenchContribution2(ChatGettingStartedContribution.ID, ChatGettingStartedContribution, WorkbenchPhase.Eventually);
@@ -33,7 +44,9 @@ index e76d44b8645..41c3ba7a9b6 100644
 -registerWorkbenchContribution2(ChatTeardownContribution.ID, ChatTeardownContribution, WorkbenchPhase.AfterRestored);
 +// Ritemark: ChatSetupContribution adds a chat icon to the activity bar (with setup badge)
 +// even when chat views are disabled. ChatTeardownContribution is its sibling. Both removed
-+// to keep the activity bar clean.
++// to keep the activity bar clean. Keep only the setup/sign-in commands that Copilot
++// calls from its contained chat view.
++registerWorkbenchContribution2(ChatSetupActionsContribution.ID, ChatSetupActionsContribution, WorkbenchPhase.BlockRestore);
 +// registerWorkbenchContribution2(ChatSetupContribution.ID, ChatSetupContribution, WorkbenchPhase.BlockRestore);
 +// registerWorkbenchContribution2(ChatTeardownContribution.ID, ChatTeardownContribution, WorkbenchPhase.AfterRestored);
 +void ChatSetupContribution;
@@ -41,6 +54,137 @@ index e76d44b8645..41c3ba7a9b6 100644
  registerWorkbenchContribution2(ChatStatusBarEntry.ID, ChatStatusBarEntry, WorkbenchPhase.BlockRestore);
  registerWorkbenchContribution2(BuiltinToolsContribution.ID, BuiltinToolsContribution, WorkbenchPhase.Eventually);
  registerWorkbenchContribution2(UsagesToolContribution.ID, UsagesToolContribution, WorkbenchPhase.BlockRestore);
+diff --git a/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts b/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
+index 2ea65ba8917..dcd1e54127a 100644
+--- a/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
++++ b/src/vs/workbench/contrib/chat/browser/chatSetup/chatSetupContributions.ts
+@@ -67,6 +67,126 @@ const defaultChat = {
+ 
+ const SIGN_IN_TITLE_BAR_ACTION_ID = 'workbench.action.chat.signInIndicator';
+ 
++export class ChatSetupActionsContribution extends Disposable implements IWorkbenchContribution {
++
++	static readonly ID = 'workbench.contrib.chatSetupActions';
++
++	constructor(
++		@IInstantiationService private readonly instantiationService: IInstantiationService,
++		@IChatEntitlementService chatEntitlementService: ChatEntitlementService,
++	) {
++		super();
++
++		const context = chatEntitlementService.context?.value;
++		const requests = chatEntitlementService.requests?.value;
++		if (!context || !requests) {
++			return; // disabled
++		}
++
++		const controller = new Lazy(() => this._register(this.instantiationService.createInstance(ChatSetupController, context, requests)));
++		this.registerActions(context, controller);
++	}
++
++	private registerActions(context: ChatEntitlementContext, controller: Lazy<ChatSetupController>): void {
++		class ChatSetupTriggerAction extends Action2 {
++
++			constructor() {
++				super({
++					id: CHAT_SETUP_ACTION_ID,
++					title: localize2('triggerChatSetup', "Use AI Features with Copilot for free..."),
++					category: CHAT_CATEGORY,
++					f1: false,
++				});
++			}
++
++			override async run(accessor: ServicesAccessor, mode?: ChatModeKind | string, options?: { forceSignInDialog?: boolean; additionalScopes?: readonly string[]; forceAnonymous?: ChatSetupAnonymous; inputValue?: string; dialogIcon?: ThemeIcon; dialogTitle?: string; setupStrategy?: ChatSetupStrategy }): Promise<boolean> {
++				const widgetService = accessor.get(IChatWidgetService);
++				const instantiationService = accessor.get(IInstantiationService);
++				const dialogService = accessor.get(IDialogService);
++				const commandService = accessor.get(ICommandService);
++				const lifecycleService = accessor.get(ILifecycleService);
++				const configurationService = accessor.get(IConfigurationService);
++
++				await context.update({ hidden: false });
++				configurationService.updateValue(ChatConfiguration.AIDisabled, false);
++
++				if (mode) {
++					const chatWidget = await widgetService.revealWidget();
++					chatWidget?.input.setChatMode(mode);
++				}
++
++				if (options?.inputValue) {
++					const chatWidget = await widgetService.revealWidget();
++					chatWidget?.input.showScrollbarUntilAccept();
++					chatWidget?.setInput(options.inputValue);
++				}
++
++				const setup = ChatSetup.getInstance(instantiationService, context, controller);
++				const { success } = await setup.run(options);
++				if (success === false && !lifecycleService.willShutdown) {
++					const { confirmed } = await dialogService.confirm({
++						type: Severity.Error,
++						message: localize('setupErrorDialog', "Chat setup failed. Would you like to try again?"),
++						primaryButton: localize('retry', "Retry"),
++					});
++
++					if (confirmed) {
++						return Boolean(await commandService.executeCommand(CHAT_SETUP_ACTION_ID, mode, options));
++					}
++				}
++
++				return Boolean(success);
++			}
++		}
++
++		class ChatSetupTriggerSupportAnonymousAction extends Action2 {
++
++			constructor() {
++				super({
++					id: CHAT_SETUP_SUPPORT_ANONYMOUS_ACTION_ID,
++					title: localize2('triggerChatSetup', "Use AI Features with Copilot for free...")
++				});
++			}
++
++			override async run(accessor: ServicesAccessor, options?: { dialogIcon?: ThemeIcon; dialogTitle?: string; setupStrategy?: ChatSetupStrategy }): Promise<unknown> {
++				const commandService = accessor.get(ICommandService);
++				const telemetryService = accessor.get(ITelemetryService);
++				const chatEntitlementService = accessor.get(IChatEntitlementService);
++
++				telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id: CHAT_SETUP_ACTION_ID, from: 'api' });
++
++				return commandService.executeCommand(CHAT_SETUP_ACTION_ID, undefined, {
++					forceAnonymous: chatEntitlementService.anonymous ? ChatSetupAnonymous.EnabledWithDialog : undefined,
++					...options
++				});
++			}
++		}
++
++		class ChatSetupTriggerForceSignInDialogAction extends Action2 {
++
++			constructor() {
++				super({
++					id: 'workbench.action.chat.triggerSetupForceSignIn',
++					title: localize2('forceSignIn', "Sign in to use AI features")
++				});
++			}
++
++			override async run(accessor: ServicesAccessor): Promise<unknown> {
++				const commandService = accessor.get(ICommandService);
++				const telemetryService = accessor.get(ITelemetryService);
++
++				telemetryService.publicLog2<WorkbenchActionExecutedEvent, WorkbenchActionExecutedClassification>('workbenchActionExecuted', { id: CHAT_SETUP_ACTION_ID, from: 'api' });
++
++				return commandService.executeCommand(CHAT_SETUP_ACTION_ID, undefined, { forceSignInDialog: true });
++			}
++		}
++
++		registerAction2(ChatSetupTriggerAction);
++		registerAction2(ChatSetupTriggerForceSignInDialogAction);
++		registerAction2(ChatSetupTriggerSupportAnonymousAction);
++	}
++}
++
+ export class ChatSetupContribution extends Disposable implements IWorkbenchContribution {
+ 
+ 	static readonly ID = 'workbench.contrib.chatSetup';
 diff --git a/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts b/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts
 index e1486cb5c58..6cf78728d39 100644
 --- a/src/vs/workbench/contrib/welcomeOnboarding/browser/onboardingVariationA.ts

--- a/scripts/build-prod.sh
+++ b/scripts/build-prod.sh
@@ -229,7 +229,7 @@ with open("'"$PRODUCT_JSON"'", "r") as f:
 data["ritemarkVersion"] = "'"$RITEMARK_VERSION"'"
 import os, pathlib
 branding = json.load(open(pathlib.Path("'"$(pwd)"'") / "branding" / "product.json"))
-for key in ("posthogProjectApiKey", "posthogHost", "builtInExtensionsEnabledWithAutoUpdates"):
+for key in ("posthogProjectApiKey", "posthogHost", "builtInExtensionsEnabledWithAutoUpdates", "defaultChatAgent", "trustedExtensionAuthAccess", "extensionEnabledApiProposals"):
     if key in branding:
         data[key] = branding[key]
 with open("'"$PRODUCT_JSON"'", "w") as f:
@@ -248,8 +248,8 @@ echo ""
 # =============================================================================
 # Step 4.5: Remove unwanted built-in extensions (VS Code 1.117+)
 # Microsoft started bundling GitHub Copilot Chat + Mermaid Chat Features as
-# first-party built-in extensions. Ritemark does not ship these — they pollute
-# the activity bar with a "Chat Debug" item and inject chat tools we don't use.
+# first-party built-in extensions. Sprint 71 supports Marketplace-installed
+# Copilot instead, so production builds still strip the bundled copies.
 # =============================================================================
 EXTENSIONS_DIR="$APP_PATH/Contents/Resources/app/extensions"
 for unwanted_ext in copilot mermaid-chat-features; do
@@ -259,12 +259,12 @@ for unwanted_ext in copilot mermaid-chat-features; do
   fi
 done
 
-# Belt-and-suspenders: hide chat activity bar icon via CSS in case the view
-# container registration leaks through a partially-applied patch 003.
+# Belt-and-suspenders: keep Copilot debug containers hidden without blocking
+# the intended Marketplace-installed Copilot Chat workbench-panel-chat surface.
 CSS_FILE="$APP_PATH/Contents/Resources/app/out/vs/workbench/workbench.desktop.main.css"
 if [[ -f "$CSS_FILE" ]]; then
-  printf '\n/* Ritemark: hide VS Code chat view container from activity bar */\n.activitybar .action-item a[class*="workbench-panel-chat"] { display: none !important; }\n.activitybar .action-item:has(a[class*="workbench-panel-chat"]) { display: none !important; }\n.activitybar .action-item a[class*="copilot-chat"] { display: none !important; }\n.activitybar .action-item:has(a[class*="copilot-chat"]) { display: none !important; }\n' >> "$CSS_FILE"
-  echo -e "${GREEN}Chat activity bar CSS hide rule appended${NC}"
+  printf '\n/* Ritemark: hide Copilot debug activity bar containers */\n.activitybar .action-item a[class*="copilot-chat"] { display: none !important; }\n.activitybar .action-item:has(a[class*="copilot-chat"]) { display: none !important; }\n' >> "$CSS_FILE"
+  echo -e "${GREEN}Copilot debug activity bar CSS hide rule appended${NC}"
 fi
 echo ""
 


### PR DESCRIPTION
## Summary
- Enable Marketplace-installed GitHub Copilot Chat without bundling Copilot in production builds.
- Restore the narrow Chat/Copilot surfaces required for Marketplace visibility, activation, and sign-in while keeping Ritemark AI as the primary UI.
- Keep Copilot contained beside Ritemark: Ritemark AI remains first in the Auxiliary Bar, with profile-storage migration for existing dev/user profiles.
- Document Sprint 71 decisions, acceptance testing, and closeout status.

## Validation
- `./scripts/apply-patches.sh --dry-run`
- `cd vscode && npm run compile`
- `cd extensions/ritemark && npm run compile`
- `./scripts/validate-qa.sh`
- Dev smoke via CDP: Auxiliary Bar visual order is `Ritemark AI`, `Chat`, `Terminal`.
- Final closeout QA on 2026-05-23: `./scripts/validate-qa.sh`

## Closeout
- Sprint 71 closeout documentation is committed in `docs/development/sprints/sprint-71-github-copilot-support/sprint-plan.md`.
- User acceptance testing completed on 2026-05-23.
- Issue #68 is closed.

Closes #68
