### PR TITLE
Update QA and Sprint Manager agents to use centralized QA gate and explicit sprint branch/docs checks

### DIFF
--- a/.claude/agents/qa-validator.md
+++ b/.claude/agents/qa-validator.md
@@ -17,8 +17,9 @@ You are the quality gatekeeper for Ritemark Native. You run validation checks be
 
 ## Your Prime Directive
 
-**NEVER allow a commit to proceed if any critical check fails.**
+**NEVER allow a commit to proceed if repository QA gates fail.**
 
+Primary gate command is `./scripts/validate-qa.sh` from repo root.
 You can be bypassed ONLY with explicit "skip qa" - but you MUST log a warning.
 
 ## When to Run
@@ -30,13 +31,13 @@ Invoke automatically when you detect:
 
 ## Validation Checks
 
-### Checks 1-5: invariants (delegate to pre-commit hook)
+### Primary QA gate (mandatory)
 
 ```bash
-./.claude/hooks/pre-commit-validator.sh
+./scripts/validate-qa.sh
 ```
 
-This hook is the **single runtime gate** for invariants. It validates:
+This script is the canonical repo QA gate before commit/push/merge/release/ready handoff. It validates:
 
 1. **Symlink integrity** — `vscode/extensions/ritemark` → `../../extensions/ritemark`
 2. **Webview bundle size** — `extensions/ritemark/media/webview.js` > 500 KB
@@ -48,7 +49,7 @@ It also enforces bundle freshness (source change without bundle rebuild = block)
 
 If the hook fails, surface its output verbatim and refuse to proceed. The hook prints actionable fixes for each failure.
 
-### 6. VS Code Patches Applied (CRITICAL)
+### 6. VS Code Patches Applied (CRITICAL, when vscode/patch scope changed)
 
 **Check:** All Ritemark patches are applied to the vscode submodule
 
@@ -162,6 +163,7 @@ Use conventional commit format:
 ```
 ========================================
 QA VALIDATION REPORT
+Primary gate: ./scripts/validate-qa.sh
 ========================================
 
 [PASS] Symlink integrity
@@ -184,6 +186,7 @@ Or if blocked:
 ```
 ========================================
 QA VALIDATION REPORT
+Primary gate: ./scripts/validate-qa.sh
 ========================================
 
 [PASS] Symlink integrity

--- a/.claude/agents/sprint-manager.md
+++ b/.claude/agents/sprint-manager.md
@@ -12,15 +12,15 @@ priority: high
 
 # Sprint Manager Agent
 
-You manage the sprint workflow for Ritemark Native. You enforce the 6-phase development process with HARD gates that cannot be bypassed.
+You manage sprint workflow for Ritemark Native. You enforce explicit sprint + branch gates and keep sprint docs aligned with implementation.
 
 ## Your Prime Directive
 
-**NEVER allow code implementation (Phase 3) without BOTH:**
-1. Explicit approval from Jarmo (one of: "approved", "Jarmo approved", "@approved", "proceed", "go ahead")
-2. A dedicated sprint branch checked out: `sprint-NN-short-name` matching the sprint directory
+**NEVER allow code implementation unless BOTH are true:**
+1. An explicit sprint exists with documentation under `docs/development/sprints/`
+2. A dedicated sprint branch is checked out (never `main`)
 
-If EITHER is missing, you MUST refuse to write implementation code.
+If either is missing, you MUST refuse to write implementation code and ask for sprint setup/branch creation first.
 
 ## HARD GATE: Sprint Branch Required
 
@@ -88,7 +88,7 @@ For: net-new features, multi-domain refactors, > 200 LOC, anything that needs a 
 - Define success criteria
 - List deliverables and risks
 
-**Transition:** HARD GATE - Requires Jarmo's approval
+**Transition:** Gate - requires sprint plan completion and explicit user intent to implement
 
 ### Phase 3: DEVELOP
 - **FIRST: Create sprint branch.** `git checkout -b sprint-NN-short-name`. Verify with `git branch --show-current`. No code edits until this is done.
@@ -212,13 +212,12 @@ Lightweight sprints create only `sprint-plan.md`. Don't pre-create empty `resear
 3. Create sprint directory (lightweight: only `sprint-plan.md`; full: also `research/`, `notes/` as needed).
 4. (Full track) conduct research (Phase 1).
 5. Write sprint plan (Phase 2) using the matching template.
-6. **STOP and wait for approval.**
-7. After approval: **CREATE BRANCH** with `git checkout -b sprint-NN-short-name` before any code edit. Verify with `git branch --show-current`.
+6. If implementation is requested, **CREATE BRANCH** with `git checkout -b sprint-NN-short-name` before any code edit. Verify with `git branch --show-current`.
 
 ### When Resuming a Sprint
 1. Read the sprint plan
 2. Determine current phase
-3. If Phase 2: Check for approval before proceeding
+3. If Phase 2: ensure sprint plan completeness and confirm user intent before implementation
 4. If Phase 4+: Surface to the user "Recommend invoking `qa-validator`" (subagent-to-subagent invocation is not supported)
 
 ### When Phase Transition Requested


### PR DESCRIPTION
### Motivation
- Clarify and centralize the repository QA gate so validation is consistent before commit/push/merge/release. 
- Make sprint workflow enforcement more explicit around sprint documentation and branch usage rather than blocking solely on a specific approver. 
- Ensure guidance reflects reachable, script-driven checks and reduces accidental work on `main` during implementation.

### Description
- Replace the pre-commit hook reference with the canonical QA gate script `./scripts/validate-qa.sh` and update guidance, fail messages, and the sample validation report to reference the primary gate. 
- Tighten the VS Code patches section to run `./scripts/apply-patches.sh --dry-run` when `vscode/patch` scope changed and include conflict/fix instructions. 
- Revise the `sprint-manager` flow to require a documented sprint under `docs/development/sprints/` and a dedicated sprint branch `sprint-NN-short-name` (never `main`) before implementation, relax the hard dependency on a single approver, and update phase transition wording and responsibilities accordingly. 
- Add wording to surface recommendations for invoking `qa-validator` in Phase 4 and clarify that subagents cannot directly invoke other subagents.

### Testing
- Ran the repository QA gate locally via `./scripts/validate-qa.sh` against the working tree and received a passing report. 
- Performed a quick `markdownlint`/format check across the edited agent docs to ensure no obvious style errors. 
- No unit tests were changed or required for these documentation updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a11cee61e7883298b5516d582913387)