### PR TITLE
chore: block docs-internal/ from being committed

### DIFF
--- a/.claude/hooks/pre-commit-validator.sh
+++ b/.claude/hooks/pre-commit-validator.sh
@@ -112,6 +112,27 @@ else
   ERRORS=$((ERRORS + 1))
 fi
 
+# Check 10: No docs-internal/ files staged
+# docs-internal/ holds internal-only material (QA strategy, product/marketing
+# planning) and is listed in .gitignore. But .gitignore ONLY protects UNTRACKED
+# files — a `git add -f`, or adding a file before the ignore rule existed, silently
+# puts it under version control where .gitignore can no longer hide it. On a PUBLIC
+# repo that leaks internal docs to the world.
+# This actually happened: 14 docs-internal/quality-assurance/ files were committed
+# and reached the public origin/main; the history had to be rewritten to scrub them
+# (2026-05-20). This check is the backstop .gitignore cannot be — it refuses the
+# commit outright the moment anything under docs-internal/ is staged.
+STAGED_INTERNAL=$(git diff --cached --name-only -- "docs-internal/" 2>/dev/null || true)
+if [[ -n "$STAGED_INTERNAL" ]]; then
+  echo "ERROR: docs-internal/ files are staged — this directory must NEVER be committed"
+  echo "  (it is internal-only and this repository is PUBLIC)"
+  echo "  Staged:"
+  echo "$STAGED_INTERNAL" | sed 's/^/    /'
+  echo "  Fix: git reset HEAD -- docs-internal/   (files stay on disk, just unstaged)"
+  echo "  If a file genuinely belongs in the repo, move it OUT of docs-internal/ first."
+  ERRORS=$((ERRORS + 1))
+fi
+
 # Summary
 if [[ $ERRORS -gt 0 ]]; then
   echo ""


### PR DESCRIPTION
## What

Adds **Check 10** to `.claude/hooks/pre-commit-validator.sh`: the commit is refused if any staged file lives under `docs-internal/`.

## Why

`docs-internal/` is in `.gitignore`, but **`.gitignore` only protects untracked files**. A `git add -f` — or a file added before the ignore rule existed — silently puts it under version control, where `.gitignore` can no longer hide it. On this **public** repo that leaks internal-only material (QA strategy, product/marketing planning).

This actually happened: 14 `docs-internal/quality-assurance/` files were committed and reached the public `origin/main`. The history of the 3 affected branches (`main`, `sprint-69-ai-browser-control`, and the sprint-71 branch) was rewritten with `git-filter-repo` to scrub them, and the files restored locally as untracked.

This check is the backstop `.gitignore` cannot be.

## Test

Force-staging a `docs-internal/` file is detected and would block the commit; normal commits are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
