### PR TITLE
docs(arch): architecture document + sprint-79 runtime unification plan

### DIFF
--- a/.claude/skills/architectural-design/SKILL.md
+++ b/.claude/skills/architectural-design/SKILL.md
@@ -1,0 +1,112 @@
+---
+name: architectural-design
+description: >
+  Architectural decision-making for Ritemark Native — when a change is
+  architectural, how to evaluate proposals against locked decisions, how
+  to choose between approaches, and where to get authoritative context.
+  Use when designing new subsystems, evaluating sprint scope, or deciding
+  whether a change triggers the Sprint Architecture Gate.
+allowed-tools: Read, Grep, Glob
+metadata:
+  version: 1.0.0
+---
+
+# Architectural Design
+
+This skill is about making good architectural decisions for Ritemark Native — not cataloging project state. For current subsystem detail, open debt, and issue links, read `docs/development/architecture.md`. This skill teaches you how to use that document and how to think.
+
+## When to Pull This Skill
+
+- Sprint plan touches a new subsystem, a new cross-boundary message type, or a new interface
+- A proposed approach conflicts with a locked decision (see below)
+- A change feels "big" but you're not sure if it's architectural
+- Choosing between two implementation approaches that have different structural implications
+- Evaluating whether a new dependency is acceptable
+
+---
+
+## Step 1 — Is This Change Architectural?
+
+A change is architectural if it does any of the following. If yes, `docs/development/architecture.md` must be updated before the sprint closes.
+
+| Trigger | Example |
+|---|---|
+| Adds, removes, or renames a module at `src/<subsystem>/` level | Adding `src/runtime/`, removing `src/rag/` |
+| Adds a new webview↔host message type crossing a subsystem boundary | New `agent-execute` replacing `ai-execute-agent` |
+| Changes an interface that other subsystems depend on | Changing `AgentRuntime` interface signature |
+| Changes the binary bundling manifest or `AgentRuntimeKind` enum | Adding a fourth runtime |
+| Adds or removes a feature flag gating a named architectural feature | New flag for `browser-agent-control` |
+
+If none of these apply, the change is implementation detail — no architecture doc update needed.
+
+---
+
+## Step 2 — Check Locked Decisions First
+
+These are non-negotiable. Any proposal that violates one needs Jarmo's explicit approval before proceeding.
+
+**VS Code as submodule, not fork.** All VS Code customizations go through patch files in `patches/vscode/`. Never edit the `vscode/` submodule tree directly. The cost of patches (brittleness on upstream bumps) is the accepted price of cheap upstream sync.
+
+**Extension symlinked, not copied.** Edit only in `extensions/ritemark/src/`. The symlink into `vscode/extensions/ritemark` is applied at build time. Never edit the submodule copy.
+
+**Webview is sandboxed.** The webview has no filesystem or Node access. Everything crosses `bridge.ts` via postMessage. Never give the webview direct FS access to "simplify" things. Hardening the boundary (typed protocol) is acceptable; dissolving it is not.
+
+**Model IDs in one file.** All model identifiers live in `src/ai/modelConfig.ts`. Never hardcode model names elsewhere. Post-Sprint 79: this is literally true; pre-Sprint 79: it was aspirationally true.
+
+**Flows are JSON + pluggable executors.** New automation capability = new node executor, not a new engine. `FlowExecutor` is not a runtime for agents; it runs single-shot node calls. Keep these shapes distinct.
+
+**Features ON by default, gated by flags.** Never delete or stub code to disable a feature. Disable only via `src/features/flags.ts`. This rule exists because stubbing broke Settings in v1.3.0 and made all AI features unusable.
+
+**Layout invariants owned by patch 002.** Sidebar, terminal, titlebar placement is contractual and enforced by the pre-commit hook. Do not regress these in unrelated work.
+
+**darwin-arm64 is the primary target.** Apple Silicon first. x64/Windows are supported but secondary.
+
+**Three distinct execution shapes.** Autonomous agent runtimes (Claude Code, Codex, ACP) and single-shot flow nodes are genuinely different. Unify their plumbing (shared interfaces, model config) but not their behavior. A flow node is not an agent session.
+
+---
+
+## Step 3 — Evaluating a Proposal
+
+Ask these questions in order:
+
+**1. Does it violate a locked decision?** If yes, stop. Bring to Jarmo.
+
+**2. Does it add a new dependency?** Check: (a) is there already something in the codebase that does this? (b) will this dependency ship in the production app or stay dev-only? (c) does it add to the 180-package tree that's already too large (see [#105](https://github.com/ProductoryHQ/ritemark-native/issues/105))? Prefer using what's already installed.
+
+**3. Does it cross a layer boundary?** Changes that cross the webview↔host boundary, the extension↔VS Code boundary, or the host↔binary boundary need explicit protocol consideration (message type, error contract, cancellation).
+
+**4. Does it grow `UnifiedViewProvider`?** Post-Sprint 79 target is ≤ 1100 LOC. Any change that adds runtime-specific logic directly to `UnifiedViewProvider` instead of to a runtime adapter is moving in the wrong direction.
+
+**5. Is there an existing pattern to follow?** Before introducing a new structural pattern, check what already exists: approval gates, browser tool injection, file attachments. Prefer extending the existing pattern over inventing a parallel one. Two patterns for the same capability is how `codexBrowserTools.ts` happened.
+
+**6. Is it reversible?** Prefer approaches where the sprint can be rolled back cleanly. If the change is irreversible (deletes code, changes a stored data format, renames a public API), note that explicitly in the sprint spec.
+
+---
+
+## Step 4 — Choosing Between Approaches
+
+When two approaches are roughly equivalent in correctness, prefer:
+
+- **Adapt, don't rewrite.** Wrap existing managers/classes rather than replacing their internals. Existing behavior stays intact; the adapter surface is what changes. This is how `ClaudeCodeRuntime`, `CodexRuntime`, and `AcpRuntime` wrap their existing managers in Sprint 79.
+
+- **Incremental over big-bang.** Each workstream should be independently committable and not leave the codebase broken at intermediate states. If a workstream requires two other workstreams to be complete before anything works, that's a risk signal.
+
+- **Audit before implementing.** For any requirement that touches an external binary or protocol (Codex JSON-RPC, ACP `initialize`, esbuild bundling), do the audit first and gate the implementation decision on audit results. Sprint 79 Phase 0 is the template.
+
+- **Make it loud when broken.** Prefer approaches where errors surface immediately (build failure, type error, test failure) over approaches where errors are silent (wrong message type at runtime, 0-byte file that passes a size check).
+
+---
+
+## Where to Get More Context
+
+| Question | Where to look |
+|---|---|
+| Current subsystem map and layer boundaries | `docs/development/architecture.md` — Subsystem Map, System Architecture Overview |
+| Agent runtime detail (AS IS + TO BE) | `docs/development/architecture.md` — Agent Runtime Architecture |
+| Open architectural debt and sequencing | `docs/development/architecture.md` — Open Architectural Debt (issue links) |
+| Build commands, Node versions, patch gotchas | `.claude/skills/vscode-development/SKILL.md` |
+| Patch rules (creating, updating, unused-imports trap) | `.claude/skills/vscode-development/PATCH-RULES.md` |
+| Feature flag implementation | `.claude/skills/feature-flags/SKILL.md` |
+| Layout invariants (patch 002 contract) | `.claude/skills/vscode-development/references/layout-invariants.md` |
+| Post-sprint-79 architectural issues | GH #105 (esbuild), #106 (typed protocol), #107 (bundle size), #108 (build gate), #109 (model gateway), #97 (cross-runtime context) |
+| Sprint architecture gate rule (enforcement) | `docs/development/architecture.md` — Sprint Architecture Gate |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,6 +7,18 @@ This file configures Codex behavior for `ritemark-native`. It is additive to the
 - Leave `.claude/**` unchanged unless the user explicitly asks to modify Claude Code assets.
 - Prefer Codex-specific instructions in this file and Codex skills in `.agents/skills/`.
 
+### Architecture Awareness
+
+The Ritemark extension architecture is documented in `docs/development/architecture.md`. Read it before starting any sprint that touches `extensions/ritemark/src/`. Key invariants:
+
+- **Three agent runtimes** (`src/agent/`, `src/codex/`, `src/acp/`) share the `AgentRuntime` interface (defined in Sprint 79). Do not add a fourth runtime without implementing this interface.
+- **All model identifiers** live in `src/ai/modelConfig.ts`. Never hardcode model IDs elsewhere.
+- **Approval gating** is handled through `UnifiedApprovalGate` (post Sprint 79). Never add a new runtime-specific approval message type.
+- **Browser tools** are injected via `BrowserToolsInjector` → MCP server path. Do not add new runtime-specific browser tool implementations.
+- **Feature flags** are defined in `src/features/flags.ts`. New features require a flag entry. Deleted features require the flag to be removed or set `disabled`.
+
+**Sprint Architecture Gate:** If a sprint changes module structure, webview message contracts, feature flags, or the binary manifest, update `docs/development/architecture.md` as part of the sprint close. The `Last updated` date in that document must be ≥ the sprint branch creation date.
+
 ### Default Workflow
 
 - Prefer existing project scripts in `scripts/` over ad hoc shell sequences.
@@ -14,6 +26,7 @@ This file configures Codex behavior for `ritemark-native`. It is additive to the
 - For release work, also use the `release-process` skill and run `./scripts/release-preflight.sh` before version bumps, tags, or build/distribution steps.
 - Keep sprint documentation under `docs/development/sprints/` aligned with implementation when the task is part of an explicit sprint.
 - Before closing a sprint or handing work off as ready, check whether user-facing behavior changed. If it did, update `docs/CHANGELOG.md` and the relevant `docs/releases/<version>/release-notes.md`; if no release note is appropriate, record why in the sprint plan.
+- If the sprint changes extension architecture (see Architecture Gate above), update `docs/development/architecture.md` before marking the sprint done.
 
 ### Hard Gates
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -96,6 +96,7 @@ Skills (knowledge injection, not agents):
 | `flow-testing` | Testing Ritemark Flows |
 | `ritemark-flows` | Building / editing flow JSON |
 | `ritemark-design` | Visual design decisions |
+| `architectural-design` | Deciding if a change is architectural, evaluating proposals against locked decisions, choosing between structural approaches |
 
 **Routing rule:** when user input contains a trigger keyword, invoke the agent BEFORE responding. Subagents cannot invoke other subagents — when one needs another's domain, it surfaces a routing recommendation to the user.
 
@@ -166,7 +167,7 @@ ritemark-native/
 │   │   └── [editors]            # ritemarkEditor, docxEditorProvider, pdfEditorProvider, excelEditorProvider
 │   ├── out/                     # Compiled JS
 │   ├── webview/                 # React webview (TipTap editor + AI sidebar)
-│   ├── media/                   # webview.js bundle (~900KB)
+│   ├── media/                   # webview.js bundle (~7.6 MB IIFE — see GH #107)
 │   └── binaries/agents/         # Bundled agent binaries (gitignored) + manifest.json
 ├── patches/vscode/              # Numbered patch files (001-*.patch … 010-*.patch)
 ├── branding/                    # Icons, logos, product.json overrides

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,9 +14,16 @@ Ritemark Native is a VS Code OSS fork with Ritemark built-in as the native markd
 | --- | --- | --- |
 | VS Code OSS | Git submodule | NOT a fork — easy upstream sync |
 | Integration | Custom Editor Provider | .md files open in Ritemark webview |
-| Build target | darwin-arm64 | Apple Silicon |
+| Build targets | darwin-arm64 (primary), win32-x64 (supported) | macOS Apple Silicon is primary; Windows is fully supported |
 | Marketplace | Hidden | Prevent extension conflicts |
 | Telemetry | Minimal, opt-out | Privacy first |
+| Agent runtimes | Claude Code (SDK), Codex (stdio), ACP/OpenCode (stdio) + `AgentRuntime` interface | All runtimes implement the same interface — see `docs/development/architecture.md` |
+| Agent approval | Unified approval gate — one webview message type for all runtimes | No runtime-specific approval message types after Sprint 79 |
+| Browser tools | `BrowserMcpServer` injected into all runtimes via `BrowserToolsInjector` | No runtime-specific browser tool implementations |
+| Model IDs | `src/ai/modelConfig.ts` is the authoritative registry | Never hardcode model IDs elsewhere; never split into runtime-specific files |
+
+**Full extension architecture (subsystems, TO BE items, open debt):** `docs/development/architecture.md`
+This document is updated at the end of every sprint that changes extension structure. Read it before planning any sprint that touches `extensions/ritemark/src/`.
 
 * * *
 
@@ -70,7 +77,7 @@ Branch name matches the sprint directory under `docs/development/sprints/`. Veri
 
 | Domain | Agent | Trigger keywords |
 | --- | --- | --- |
-| Builds, Extensions, Errors, Patches | `vscode-expert` | build, compile, error, fail, not working, extension, patch, update vscode, prod, production, gulp, run dev, start dev, launch, npm run, yarn |
+| Builds, Extensions, Errors, Patches | `vscode-expert` | build, compile, error, fail, not working, extension, patch, update vscode, prod, production, gulp, run dev, start dev, launch, open, start, scripts/code.sh, npm run, yarn |
 | PR Reviews & Merging | `pr-reviewer` | review PR, merge PR, check PR, approve PR |
 | Sprint Workflow | `sprint-manager` | sprint, phase, plan, implement, feature |
 | Quality Gates | `qa-validator` | commit, push, done, merge, PR |
@@ -116,7 +123,7 @@ Customizations to VS Code go through patch files in `patches/vscode/`, NEVER dir
 
 After fresh clone: run `./scripts/apply-patches.sh`. Before VS Code upstream bump: run `./scripts/update-vscode.sh --check`.
 
-### Current patches (6)
+### Current patches (10)
 
 | Patch | Purpose |
 | --- | --- |
@@ -126,6 +133,10 @@ After fresh clone: run `./scripts/apply-patches.sh`. Before VS Code upstream bum
 | `004-ritemark-build-system.patch` | jschardet, microphone permission, integrity check skip |
 | `005-ritemark-windows-and-oss-fixes.patch` | Windows builds, OSS compatibility, account service |
 | `006-ritemark-dev-launch-fallback.patch` | Dev mode scripts, product.json dev launch fallback |
+| `007-ritemark-vscode-1117-compat.patch` | VS Code 1.117 API compatibility fixes |
+| `008-ritemark-windows-binary-strip.patch` | Strip debug symbols from Windows agent binaries |
+| `009-ritemark-browser-context-bridge.patch` | Bridges VS Code webview context to the integrated browser panel |
+| `010-ritemark-browser-action-bridge.patch` | Enables AI agent actions (click, navigate, fill) in the integrated browser |
 
 Patch rules and unused-imports gotcha: `.claude/skills/vscode-development/PATCH-RULES.md`.
 
@@ -138,19 +149,37 @@ ritemark-native/
 ├── vscode/                      # VS Code OSS submodule (patches applied here)
 │   └── extensions/ritemark/     # SYMLINK → ../../extensions/ritemark
 ├── extensions/ritemark/         # Ritemark extension SOURCE (edit here!)
-│   ├── src/                     # TypeScript source
+│   ├── src/
+│   │   ├── agent/               # Claude Code runtime (SDK + bundled binary)
+│   │   ├── codex/               # Codex runtime (stdio JSON-RPC)
+│   │   ├── acp/                 # ACP/OpenCode runtime (@agentclientprotocol/sdk)
+│   │   ├── runtime/             # Shared AgentRuntime interface + registry (Sprint 79+)
+│   │   ├── browser/             # Integrated browser — CDP panel, MCP server, action tools
+│   │   ├── flows/               # Flow engine — scheduler, executor, storage
+│   │   ├── features/            # Feature flags (flags.ts registry)
+│   │   ├── ai/                  # Shared AI — modelConfig.ts, connectivity, analytics
+│   │   ├── views/               # UnifiedViewProvider (AI sidebar), AgentLibraryViewProvider
+│   │   ├── settings/            # Settings page bridge
+│   │   ├── utils/               # Binary resolution, platform utils, bundledAgentRuntime
+│   │   ├── voiceDictation/      # Whisper STT (macOS only)
+│   │   ├── export/              # PDF/DOCX export
+│   │   └── [editors]            # ritemarkEditor, docxEditorProvider, pdfEditorProvider, excelEditorProvider
 │   ├── out/                     # Compiled JS
-│   ├── webview/                 # React webview (TipTap editor)
-│   └── media/                   # webview.js bundle (~900KB)
-├── patches/vscode/              # Numbered patch files (001-*.patch …)
+│   ├── webview/                 # React webview (TipTap editor + AI sidebar)
+│   ├── media/                   # webview.js bundle (~900KB)
+│   └── binaries/agents/         # Bundled agent binaries (gitignored) + manifest.json
+├── patches/vscode/              # Numbered patch files (001-*.patch … 010-*.patch)
 ├── branding/                    # Icons, logos, product.json overrides
 ├── scripts/                     # Development and release scripts
-├── VSCode-darwin-arm64/         # Production build output
+├── VSCode-darwin-arm64/         # Production build output (macOS)
 ├── docs/
 │   ├── WISHLIST.md              # DEPRECATED — historical reference only (see below)
 │   ├── user/                    # User-facing docs
 │   ├── releases/                # Release notes per version
-│   └── development/             # Developer docs (analysis, sprints, release-process)
+│   └── development/
+│       ├── architecture.md      # Extension architecture — AS IS + TO BE (update each sprint)
+│       ├── analysis/            # Research docs (dated)
+│       └── sprints/             # Sprint docs (spec, tech-plan, tasks, sprint-plan)
 └── docs-internal/               # Gitignored: marketing, product strategy
 ```
 
@@ -162,10 +191,14 @@ Feature ideas/requests → **GitHub Issues** on `ProductoryHQ/ritemark-native` w
 
 ## AI Model Configuration
 
-All AI model identifiers live in **one** file: `extensions/ritemark/src/ai/modelConfig.ts`. Never hardcode model names elsewhere.
+All AI model identifiers must live in `extensions/ritemark/src/ai/modelConfig.ts`. Never hardcode model IDs anywhere else.
+
+**Current state (pre-Sprint 79):** Three locations exist — `modelConfig.ts` (OpenAI/BYOK models), `src/agent/types.ts` (`CLAUDE_MODELS`), `src/codex/codexModels.ts` (Codex dynamic list). Sprint 79 consolidates all into `modelConfig.ts`.
+
+**After Sprint 79:** The single-source rule is strictly true. Import from:
 
 ```typescript
-import { DEFAULT_MODELS, OPENAI_LLM_MODELS } from '../ai/modelConfig';
+import { CLAUDE_MODELS, OPENAI_LLM_MODELS, BYOK_PROVIDER_MODELS } from '../ai/modelConfig';
 ```
 
 For webview code, the extension sends model config via the `flow:modelConfig` message into `webview/src/config/modelConfig.ts`.
@@ -181,6 +214,8 @@ Webview uses **Tailwind CSS** + **shadcn/ui** (Radix primitives, copy-paste patt
 ## Feature Flags
 
 Project uses feature flags for platform-specific, experimental, and premium features. Implementation: `.claude/skills/feature-flags/SKILL.md`. Sprint-manager prompts when a sprint touches a feature that may need gating.
+
+**Rule:** When a feature is deleted, its flag must also be deleted (or set to `status: 'disabled'`). Zombie flags that gate deleted code are tracked in `docs/development/architecture.md` under ARCH-3.
 
 * * *
 

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -1,0 +1,281 @@
+# Ritemark Extension Architecture
+
+**Status:** Living document — updated at the end of each sprint that changes extension architecture.
+**Last updated:** 2026-06-06 (baseline, pre-Sprint 79)
+**Owner:** Jarmo (decisions) · Claude (maintenance)
+
+---
+
+## Purpose
+
+This document is the single source of truth for the Ritemark extension's **structural architecture** — how the main subsystems are organized, how they communicate, and what invariants must hold across sprints. It covers the extension host only; VS Code patches are documented in `CLAUDE.md`; webview internals are in `extensions/ritemark/webview/`.
+
+Sprint planning must consult this document. Any sprint that changes the architecture must update this document as part of its definition of done (see [Sprint Architecture Gate](#sprint-architecture-gate)).
+
+---
+
+## Subsystem Map (current, post-Sprint 78)
+
+```
+extensions/ritemark/src/
+├── agent/           Claude Code runtime — SDK-based, in-process + bundled binary
+├── codex/           Codex runtime — JSON-RPC 2.0 / stdio binary, custom protocol
+├── acp/             ACP runtime — JSON-RPC 2.0 / stdio, @agentclientprotocol/sdk
+├── browser/         Integrated browser — CDP panel, MCP server, action tools
+├── flows/           Flow engine — scheduler, executor, storage, test runner
+├── features/        Feature flags — flags.ts registry, featureGate.ts
+├── ai/              Shared AI utilities — modelConfig.ts, connectivity, analytics
+├── views/           View providers — UnifiedViewProvider (AI sidebar), AgentLibraryViewProvider
+├── settings/        Settings page bridge
+├── utils/           Binary resolution, platform utils, bundledAgentRuntime
+├── voiceDictation/  Whisper-based STT (macOS only)
+├── export/          PDF/DOCX export
+└── [editors]        ritemarkEditor.ts, docxEditorProvider.ts, pdfEditorProvider.ts, excelEditorProvider.ts
+```
+
+---
+
+## Agent Runtime Architecture
+
+### AS IS (Sprints 1–78) — Three Parallel Worlds
+
+Each runtime was integrated independently. The result is three structurally similar but incompatible stacks:
+
+| Dimension | Claude Code (`src/agent/`) | Codex (`src/codex/`) | ACP/OpenCode (`src/acp/`) |
+|---|---|---|---|
+| **Interface** | In-process TS SDK (`@anthropic-ai/claude-agent-sdk`) + bundled `claude` binary | Bundled `codex-app-server` binary, hand-written JSON-RPC 2.0/stdio (`codexProtocol.ts` 463 LOC) | `@agentclientprotocol/sdk` over stdio |
+| **Session manager** | `AgentRunner.ts` (1235 LOC) | `CodexManager.ts` (906 LOC) | `AcpManager.ts` (286 LOC) |
+| **Auth** | Claude OAuth / Anthropic API key | ChatGPT OAuth built into binary | BYOK — env-var injection from Settings |
+| **Approval** | `agent-answer-plan` webview message → PlanApprovalCard | `codex-approve` → CodexApprovalCard | `acp-approval-response` → CodexApprovalCard (shared shape, different message type) |
+| **Browser tools** | `BrowserMcpServer` injected via `AgentSessionConfig.mcpServers` | `codexBrowserTools.ts` — dynamic tool injection via Codex protocol | Not implemented |
+| **File attachments** | Full `FileAttachment` (image/pdf/text) | Images converted to data URLs; PDF/text not supported | No attachment support |
+| **Model config** | `CLAUDE_MODELS` in `src/agent/types.ts` | `getCodexModels()` in `src/codex/codexModels.ts` | `BYOK_PROVIDER_MODELS` in `src/ai/modelConfig.ts` |
+| **Webview execute message** | `ai-execute-agent` | `codex-execute` | `acp-execute` |
+| **Webview cancel message** | `ai-cancel-agent` | `codex-cancel` | `acp-cancel` |
+
+**Dispatch:** `UnifiedViewProvider.ts` (2480 LOC) contains three parallel switch-case trees — one per runtime — plus runtime-specific private methods. Adding a fourth runtime requires ~200 LOC of new switch cases and private methods.
+
+### TO BE (Sprint 79+) — Runtime Adapter Pattern
+
+A thin abstraction layer makes `UnifiedViewProvider` runtime-agnostic. Each runtime becomes a pluggable adapter. New runtimes (e.g. Goose, Cursor via ACP) require only a new adapter class + registry entry.
+
+```
+src/runtime/                          ← NEW in Sprint 79
+├── AgentRuntime.ts                   interface + shared types
+├── RuntimeRegistry.ts                factory, lookup, lifecycle management
+├── UnifiedApprovalGate.ts            single approval path for all runtimes
+└── BrowserToolsInjector.ts           single browser MCP injection for all runtimes
+
+src/agent/   → ClaudeCodeRuntime implements AgentRuntime
+src/codex/   → CodexRuntime implements AgentRuntime
+src/acp/     → AcpRuntime implements AgentRuntime
+```
+
+**`AgentRuntime` interface:**
+
+```typescript
+interface AgentRuntime {
+  readonly id: AgentId;
+
+  start(config: RuntimeSessionConfig): Promise<void>;
+  prompt(turn: RuntimeTurnConfig): Promise<void>;
+  cancel(): Promise<void>;
+  dispose(): void;
+
+  // Unified approval — all runtimes respond through one path
+  respondToApproval(requestId: string, approved: boolean, alwaysAllow: boolean): void;
+
+  getStatus(): Promise<RuntimeStatus>;
+}
+```
+
+**`RuntimeSessionConfig`** — shared session config that each adapter translates to its native form:
+
+```typescript
+interface RuntimeSessionConfig {
+  workspacePath: string;
+  model?: string;
+  attachments?: UnifiedAttachment[];     // see File Attachments section
+  mcpServers?: Record<string, unknown>;  // browser tools + future MCP
+  excludedFolders?: string[];
+  extraSystemPrompt?: string;
+}
+```
+
+**Unified dispatch in `UnifiedViewProvider` (post-Sprint 79):**
+
+```typescript
+// Before: 3 × execute + 3 × cancel + 3 × approve = 9 cases
+// After: 3 cases total
+case 'agent-execute': {
+  const runtime = this._runtimeRegistry.get(message.agentId);
+  await runtime.prompt({ prompt: message.prompt, model: message.model, attachments: message.attachments });
+  break;
+}
+case 'agent-cancel': {
+  this._runtimeRegistry.get(message.agentId)?.cancel();
+  break;
+}
+case 'agent-approve': {
+  this._runtimeRegistry.get(message.agentId)?.respondToApproval(message.requestId, message.approved, message.alwaysAllow);
+  break;
+}
+```
+
+**Target size:** `UnifiedViewProvider` ~900 LOC (from 2480).
+
+### Unified Approval Gate
+
+One webview message contract, one approval card component, all runtimes:
+
+```typescript
+// Extension → Webview (all runtimes):
+{
+  type: 'agent-approval-request',
+  agentId: AgentId,
+  requestId: string,
+  kind: 'file-write' | 'shell-command' | 'permission' | 'plan',
+  // kind-specific payload (file path, command, plan text, etc.)
+}
+
+// Webview → Extension (all runtimes):
+{
+  type: 'agent-approve',
+  agentId: AgentId,
+  requestId: string,
+  approved: boolean,
+  alwaysAllow: boolean,
+}
+```
+
+Each runtime adapter translates its native approval format (Codex JSON-RPC, ACP `session/request_permission`, Claude plan approval) into this shape before forwarding to the webview.
+
+### Browser Tool Injection
+
+**Target:** All runtimes receive browser tools through a single `BrowserToolsInjector` that produces an MCP server spec. Each adapter knows how to inject an MCP server into its runtime.
+
+```
+BrowserToolsInjector.getServers() → MCP server config
+  → ClaudeCodeRuntime: mcpServers field (already works this way)
+  → CodexRuntime: replaces codexBrowserTools.ts with MCP injection via Codex protocol
+  → AcpRuntime: MCP server list in ACP `initialize` request
+```
+
+`codexBrowserTools.ts` is deleted in Sprint 79.
+
+---
+
+## File Attachments
+
+### AS IS
+
+Attachment support is runtime-specific and inconsistent:
+
+| Runtime | Images | PDFs | Text files |
+|---|---|---|---|
+| Claude Code | ✅ via `FileAttachment` | ✅ | ✅ |
+| Codex | ⚠️ converted to data URLs; no `kind` check | ❌ | ❌ |
+| ACP/OpenCode | ❌ not implemented | ❌ | ❌ |
+
+### TO BE
+
+Single `UnifiedAttachment` type in `src/runtime/AgentRuntime.ts`. Each adapter converts to its native format:
+
+```typescript
+interface UnifiedAttachment {
+  id: string;
+  kind: 'image' | 'pdf' | 'text';
+  name: string;
+  data: string;       // base64 for image/pdf, raw text for text
+  mediaType: string;
+}
+```
+
+- `ClaudeCodeRuntime` passes through unchanged (it already matches this shape).
+- `CodexRuntime` converts images to data URLs, skips pdf/text with a visible notice ("Codex does not support PDF attachments").
+- `AcpRuntime` converts images to inline base64 in the prompt text (OpenCode BYOK providers vary in multimodal support; text content is inlined as a fenced block).
+
+---
+
+## Scheduled Agent Tasks (Daemon)
+
+### Vision
+
+Agents with a `schedule:` frontmatter field run autonomously while Ritemark is open. A daemon watches registered agents, fires them on schedule, and surfaces results in the Agent Library without interrupting the user.
+
+### Architecture (TO BE — Sprint 80+)
+
+```
+src/daemon/                          ← NEW
+├── AgentDaemon.ts                   cron watcher, registration, lifecycle
+├── DaemonSession.ts                 headless AgentRuntime session (no UI approval)
+├── DaemonResultStore.ts             persists run history (workspaceState)
+└── DaemonStatusEvents.ts            VS Code status bar + Agent Library notifications
+```
+
+**Key design decisions:**
+
+1. **Daemon uses the same `AgentRuntime` interface** — it calls `runtime.prompt()` like an interactive session, but with a `headless: true` flag that routes approvals to auto-approve-or-skip logic instead of the UI. This is the reason the `AgentRuntime` abstraction must exist first (Sprint 79 is a hard prerequisite).
+
+2. **No daemon-specific runtime.** The daemon is a client of the existing runtime layer, not a fourth runtime.
+
+3. **Auto-approval policy for headless runs:** The daemon must not silently execute destructive operations. Default policy: file-reads auto-approved; file-writes blocked and surfaced as a notification; shell commands blocked. The agent's `allowedTools` frontmatter narrows this further.
+
+4. **Flow `routine:` integration.** If the agent's frontmatter has `routine: <flow-stem>`, the daemon calls `FlowExecutor` after the agent run completes (or instead of — TBD in Sprint 80 spec).
+
+5. **Background execution (Phase 2).** Phase 1 (Sprint 80) runs while Ritemark is open. True background execution (process keeps running after app close) is a separate decision requiring OS-level service integration — out of scope until there is user demand.
+
+---
+
+## Model Configuration (Single Source of Truth)
+
+### AS IS — Three locations
+
+| Location | Models |
+|---|---|
+| `src/agent/types.ts:52` | `CLAUDE_MODELS` (Sonnet/Opus/Haiku) |
+| `src/codex/codexModels.ts` | `getCodexModels()` dynamic |
+| `src/ai/modelConfig.ts` | `OPENAI_LLM_MODELS` + `BYOK_PROVIDER_MODELS` |
+
+### TO BE — One location
+
+All model identifiers in `src/ai/modelConfig.ts`. The CLAUDE.md rule "all model identifiers in one file" becomes literally true. `agent/types.ts` retains `CLAUDE_MODELS` only until Sprint 79 migrates it; `CODEX_MODELS` (already `@deprecated`) is deleted.
+
+---
+
+## Open Architectural Debt
+
+These items are tracked here until resolved in a sprint:
+
+| ID | Item | Blocking? | Target sprint |
+|---|---|---|---|
+| **ARCH-1** | `@agentclientprotocol/sdk` must be esbuild-bundleable (no dynamic `require()`). Verify before prod build. | Sprint 76 shipped without verification on prod. | Sprint 79 pre-flight |
+| **ARCH-2** | Unified approval gate (TO BE #2 from Sprint 76 tech plan). ACP pre-aligned; full migration deferred. | No, but each sprint without it adds drift. | Sprint 79 |
+| **ARCH-3** | `document-search` (`'stable'`) flag gates deleted RAG code (`src/rag/` removed in Sprint 74). Zombie flag. | No (flag has no effect; RAG code is gone). | Sprint 79 cleanup |
+| **ARCH-4** | `CODEX_MODELS` in `types.ts` is `@deprecated` but callers not migrated. | No. | Sprint 79 |
+| **ARCH-5** | Codex browser tools use dynamic injection (`codexBrowserTools.ts`); Claude Code uses MCP server. Two patterns for same capability. | No, but blocks browser parity for ACP. | Sprint 79 |
+| **ARCH-6** | File attachments broken for Codex (partial) and ACP (missing). | Yes — user-visible bug. | Sprint 79 |
+| **ARCH-7** | `UnifiedViewProvider` at 2480 LOC; grows linearly with each new runtime. | No, but maintainability cost compounds. | Sprint 79 |
+
+---
+
+## Sprint Architecture Gate
+
+**Rule:** Any sprint whose implementation changes the structure of a subsystem listed in this document must update this document before the sprint is closed.
+
+"Changes structure" means:
+- Adding, removing, or renaming a module at the `src/<subsystem>/` level
+- Adding a new webview↔extension message type that crosses a subsystem boundary
+- Changing an interface that other subsystems depend on
+- Adding or removing a feature flag that gates a named architectural feature
+- Changing the binary bundling manifest or `AgentRuntimeKind` enum
+
+**Enforcement:** The sprint-manager skill checks for this requirement. The `qa-validator` blocks merge if the sprint's technical-plan says "changes architecture" but this document's `Last updated` date is older than the sprint branch creation date.
+
+---
+
+## Version History
+
+| Date | Sprint | Changes |
+|---|---|---|
+| 2026-06-06 | Baseline | Initial document. Captures AS IS state post-Sprint 78: 3 runtimes, 2 browser integration patterns, 3 model config locations. Defines TO BE for Sprint 79 (runtime adapter unification). |

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -1,16 +1,71 @@
 # Ritemark Extension Architecture
 
 **Status:** Living document — updated at the end of each sprint that changes extension architecture.
-**Last updated:** 2026-06-06 (baseline, pre-Sprint 79)
+**Last updated:** 2026-06-06 (pre-Sprint 79 baseline; expanded to full system scope)
 **Owner:** Jarmo (decisions) · Claude (maintenance)
 
 ---
 
 ## Purpose
 
-This document is the single source of truth for the Ritemark extension's **structural architecture** — how the main subsystems are organized, how they communicate, and what invariants must hold across sprints. It covers the extension host only; VS Code patches are documented in `CLAUDE.md`; webview internals are in `extensions/ritemark/webview/`.
+This document is the single source of truth for Ritemark extension architecture — system layers, subsystem structure, data flows, and invariants that must hold across sprints. It covers the extension host and its integration with VS Code OSS; VS Code patch specifics are in `CLAUDE.md`; webview component internals are in `extensions/ritemark/webview/`.
 
-Sprint planning must consult this document. Any sprint that changes the architecture must update this document as part of its definition of done (see [Sprint Architecture Gate](#sprint-architecture-gate)).
+Sprint planning must consult this document. Any sprint that changes the structure of a subsystem listed here must update this document as part of its definition of done (see [Sprint Architecture Gate](#sprint-architecture-gate)).
+
+---
+
+## System Architecture Overview
+
+Ritemark Native is a **VS Code OSS fork — as a git submodule, not a hard fork** — with the Ritemark markdown editor built in natively. `.md` files open in a TipTap WYSIWYG webview via a Custom Editor Provider. The submodule choice is the keystone structural decision: all VS Code customizations live in **patch files** (`patches/vscode/`), never in the submodule tree, keeping upstream VS Code sync cheap.
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Ritemark.app                                           │
+│                                                         │
+│  Layer 4: Webview        /webview/src                   │
+│           React + TipTap + Vite (IIFE, ~7.6 MB)         │
+│                    ↕ bridge.ts (postMessage)             │
+│  Layer 3: Extension host /extensions/ritemark/src       │
+│           TypeScript → Node.js                          │
+│                    ↕ VS Code Extension API              │
+│  Layer 2: VS Code patches /patches/vscode               │
+│           001–010.patch (applied at build time)         │
+│                    ↕                                    │
+│  Layer 1: VS Code OSS    /vscode  (git submodule)       │
+└─────────────────────────────────────────────────────────┘
+```
+
+**Layer boundaries are isolation boundaries.** Patches never touch the extension source; the webview never touches Node APIs directly. Every cross-boundary interaction is explicit and documented. This is what makes the system maintainable across VS Code upstream bumps.
+
+---
+
+## Webview ↔ Extension Protocol
+
+The load-bearing boundary. The TipTap editor cannot read files, make AI calls, or do any I/O. It requests everything through `bridge.ts`. This keeps the editor sandboxed and independently testable; the webview bundle (`media/webview.js`) is a self-contained artifact that ships separately from the host.
+
+`bridge.ts` exposes four channels:
+
+| Function | Direction | Use |
+|---|---|---|
+| `sendToExtension(type, data)` | webview → host | request file ops, AI calls, navigation |
+| `onMessage(cb)` | host → webview | document content, AI streams, state pushes |
+| `emitInternalEvent` / `onInternalEvent` | webview ↔ webview | UI-only events, no host round-trip |
+| `openExternalUrl` / `openInternalLink` | webview → host | external and cross-document links |
+
+`saveState` / `getState` (VS Code webview API) persist webview UI state across panel hide/show without a host round-trip.
+
+### Core file editing flow
+
+```
+.md file opened
+  → host: onMessage("document", content)  → webview renders in TipTap
+  user edits
+  → webview: sendToExtension("save", markdown)  → host writes to disk
+  external change detected by file watcher
+  → host: onMessage("document", content)  → webview re-renders
+```
+
+**Protocol type safety (AS IS):** `sendToExtension(type: string, data: Record<string, unknown>)` is stringly-typed. The host and webview agree on message names and payload shapes only by convention. A renamed `type` or changed payload field fails silently at runtime in a sandboxed context where it is hard to observe. See ARCH-9.
 
 ---
 
@@ -32,6 +87,8 @@ extensions/ritemark/src/
 ├── export/          PDF/DOCX export
 └── [editors]        ritemarkEditor.ts, docxEditorProvider.ts, pdfEditorProvider.ts, excelEditorProvider.ts
 ```
+
+Entry point `extension.ts` registers all providers, commands, and views.
 
 ---
 
@@ -95,10 +152,12 @@ interface AgentRuntime {
 interface RuntimeSessionConfig {
   workspacePath: string;
   model?: string;
-  attachments?: UnifiedAttachment[];     // see File Attachments section
+  attachments?: UnifiedAttachment[];
   mcpServers?: Record<string, unknown>;  // browser tools + future MCP
   excludedFolders?: string[];
   extraSystemPrompt?: string;
+  onProgress: (p: AgentProgress) => void;
+  onApprovalRequest: (req: UnifiedApprovalRequest) => void;
 }
 ```
 
@@ -122,9 +181,11 @@ case 'agent-approve': {
 }
 ```
 
-**Target size:** `UnifiedViewProvider` ~900 LOC (from 2480).
+**Target size:** `UnifiedViewProvider` ≤ 1100 LOC (from 2480).
 
-### Unified Approval Gate
+---
+
+## Unified Approval Gate
 
 One webview message contract, one approval card component, all runtimes:
 
@@ -135,7 +196,7 @@ One webview message contract, one approval card component, all runtimes:
   agentId: AgentId,
   requestId: string,
   kind: 'file-write' | 'shell-command' | 'permission' | 'plan',
-  // kind-specific payload (file path, command, plan text, etc.)
+  // kind-specific payload (file path, diff, command, plan text, etc.)
 }
 
 // Webview → Extension (all runtimes):
@@ -150,7 +211,9 @@ One webview message contract, one approval card component, all runtimes:
 
 Each runtime adapter translates its native approval format (Codex JSON-RPC, ACP `session/request_permission`, Claude plan approval) into this shape before forwarding to the webview.
 
-### Browser Tool Injection
+---
+
+## Browser Tool Injection
 
 **Target:** All runtimes receive browser tools through a single `BrowserToolsInjector` that produces an MCP server spec. Each adapter knows how to inject an MCP server into its runtime.
 
@@ -158,10 +221,24 @@ Each runtime adapter translates its native approval format (Codex JSON-RPC, ACP 
 BrowserToolsInjector.getServers() → MCP server config
   → ClaudeCodeRuntime: mcpServers field (already works this way)
   → CodexRuntime: replaces codexBrowserTools.ts with MCP injection via Codex protocol
-  → AcpRuntime: MCP server list in ACP `initialize` request
+  → AcpRuntime: MCP server list in ACP initialize request
 ```
 
-`codexBrowserTools.ts` is deleted in Sprint 79.
+`codexBrowserTools.ts` is deleted in Sprint 79 (Path A) if the Phase 0 Codex MCP injection audit confirms support. If not (Path B), the logic moves inside `CodexRuntime` and is tracked as ARCH-5 debt for a future sprint.
+
+---
+
+## Flows Architecture
+
+Flows are JSON-serialized, node-based automation workflows. The engine resolves node dependencies and executes nodes through pluggable executors.
+
+Engine files: `FlowExecutor.ts` (run), `FlowScheduler.ts` (timed triggers), `FlowStorage.ts` (load/save/enumerate), `FlowEditorProvider.ts` (custom editor for `.flow.json` files).
+
+Node executors (`src/flows/nodes/`): `LLMNodeExecutor`, `ImageNodeExecutor`, `SaveFileNodeExecutor`, `ClaudeCodeNodeExecutor`, `CodexNodeExecutor`. Template interpolation (`{{variables}}`) handled by `interpolate.ts`.
+
+UI: `webview/src/components/flows/` — canvas editor, node config panels, execution monitor.
+
+**Key invariant:** flow nodes call model APIs directly through their own executors, not through the `AgentRuntime` interface. `ClaudeCodeNodeExecutor` and `CodexNodeExecutor` call their respective managers for single-shot turns within a flow. The distinction — autonomous agent runtime vs. single-shot flow node — is a deliberate design decision (see Locked Decisions).
 
 ---
 
@@ -169,15 +246,13 @@ BrowserToolsInjector.getServers() → MCP server config
 
 ### AS IS
 
-Attachment support is runtime-specific and inconsistent:
-
 | Runtime | Images | PDFs | Text files |
 |---|---|---|---|
 | Claude Code | ✅ via `FileAttachment` | ✅ | ✅ |
-| Codex | ⚠️ converted to data URLs; no `kind` check | ❌ | ❌ |
+| Codex | ⚠️ converted to data URLs; no `kind` check | ❌ silently dropped | ❌ silently dropped |
 | ACP/OpenCode | ❌ not implemented | ❌ | ❌ |
 
-### TO BE
+### TO BE (Sprint 79)
 
 Single `UnifiedAttachment` type in `src/runtime/AgentRuntime.ts`. Each adapter converts to its native format:
 
@@ -191,9 +266,30 @@ interface UnifiedAttachment {
 }
 ```
 
-- `ClaudeCodeRuntime` passes through unchanged (it already matches this shape).
-- `CodexRuntime` converts images to data URLs, skips pdf/text with a visible notice ("Codex does not support PDF attachments").
-- `AcpRuntime` converts images to inline base64 in the prompt text (OpenCode BYOK providers vary in multimodal support; text content is inlined as a fenced block).
+- `ClaudeCodeRuntime`: passes through unchanged (already compatible).
+- `CodexRuntime`: images → data URLs; PDF/text → inlined as fenced block in prompt preamble with notice.
+- `AcpRuntime`: images → inline base64 if provider supports multimodal (check `BYOK_PROVIDER_MODELS`); text/PDF → inlined fenced block with downgrade notice.
+
+---
+
+## Build Pipeline
+
+```
+tsc → out/              extension host: 105 loose .js files
+Vite → media/webview.js webview bundle: ~7.6 MB IIFE
+apply-patches.sh        applies patches/vscode/001–010.patch to /vscode submodule
+gulp darwin-arm64-min   VS Code full build against submodule
+codesign                Apple Developer ID + Hardened Runtime + agent binary re-signing (JKBSC3ZDT5)
+xcrun notarytool        Apple notarization (pull log with --id before assuming outage)
+create-dmg              Sparkle-compatible .dmg
+update-feed.json        Sparkle update feed → jarmo-productory/ritemark-public
+```
+
+Build prerequisites (not enforceable at commit time): Node v20.x arm64 for prod, Node v22.21.1 arm64 for dev, `arch -arm64` shell wrapper. Full commands and gotchas in `.claude/skills/vscode-development/SKILL.md`.
+
+**Known architectural issue — extension host (ARCH-8):** The host ships as 105 loose `.js` files plus the entire `node_modules` tree (~180 packages). Most packages are transitive dependencies of `@anthropic-ai/claude-agent-sdk` + `@modelcontextprotocol/sdk` and are not loaded at runtime. This is the root cause of three documented incidents: Windows EMFILE, the 0-byte tsc trap (v1.7.1), and DMG bloat. Fix: esbuild bundle with tree-shaking; target is a handful of self-contained files.
+
+**Known architectural issue — webview bundle (ARCH-10):** The webview bundle is documented in several places as "~900 KB" but is actually **~7.6 MB** (~8× undocumented growth). All surfaces — TipTap editor, PDF/Excel/DOCX viewers, Flows canvas, AI sidebar — are in one IIFE loaded on every `.md` open. No CI bundle-size budget exists.
 
 ---
 
@@ -203,10 +299,10 @@ interface UnifiedAttachment {
 
 Agents with a `schedule:` frontmatter field run autonomously while Ritemark is open. A daemon watches registered agents, fires them on schedule, and surfaces results in the Agent Library without interrupting the user.
 
-### Architecture (TO BE — Sprint 80+)
+### Architecture (TO BE — Sprint 79 foundation, Sprint 80+ activation)
 
 ```
-src/daemon/                          ← NEW
+src/daemon/                          ← NEW in Sprint 79
 ├── AgentDaemon.ts                   cron watcher, registration, lifecycle
 ├── DaemonSession.ts                 headless AgentRuntime session (no UI approval)
 ├── DaemonResultStore.ts             persists run history (workspaceState)
@@ -215,21 +311,21 @@ src/daemon/                          ← NEW
 
 **Key design decisions:**
 
-1. **Daemon uses the same `AgentRuntime` interface** — it calls `runtime.prompt()` like an interactive session, but with a `headless: true` flag that routes approvals to auto-approve-or-skip logic instead of the UI. This is the reason the `AgentRuntime` abstraction must exist first (Sprint 79 is a hard prerequisite).
+1. **Daemon uses the same `AgentRuntime` interface** — it calls `runtime.prompt()` like an interactive session, but with a headless session that routes approvals to auto-block-or-skip logic instead of the UI. This is the reason the `AgentRuntime` abstraction must exist first (Sprint 79 is a hard prerequisite).
 
 2. **No daemon-specific runtime.** The daemon is a client of the existing runtime layer, not a fourth runtime.
 
-3. **Auto-approval policy for headless runs:** The daemon must not silently execute destructive operations. Default policy: file-reads auto-approved; file-writes blocked and surfaced as a notification; shell commands blocked. The agent's `allowedTools` frontmatter narrows this further.
+3. **Auto-approval policy for headless runs:** file-reads auto-approved; file-writes blocked and surfaced as a notification; shell commands blocked. The agent's `allowedTools` frontmatter narrows this further.
 
-4. **Flow `routine:` integration.** If the agent's frontmatter has `routine: <flow-stem>`, the daemon calls `FlowExecutor` after the agent run completes (or instead of — TBD in Sprint 80 spec).
+4. **Background execution (Phase 2).** Phase 1 (Sprint 80) runs while Ritemark is open. True background execution (process keeps running after app close) requires OS-level service integration — out of scope until there is user demand.
 
-5. **Background execution (Phase 2).** Phase 1 (Sprint 80) runs while Ritemark is open. True background execution (process keeps running after app close) is a separate decision requiring OS-level service integration — out of scope until there is user demand.
+5. **Cross-runtime context (Sprint 80 pre-flight):** The daemon fires a runtime and receives results. When the daemon result is surfaced in the Agent Library alongside interactive history, what context (if any) carries between them? See ARCH-13.
 
 ---
 
 ## Model Configuration (Single Source of Truth)
 
-### AS IS — Three locations
+### AS IS — Three locations (pre-Sprint 79)
 
 | Location | Models |
 |---|---|
@@ -237,25 +333,74 @@ src/daemon/                          ← NEW
 | `src/codex/codexModels.ts` | `getCodexModels()` dynamic |
 | `src/ai/modelConfig.ts` | `OPENAI_LLM_MODELS` + `BYOK_PROVIDER_MODELS` |
 
-### TO BE — One location
+### TO BE — One location (post-Sprint 79)
 
-All model identifiers in `src/ai/modelConfig.ts`. The CLAUDE.md rule "all model identifiers in one file" becomes literally true. `agent/types.ts` retains `CLAUDE_MODELS` only until Sprint 79 migrates it; `CODEX_MODELS` (already `@deprecated`) is deleted.
+All model identifiers in `src/ai/modelConfig.ts`. The CLAUDE.md rule "all model identifiers in one file" becomes literally true. `agent/types.ts` retains only type definitions; `CODEX_MODELS` (`@deprecated`) is deleted in Sprint 79. Full elimination of the runtime `flow:modelConfig` mirror message (for static config) requires the shared module approach — see ARCH-9 + to-be-proposal.md #3.
+
+---
+
+## Broader Architectural Roadmap (Post-Sprint 79)
+
+These improvements are not in Sprint 79 scope. Each is independently shippable. Tracked as ARCH items below.
+
+**Sequencing (from docs-internal/architecture/to-be-proposal.md):**
+
+1. ~~Dead-code removal (#4)~~ ✅ Sprint 74 | Patch manifest (#7) — low priority
+2. **Esbuild host bundle (#1) + build integrity gate (#6)** — ARCH-8, ARCH-11. The keystone structural win; they reinforce each other. Sprint 79 runtime unification makes the host cleaner and esbuild more tractable.
+3. **Shared model config (#3) + typed webview protocol (#2)** — ARCH-9. Sprint 79 does the model-ID half; the full shared-module approach pairs with the typed protocol.
+4. **Webview lazy-load + size budget (#5)** — ARCH-10. Last; highest constraint (CSP-compatible chunk loading, not just a Vite flag).
+
+**Item summaries:**
+
+**#1 Bundle the extension host (esbuild) — ARCH-8 — the keystone win.** Bundle the host into a small set of files using esbuild (same tool VS Code extensions use), tree-shaking out everything not reachable from `extension.ts`. `node_modules` stops shipping. Payoff: dissolves EMFILE structurally, eliminates the 0-byte tsc trap (a broken bundle fails loudly, not silently), shrinks the DMG, speeds extension activation. Watch-out: native modules and bundled agent binaries stay external (mark `external` in esbuild, copy explicitly).
+
+**#2 Typed webview ↔ host protocol — ARCH-9.** Define the protocol as a discriminated union in a shared module (`shared/protocol.ts`) imported by both sides. Adding or changing a message type becomes a compile error on both ends until both are updated. Sprint 79 reduces message types from 9+ to 3 (agent-execute/cancel/approve), making the typed protocol tractable.
+
+**#3 Single model-config source — partial in Sprint 79 (R6).** Sprint 79 consolidates model IDs into `modelConfig.ts`. Full solution: promote to a `@shared` module that both host (esbuild) and webview (Vite `@shared` alias) import directly, eliminating the runtime `flow:modelConfig` mirror message for static config.
+
+**#5 Webview lazy-load + size budget — ARCH-10.** Split viewers (PDF/Excel/DOCX) and Flows canvas out of the editor critical path. Requires CSP-compatible chunk loading (nonce'd script injection or small loader) — not just flipping `inlineDynamicImports`. Add a CI bundle-size budget so the ~7.6 MB figure is tracked, not invisible.
+
+**#6 Build-integrity gate — ARCH-11.** Before signing: (a) clean build from empty `out/`/`dist/` (no incremental tsc state); (b) assert every emitted artifact is non-zero; (c) smoke-launch the built app headless and confirm the `ai-sidebar` sentinel. Win #8 (esbuild bundling) makes (a) and (b) near-automatic — a broken bundle fails at build time, not as a 0-byte file.
+
+**Model gateway — ARCH-12.** Currently the three agent runtimes and flow nodes each carry their own auth, model-resolution, retry, and telemetry paths. A thin gateway interface would unify these without merging execution shapes. Separate from R6 (which consolidates model IDs, not call paths).
+
+**Cross-runtime conversation context — ARCH-13 (GH#97).** When switching agents mid-conversation, what context (if any) carries to the new runtime? Today each runtime has its own backend session; the sidebar renders a single combined transcript — so switching drops prior context from the new agent's view. Three design options: replay-on-switch, unified transcript + per-turn runtime marker, explicit "carry context to <agent>" handoff. **Must be decided before any Sprint 80+ daemon wiring or multi-agent orchestration.** Tracking: [ProductoryHQ/ritemark-native#97](https://github.com/ProductoryHQ/ritemark-native/issues/97).
 
 ---
 
 ## Open Architectural Debt
 
-These items are tracked here until resolved in a sprint:
-
 | ID | Item | Blocking? | Target sprint |
 |---|---|---|---|
-| **ARCH-1** | `@agentclientprotocol/sdk` must be esbuild-bundleable (no dynamic `require()`). Verify before prod build. | Sprint 76 shipped without verification on prod. | Sprint 79 pre-flight |
-| **ARCH-2** | Unified approval gate (TO BE #2 from Sprint 76 tech plan). ACP pre-aligned; full migration deferred. | No, but each sprint without it adds drift. | Sprint 79 |
-| **ARCH-3** | `document-search` (`'stable'`) flag gates deleted RAG code (`src/rag/` removed in Sprint 74). Zombie flag. | No (flag has no effect; RAG code is gone). | Sprint 79 cleanup |
-| **ARCH-4** | `CODEX_MODELS` in `types.ts` is `@deprecated` but callers not migrated. | No. | Sprint 79 |
-| **ARCH-5** | Codex browser tools use dynamic injection (`codexBrowserTools.ts`); Claude Code uses MCP server. Two patterns for same capability. | No, but blocks browser parity for ACP. | Sprint 79 |
-| **ARCH-6** | File attachments broken for Codex (partial) and ACP (missing). | Yes — user-visible bug. | Sprint 79 |
-| **ARCH-7** | `UnifiedViewProvider` at 2480 LOC; grows linearly with each new runtime. | No, but maintainability cost compounds. | Sprint 79 |
+| **ARCH-1** | `@agentclientprotocol/sdk` esbuild compatibility — verify no dynamic `require()` in prod build. Sprint 76 shipped without verification. | Not blocking, but prerequisite for ARCH-8. | Sprint 79 Phase 0 audit |
+| **ARCH-2** | Unified approval gate — three incompatible approval message types. | No, but each sprint without it adds drift. | Sprint 79 (R3) |
+| **ARCH-3** | `document-search` zombie flag gates deleted RAG code (`src/rag/` removed Sprint 74). | No effect; flag is a tombstone. | Sprint 79 cleanup (R7) |
+| **ARCH-4** | `CODEX_MODELS` in `types.ts` is `@deprecated` but not removed. | No. | Sprint 79 (R6) |
+| **ARCH-5** | Codex browser tools use dynamic injection (`codexBrowserTools.ts`); Claude Code uses MCP server. Two patterns for same capability. | No, but blocks ACP browser parity. | Sprint 79 (R4) — Path A if audit confirms, Path B if blocked |
+| **ARCH-6** | File attachments broken for Codex (partial) and ACP (missing). | Yes — user-visible bug. | Sprint 79 (R5) |
+| **ARCH-7** | `UnifiedViewProvider` at 2480 LOC; grows linearly with each new runtime. | No, but maintainability cost compounds. | Sprint 79 (R2) |
+| **ARCH-8** | Extension host ships as 105 loose `.js` files + ~180 `node_modules` packages. Root cause of Windows EMFILE, 0-byte tsc trap, DMG bloat. Fix: esbuild bundle. | No — three documented incidents but not hard-blocking. | Sprint 80 or 81 |
+| **ARCH-9** | Webview ↔ host protocol is stringly-typed (`bridge.ts`). Message renames fail silently at runtime. | No. | After Sprint 79 (sprint count TBD; Sprint 79 reduces message types from 9+ → 3 first) |
+| **ARCH-10** | Webview bundle is ~7.6 MB IIFE (documented as ~900 KB; 8× undocumented growth). All surfaces loaded on every `.md` open; no CI size budget. | No — UX impact on cold start but not broken. | After ARCH-8 (esbuild first) |
+| **ARCH-11** | Build-integrity gate: Gate 1 has passed a build with 0-byte `.js` files (v1.7.1 incident). Gate checks file existence, not integrity. | Yes — can ship broken DMGs that pass Gate 1. | Sprint 80 (with ARCH-8) |
+| **ARCH-12** | Model gateway: agent runtimes and flow nodes have separate auth / model-resolution / retry / telemetry paths. | No. | After Sprint 79; sequence TBD |
+| **ARCH-13** | Cross-runtime conversation context (GH#97). Switching agents mid-conversation silently drops prior context from the new runtime. Open design decision. | Decision required before Sprint 80 daemon wiring. | Sprint 80 pre-flight |
+
+---
+
+## Locked Decisions
+
+The decisions that define the system. Changing any of these is an architecture-level change requiring Jarmo's approval and an architecture.md update.
+
+- **VS Code as submodule, not fork** — customise via patches; keep upstream sync cheap. The brittleness of patch files is the accepted price.
+- **Extension symlinked, not copied** — single source of truth in `extensions/ritemark/`; symlinked into `vscode/extensions/ritemark` at build time. Never edit the submodule copy.
+- **Webview is sandboxed** — no filesystem/Node access; everything through `bridge.ts`. Never give the webview direct FS access to "simplify" things. ARCH-9 hardens this boundary; it must not dissolve it.
+- **Model IDs centralised** — only in `src/ai/modelConfig.ts` (post-Sprint 79). Never hardcode model names anywhere else.
+- **Flows are JSON + pluggable executors** — new automation capability = new node executor, not a new engine.
+- **Features ON by default, gated by flags** — never delete code to disable (broke Settings in v1.3.0). Disable only via `src/features/flags.ts` and only on explicit instruction.
+- **Layout invariants owned by patch 002** — sidebar, terminal, titlebar placement is contractual; enforced by `.claude/hooks/pre-commit-validator.sh`.
+- **darwin-arm64 is the primary target** — Apple Silicon first; x64/Windows follow.
+- **Three distinct AI execution shapes** — autonomous agent runtimes (Claude Code, Codex, ACP) vs. single-shot flow nodes are genuinely different and must stay so. Sprint 79 unifies the plumbing, not the behavior. The distinction is why `AgentRuntime.prompt()` is separate from `FlowExecutor` node execution.
 
 ---
 
@@ -278,4 +423,5 @@ These items are tracked here until resolved in a sprint:
 
 | Date | Sprint | Changes |
 |---|---|---|
-| 2026-06-06 | Baseline | Initial document. Captures AS IS state post-Sprint 78: 3 runtimes, 2 browser integration patterns, 3 model config locations. Defines TO BE for Sprint 79 (runtime adapter unification). |
+| 2026-06-06 | Baseline | Initial document (agent runtime scope). Captures AS IS post-Sprint 78: 3 runtimes, 2 browser integration patterns, 3 model config locations. Defines TO BE for Sprint 79 (runtime adapter unification). |
+| 2026-06-06 | Pre-Sprint 79 | Expanded to full system scope. Added: system layers overview, webview↔host protocol, flows architecture, build pipeline (with ARCH-8 and ARCH-10 observations), broader TO BE roadmap (ARCH-8 through ARCH-13), locked decisions. Reconciled with `docs-internal/architecture/` (high-level-architecture.md + to-be-proposal.md). |

--- a/docs/development/architecture.md
+++ b/docs/development/architecture.md
@@ -287,9 +287,9 @@ update-feed.json        Sparkle update feed → jarmo-productory/ritemark-public
 
 Build prerequisites (not enforceable at commit time): Node v20.x arm64 for prod, Node v22.21.1 arm64 for dev, `arch -arm64` shell wrapper. Full commands and gotchas in `.claude/skills/vscode-development/SKILL.md`.
 
-**Known architectural issue — extension host (ARCH-8):** The host ships as 105 loose `.js` files plus the entire `node_modules` tree (~180 packages). Most packages are transitive dependencies of `@anthropic-ai/claude-agent-sdk` + `@modelcontextprotocol/sdk` and are not loaded at runtime. This is the root cause of three documented incidents: Windows EMFILE, the 0-byte tsc trap (v1.7.1), and DMG bloat. Fix: esbuild bundle with tree-shaking; target is a handful of self-contained files.
+**Known architectural issue ([#105](https://github.com/ProductoryHQ/ritemark-native/issues/105)):** The host ships as 105 loose `.js` files plus the entire `node_modules` tree (~180 packages). Most packages are transitive dependencies not loaded at runtime. Root cause of three documented incidents: Windows EMFILE, the 0-byte tsc trap (v1.7.1), and DMG bloat.
 
-**Known architectural issue — webview bundle (ARCH-10):** The webview bundle is documented in several places as "~900 KB" but is actually **~7.6 MB** (~8× undocumented growth). All surfaces — TipTap editor, PDF/Excel/DOCX viewers, Flows canvas, AI sidebar — are in one IIFE loaded on every `.md` open. No CI bundle-size budget exists.
+**Known architectural issue ([#107](https://github.com/ProductoryHQ/ritemark-native/issues/107)):** The webview bundle is documented in several places as "~900 KB" but is actually **~7.6 MB** (~8× undocumented growth). All surfaces in one IIFE loaded on every `.md` open. No CI bundle-size budget exists.
 
 ---
 
@@ -319,7 +319,7 @@ src/daemon/                          ← NEW in Sprint 79
 
 4. **Background execution (Phase 2).** Phase 1 (Sprint 80) runs while Ritemark is open. True background execution (process keeps running after app close) requires OS-level service integration — out of scope until there is user demand.
 
-5. **Cross-runtime context (Sprint 80 pre-flight):** The daemon fires a runtime and receives results. When the daemon result is surfaced in the Agent Library alongside interactive history, what context (if any) carries between them? See ARCH-13.
+5. **Cross-runtime context (Sprint 80 pre-flight):** The daemon fires a runtime and receives results. When the daemon result is surfaced in the Agent Library alongside interactive history, what context (if any) carries between them? Design decision required before Sprint 80 — see [#97](https://github.com/ProductoryHQ/ritemark-native/issues/97).
 
 ---
 
@@ -339,52 +339,30 @@ All model identifiers in `src/ai/modelConfig.ts`. The CLAUDE.md rule "all model 
 
 ---
 
-## Broader Architectural Roadmap (Post-Sprint 79)
-
-These improvements are not in Sprint 79 scope. Each is independently shippable. Tracked as ARCH items below.
-
-**Sequencing (from docs-internal/architecture/to-be-proposal.md):**
-
-1. ~~Dead-code removal (#4)~~ ✅ Sprint 74 | Patch manifest (#7) — low priority
-2. **Esbuild host bundle (#1) + build integrity gate (#6)** — ARCH-8, ARCH-11. The keystone structural win; they reinforce each other. Sprint 79 runtime unification makes the host cleaner and esbuild more tractable.
-3. **Shared model config (#3) + typed webview protocol (#2)** — ARCH-9. Sprint 79 does the model-ID half; the full shared-module approach pairs with the typed protocol.
-4. **Webview lazy-load + size budget (#5)** — ARCH-10. Last; highest constraint (CSP-compatible chunk loading, not just a Vite flag).
-
-**Item summaries:**
-
-**#1 Bundle the extension host (esbuild) — ARCH-8 — the keystone win.** Bundle the host into a small set of files using esbuild (same tool VS Code extensions use), tree-shaking out everything not reachable from `extension.ts`. `node_modules` stops shipping. Payoff: dissolves EMFILE structurally, eliminates the 0-byte tsc trap (a broken bundle fails loudly, not silently), shrinks the DMG, speeds extension activation. Watch-out: native modules and bundled agent binaries stay external (mark `external` in esbuild, copy explicitly).
-
-**#2 Typed webview ↔ host protocol — ARCH-9.** Define the protocol as a discriminated union in a shared module (`shared/protocol.ts`) imported by both sides. Adding or changing a message type becomes a compile error on both ends until both are updated. Sprint 79 reduces message types from 9+ to 3 (agent-execute/cancel/approve), making the typed protocol tractable.
-
-**#3 Single model-config source — partial in Sprint 79 (R6).** Sprint 79 consolidates model IDs into `modelConfig.ts`. Full solution: promote to a `@shared` module that both host (esbuild) and webview (Vite `@shared` alias) import directly, eliminating the runtime `flow:modelConfig` mirror message for static config.
-
-**#5 Webview lazy-load + size budget — ARCH-10.** Split viewers (PDF/Excel/DOCX) and Flows canvas out of the editor critical path. Requires CSP-compatible chunk loading (nonce'd script injection or small loader) — not just flipping `inlineDynamicImports`. Add a CI bundle-size budget so the ~7.6 MB figure is tracked, not invisible.
-
-**#6 Build-integrity gate — ARCH-11.** Before signing: (a) clean build from empty `out/`/`dist/` (no incremental tsc state); (b) assert every emitted artifact is non-zero; (c) smoke-launch the built app headless and confirm the `ai-sidebar` sentinel. Win #8 (esbuild bundling) makes (a) and (b) near-automatic — a broken bundle fails at build time, not as a 0-byte file.
-
-**Model gateway — ARCH-12.** Currently the three agent runtimes and flow nodes each carry their own auth, model-resolution, retry, and telemetry paths. A thin gateway interface would unify these without merging execution shapes. Separate from R6 (which consolidates model IDs, not call paths).
-
-**Cross-runtime conversation context — ARCH-13 (GH#97).** When switching agents mid-conversation, what context (if any) carries to the new runtime? Today each runtime has its own backend session; the sidebar renders a single combined transcript — so switching drops prior context from the new agent's view. Three design options: replay-on-switch, unified transcript + per-turn runtime marker, explicit "carry context to <agent>" handoff. **Must be decided before any Sprint 80+ daemon wiring or multi-agent orchestration.** Tracking: [ProductoryHQ/ritemark-native#97](https://github.com/ProductoryHQ/ritemark-native/issues/97).
-
----
-
 ## Open Architectural Debt
 
-| ID | Item | Blocking? | Target sprint |
-|---|---|---|---|
-| **ARCH-1** | `@agentclientprotocol/sdk` esbuild compatibility — verify no dynamic `require()` in prod build. Sprint 76 shipped without verification. | Not blocking, but prerequisite for ARCH-8. | Sprint 79 Phase 0 audit |
-| **ARCH-2** | Unified approval gate — three incompatible approval message types. | No, but each sprint without it adds drift. | Sprint 79 (R3) |
-| **ARCH-3** | `document-search` zombie flag gates deleted RAG code (`src/rag/` removed Sprint 74). | No effect; flag is a tombstone. | Sprint 79 cleanup (R7) |
-| **ARCH-4** | `CODEX_MODELS` in `types.ts` is `@deprecated` but not removed. | No. | Sprint 79 (R6) |
-| **ARCH-5** | Codex browser tools use dynamic injection (`codexBrowserTools.ts`); Claude Code uses MCP server. Two patterns for same capability. | No, but blocks ACP browser parity. | Sprint 79 (R4) — Path A if audit confirms, Path B if blocked |
-| **ARCH-6** | File attachments broken for Codex (partial) and ACP (missing). | Yes — user-visible bug. | Sprint 79 (R5) |
-| **ARCH-7** | `UnifiedViewProvider` at 2480 LOC; grows linearly with each new runtime. | No, but maintainability cost compounds. | Sprint 79 (R2) |
-| **ARCH-8** | Extension host ships as 105 loose `.js` files + ~180 `node_modules` packages. Root cause of Windows EMFILE, 0-byte tsc trap, DMG bloat. Fix: esbuild bundle. | No — three documented incidents but not hard-blocking. | Sprint 80 or 81 |
-| **ARCH-9** | Webview ↔ host protocol is stringly-typed (`bridge.ts`). Message renames fail silently at runtime. | No. | After Sprint 79 (sprint count TBD; Sprint 79 reduces message types from 9+ → 3 first) |
-| **ARCH-10** | Webview bundle is ~7.6 MB IIFE (documented as ~900 KB; 8× undocumented growth). All surfaces loaded on every `.md` open; no CI size budget. | No — UX impact on cold start but not broken. | After ARCH-8 (esbuild first) |
-| **ARCH-11** | Build-integrity gate: Gate 1 has passed a build with 0-byte `.js` files (v1.7.1 incident). Gate checks file existence, not integrity. | Yes — can ship broken DMGs that pass Gate 1. | Sprint 80 (with ARCH-8) |
-| **ARCH-12** | Model gateway: agent runtimes and flow nodes have separate auth / model-resolution / retry / telemetry paths. | No. | After Sprint 79; sequence TBD |
-| **ARCH-13** | Cross-runtime conversation context (GH#97). Switching agents mid-conversation silently drops prior context from the new runtime. Open design decision. | Decision required before Sprint 80 daemon wiring. | Sprint 80 pre-flight |
+Items being resolved in Sprint 79:
+
+| Item | Sprint 79 requirement |
+|---|---|
+| `@agentclientprotocol/sdk` esbuild compatibility audit | Phase 0 audit → `research/arch-1-esbuild-audit.md` |
+| Unified approval gate (3 incompatible message types) | R3 |
+| `document-search` zombie flag (RAG removed Sprint 74) | R7 cleanup |
+| `CODEX_MODELS` deprecated constant | R6 |
+| Codex browser tools: dynamic injection vs MCP server (two patterns) | R4 |
+| File attachments broken for Codex (partial) and ACP (missing) | R5 |
+| `UnifiedViewProvider` at 2480 LOC | R2 — target ≤ 1100 |
+
+Post-Sprint 79 items tracked as GitHub Issues:
+
+| Issue | Item | Prerequisite |
+|---|---|---|
+| [#105](https://github.com/ProductoryHQ/ritemark-native/issues/105) | Extension host esbuild bundling — 105 loose files + ~180 packages; root cause of EMFILE, 0-byte tsc trap, DMG bloat | Sprint 79 |
+| [#106](https://github.com/ProductoryHQ/ritemark-native/issues/106) | Typed webview ↔ host protocol — `bridge.ts` is stringly-typed; renames fail silently at runtime | Sprint 79 (reduces message count 9→3 first) |
+| [#107](https://github.com/ProductoryHQ/ritemark-native/issues/107) | Webview bundle ~7.6 MB IIFE (documented as ~900 KB); no CI size budget; all surfaces loaded on every `.md` open | #105 esbuild first |
+| [#108](https://github.com/ProductoryHQ/ritemark-native/issues/108) | Build-integrity gate — Gate 1 has passed 0-byte builds (v1.7.1); checks presence not integrity | #105 esbuild first |
+| [#109](https://github.com/ProductoryHQ/ritemark-native/issues/109) | Model gateway — agent runtimes and flow nodes have separate auth/model-resolution/retry/telemetry paths | Sprint 79 R6 |
+| [#97](https://github.com/ProductoryHQ/ritemark-native/issues/97) | Cross-runtime conversation context — switching agents drops prior context; open design decision | **Decide before Sprint 80 daemon wiring** |
 
 ---
 

--- a/docs/development/sprints/sprint-79-runtime-unification/scenarios.md
+++ b/docs/development/sprints/sprint-79-runtime-unification/scenarios.md
@@ -1,0 +1,113 @@
+# Sprint 79 Scenarios
+
+## S1 — Claude Code prompt, no regression
+
+**Setup:** Claude Code selected, workspace open, Claude authenticated.
+
+1. User types a prompt in the AI sidebar and sends.
+2. Extension receives `agent-execute { agentId: 'claude-code', prompt, model }`.
+3. `RuntimeRegistry.get('claude-code').prompt(...)` called.
+4. Progress events stream to the sidebar (thinking, tool use, text).
+5. Run completes; sidebar shows result.
+
+**Pass:** Identical behavior to v1.7.3. Message type is `agent-execute` (not `ai-execute-agent`).
+
+## S2 — Codex prompt, no regression
+
+**Setup:** Codex selected, ChatGPT authenticated.
+
+1. User sends prompt. Extension receives `agent-execute { agentId: 'codex', ... }`.
+2. `CodexRuntime.prompt(...)` called.
+3. Streaming progress. Run completes.
+
+**Pass:** Identical behavior to v1.7.3. Old `codex-execute` message no longer exists.
+
+## S3 — ACP/OpenCode prompt, no regression
+
+**Setup:** OpenCode selected, Anthropic API key configured.
+
+1. User sends prompt. Extension receives `agent-execute { agentId: 'opencode', ... }`.
+2. `AcpRuntime.prompt(...)` called.
+3. Streaming, approval if file write attempted, completes.
+
+**Pass:** Identical to v1.7.3.
+
+## S4 — Unified file-write approval (Codex)
+
+1. Codex agent attempts to write a file.
+2. Webview receives `agent-approval-request { agentId: 'codex', kind: 'file-write', filePath, diff }`.
+3. `ApprovalCard` renders with file diff view.
+4. User clicks Approve.
+5. Webview sends `agent-approve { agentId: 'codex', requestId, approved: true, alwaysAllow: false }`.
+6. `CodexRuntime.respondToApproval(...)` resolves the native Codex JSON-RPC approval.
+7. File is written.
+
+**Pass:** Codex file write approval uses the unified card, not the old Codex-specific card.
+
+## S5 — Unified plan approval (Claude Code)
+
+1. Claude enters plan mode and sends plan.
+2. Webview receives `agent-approval-request { agentId: 'claude-code', kind: 'plan', planText }`.
+3. `ApprovalCard` renders plan text.
+4. User approves.
+5. Claude continues execution.
+
+**Pass:** Plan approval uses the unified card. Old `agent-answer-plan` message type no longer exists.
+
+## S6 — Image attachment, Claude Code
+
+1. User attaches a PNG image and sends prompt.
+2. `agent-execute.attachments = [{ kind: 'image', ... }]`.
+3. `ClaudeCodeRuntime` passes attachment to SDK.
+4. Claude responds referencing the image.
+
+**Pass:** No change from v1.7.3.
+
+## S7 — PDF attachment, Codex (new behavior)
+
+1. User attaches a PDF and sends prompt to Codex.
+2. `CodexRuntime.prompt()` inlines PDF content as fenced block in prompt preamble.
+3. Progress stream emits a text event: "Attachment: report.pdf (inlined as text)".
+4. Codex agent responds with content referencing the PDF text.
+
+**Pass:** Previously broken (PDF silently dropped). Now inlined.
+
+## S8 — Browser action, Claude Code (regression)
+
+1. Browser panel open, `browser-agent-control` flag on.
+2. User sends prompt to Claude: "Go to the homepage and summarize the title."
+3. `BrowserToolsInjector.getServers()` called; `browserMcpServer` injected.
+4. Claude uses `browser_navigate` and `browser_snapshot` tools.
+5. Result streamed to sidebar.
+
+**Pass:** Identical to v1.7.3. Browser works via MCP injection (unchanged path).
+
+## S9 — Browser action, Codex (regression or new)
+
+1. Browser panel open, `browser-agent-control` flag on.
+2. User sends prompt to Codex: "Summarize the current browser page."
+3. `CodexRuntime` injects browser tools (via MCP if Path A, via dynamic tools inside adapter if Path B).
+4. Codex uses browser tools, responds.
+
+**Pass:** Identical to v1.7.3 behavior. `_codexBrowserToolsEnabledForThread` is gone from `UnifiedViewProvider`.
+
+## S10 — Cancel mid-run (all runtimes)
+
+1. User sends prompt. Agent starts running.
+2. User clicks Cancel.
+3. Extension receives `agent-cancel { agentId }`.
+4. `RuntimeRegistry.get(agentId).cancel()` called.
+5. Sidebar returns to idle within 3 seconds.
+
+**Pass:** All three runtimes cancel cleanly. Old `codex-cancel` / `acp-cancel` / `ai-cancel-agent` messages gone.
+
+## S11 — Daemon registration (not activated)
+
+1. Developer calls `AgentDaemon.register('claude-code', '0 9 * * 1-5', '/workspace')`.
+2. Daemon does NOT fire immediately (cron not matched).
+3. Developer advances mock clock to 9:00 AM Monday.
+4. `ClaudeCodeRuntime.prompt(...)` called with a headless session.
+5. File-write approval blocked (headless policy); progress logged to output channel.
+6. `DaemonResultStore` records run.
+
+**Pass:** Daemon module works in isolation. Not visible in UI (Sprint 80 wires the UI).

--- a/docs/development/sprints/sprint-79-runtime-unification/spec.md
+++ b/docs/development/sprints/sprint-79-runtime-unification/spec.md
@@ -1,0 +1,142 @@
+# Sprint 79 Spec — Runtime Unification
+
+**Track:** SDD
+**Branch:** `sprint-79-runtime-unification`
+**Architecture doc:** `docs/development/architecture.md`
+
+## Purpose
+
+Eliminate the three parallel agent runtime stacks by introducing a shared `AgentRuntime` interface and collapsing `UnifiedViewProvider` from 2480 LOC to ~900. Fix broken file attachments for Codex and ACP. Unify the approval system to one webview message type. Standardize browser tool injection across all runtimes. Consolidate model config to one file. Clean up architectural debt (zombie flag, deprecated types). Lay the daemon scheduling foundation.
+
+This sprint is a **structural refactor** — no user-visible behavior changes except fixing broken file attachments. Every existing feature must work identically after the sprint.
+
+## Principles
+
+- **Zero user-visible regression.** All three runtimes must work correctly after the refactor. Full integration test for each runtime before merge.
+- **Adapt, don't rewrite.** Existing `CodexManager`, `AcpManager`, and `AgentRunner` are wrapped by adapters, not replaced. Their internal logic stays intact.
+- **Architecture doc as deliverable.** `docs/development/architecture.md` `Last updated` date must equal the sprint close date. This is a required output, not optional.
+- **Incremental, branch-local.** All changes on `sprint-79-runtime-unification`. Each workstream can be a separate commit series; merge to the sprint branch only, never directly to `main` during the sprint.
+
+## Requirements
+
+### R1: `AgentRuntime` interface + `RuntimeRegistry`
+
+As a developer extending Ritemark with a new agent runtime, I want a single well-typed interface to implement, so adding the fourth runtime requires only a new class + a registry entry.
+
+Acceptance criteria:
+- New module `extensions/ritemark/src/runtime/` with:
+  - `AgentRuntime.ts` — the `AgentRuntime` interface, `RuntimeSessionConfig`, `RuntimeTurnConfig`, `RuntimeStatus`, `UnifiedAttachment`
+  - `RuntimeRegistry.ts` — factory that holds one instance per `AgentId`, exposes `get(id)`, `getAll()`, `dispose()`
+- `ClaudeCodeRuntime` in `src/agent/` implements `AgentRuntime`, wrapping existing `AgentRunner` / `AgentSession`. No behavior changes.
+- `CodexRuntime` in `src/codex/` implements `AgentRuntime`, wrapping existing `CodexManager`. No behavior changes.
+- `AcpRuntime` in `src/acp/` implements `AgentRuntime`, wrapping existing `AcpManager`. No behavior changes.
+- `RuntimeRegistry` is created once in `UnifiedViewProvider` constructor and disposed on deactivation.
+- Unit tests: `RuntimeRegistry.test.ts` — get/dispose lifecycle; adapter construction.
+
+### R2: Unified dispatch in `UnifiedViewProvider`
+
+As a developer reading `UnifiedViewProvider`, I want to see one `agent-execute`, one `agent-cancel`, and one `agent-approve` case — not nine runtime-specific variants.
+
+Acceptance criteria:
+- Webview message types refactored (extension host + webview side must agree):
+  - `ai-execute-agent` / `codex-execute` / `acp-execute` → **`agent-execute`** (with `agentId` field)
+  - `ai-cancel-agent` / `codex-cancel` / `acp-cancel` → **`agent-cancel`** (with `agentId`)
+  - `codex-approve` / `acp-approval-response` / `agent-answer-plan` → **`agent-approve`** (with `agentId`, `requestId`, `approved`, `alwaysAllow`, `kind`)
+- `UnifiedViewProvider` switch statement has exactly three cases for the above (plus existing non-agent cases unchanged).
+- All private `_handleAgentExecution`, `_handleCodexExecution`, `_handleAcpExecution` methods are deleted; logic moves into respective runtime adapters.
+- `UnifiedViewProvider` target: ≤ 1100 LOC (from 2480). Remaining LOC is settings handling, browser panel, onboarding, status events — none of which is agent-runtime-specific.
+- Webview (`AgentSelector.tsx`, AI sidebar message posting) updated to send `agent-execute` / `agent-cancel` / `agent-approve`.
+
+### R3: Unified approval gate
+
+As a user, I want file-edit approvals, command approvals, and plan approvals to look and behave the same regardless of which agent runtime is running.
+
+Acceptance criteria:
+- New `src/runtime/UnifiedApprovalGate.ts` — maps native approval types from each runtime adapter into one webview message shape:
+  ```
+  { type: 'agent-approval-request', agentId, requestId, kind: 'file-write'|'shell-command'|'permission'|'plan', ... }
+  ```
+- Extension → webview approval request always uses this shape. Runtime adapters call `ApprovalGate.request(...)` which sends to the webview and returns a Promise that resolves when `agent-approve` arrives.
+- Webview: one `ApprovalCard` component handles all four `kind` values. Existing `PlanApprovalCard` and `CodexApprovalCard` are unified into it. The visual appearance may differ per kind but the component file is one.
+- `codexApproval.ts` routing logic is absorbed into `CodexRuntime` adapter; `codexApproval.ts` is deleted.
+- Rejection sends the correct native rejection to the runtime (Codex JSON-RPC negative response, ACP rejection outcome, Claude SDK interrupt).
+
+### R4: Browser tool injection unification
+
+As a developer, I want browser tools to be injected into all three runtimes through a single `BrowserToolsInjector`, so adding a fourth runtime automatically gets browser capabilities.
+
+Acceptance criteria:
+- New `src/runtime/BrowserToolsInjector.ts` — returns `{ enabled: boolean, mcpServers: Record<string, unknown> }` based on `browser-agent-control` flag and current browser state.
+- `ClaudeCodeRuntime` calls `BrowserToolsInjector.get()` and passes `mcpServers` into `AgentSessionConfig` (existing behavior, just relocated).
+- `CodexRuntime` calls `BrowserToolsInjector.get()` and uses `codexBrowserTools.ts`'s MCP injection path (or equivalent). `codexBrowserTools.ts` is **deleted**; Codex receives browser as MCP, not as dynamic tools. This is the primary behavioral change — verify with an integration test (Codex + browser action).
+- `AcpRuntime` calls `BrowserToolsInjector.get()` and passes MCP servers into the ACP `initialize` request (OpenCode supports `mcpServers` in ACP init — verify in research/acp-browser-audit.md).
+- `UnifiedViewProvider` no longer holds `_codexBrowserToolsEnabledForThread` state; this is internalized in `CodexRuntime`.
+
+### R5: File attachment unification
+
+As a user, I want to attach images, PDFs, and text files to prompts for any agent runtime, not just Claude Code.
+
+Acceptance criteria:
+- `UnifiedAttachment` type in `src/runtime/AgentRuntime.ts`:
+  ```typescript
+  interface UnifiedAttachment { id: string; kind: 'image'|'pdf'|'text'; name: string; data: string; mediaType: string; }
+  ```
+- `ClaudeCodeRuntime`: passes `UnifiedAttachment[]` through unchanged (already compatible).
+- `CodexRuntime`: images → data URLs (existing behavior); PDF and text files → inline as a fenced block in the prompt preamble with a notice ("Attachment: <name>\n```\n<content>\n```"). Codex does not support native multimodal; the inline approach is the best available.
+- `AcpRuntime`: images → inline base64 prompt attachment if the selected provider supports multimodal (check provider capabilities from `BYOK_PROVIDER_MODELS`); text/PDF → inline fenced block like Codex. Show a notice in the progress stream when a non-supported attachment type is downgraded.
+- Webview: the attachment picker sends `UnifiedAttachment[]` in `agent-execute.attachments` (unified message type from R2). The attachment UI does not change visually.
+
+### R6: Model config consolidation
+
+As a developer, I want all model IDs in one file (`modelConfig.ts`), so the CLAUDE.md rule is literally true.
+
+Acceptance criteria:
+- `CLAUDE_MODELS` and `DEFAULT_MODEL` are moved from `src/agent/types.ts` to `src/ai/modelConfig.ts`.
+- `CODEX_MODELS` (deprecated) in `types.ts` is **deleted**. Any remaining callers (verify with grep) are migrated to `codexModels.ts::getCodexModels()`.
+- `agent/types.ts` retains only type definitions — no runtime data (model arrays, default strings).
+- All imports updated. TS compiles cleanly. Pre-commit hook passes.
+
+### R7: Architectural debt cleanup
+
+Acceptance criteria:
+- **ARCH-3 (zombie flag):** `document-search` flag in `flags.ts` set to `status: 'disabled'` (the RAG code it gated was deleted in Sprint 74). Description updated: "Removed in Sprint 74. Flag retained as a kill-switch tombstone."
+- **ARCH-4 (deprecated constant):** `CODEX_MODELS` deleted (see R6).
+- **ARCH-1 (esbuild bundling):** Verify `@agentclientprotocol/sdk` has no dynamic `require()` by running the production build and checking for bundling warnings. Record result in `research/arch-1-esbuild-audit.md`.
+
+### R8: Daemon foundation
+
+As a developer building scheduled agent tasks, I want a `AgentDaemon` module that can register an agent + schedule and fire it, using the `AgentRuntime` interface, so Sprint 80 can build the full scheduling UX without protocol-level work.
+
+Acceptance criteria:
+- New `src/daemon/AgentDaemon.ts` — takes a `RuntimeRegistry`, registers `(agentId, cronExpression, workspacePath)` entries, fires `runtime.prompt(...)` on schedule using `node-cron` (or `cron-parser` already installed via Sprint 77).
+- `AgentDaemon` runs inside the VS Code extension host process (no separate process, no OS service — Phase 1 "open only" design).
+- Headless approval policy: `file-write` → blocked (logged as skipped, not silently applied); `shell-command` → blocked; `permission` → blocked. Agent only performs read-only operations unless the approval policy is explicitly configured. This prevents autonomous destructive operations.
+- `DaemonResultStore.ts` — persists last-run timestamp + result summary in `workspaceState` per agent ID.
+- `AgentDaemon` is NOT activated in this sprint — it is instantiated but not connected to any UI or to the `schedule:` frontmatter field. Sprint 80 does that wiring. The sprint 79 deliverable is the working, tested module.
+- Unit tests: `AgentDaemon.test.ts` — register/fire/cancel; headless approval blocks fire-and-forget; result stored.
+
+### R9: Architecture document update
+
+Acceptance criteria:
+- `docs/development/architecture.md` `Last updated` date = sprint close date.
+- All ARCH-N items resolved in this sprint are moved from "Open Architectural Debt" to the Version History entry.
+- The AS IS section is updated to describe the post-Sprint 79 state (not the pre-sprint state).
+- `CLAUDE.md` model config section updated to reflect consolidation.
+
+## Non-Requirements
+
+- No change to user-visible UI except file attachment behavior for Codex/ACP (R5).
+- No new features beyond R8 daemon foundation.
+- No Goose or other additional ACP agent bundled (out of scope — the interface enables it, the bundling is not part of this sprint).
+- No background daemon execution (OS service, launchd, systemd) — Phase 2, post-Sprint 80.
+- No changes to the webview bundle architecture or Vite config.
+- No VS Code patches added or removed.
+
+## Open Questions
+
+| # | Question | Owner |
+|---|---|---|
+| Q1 | Does OpenCode ACP `initialize` accept `mcpServers`? What's the exact field name? | Verify in `research/acp-browser-audit.md` (Phase 0 audit) |
+| Q2 | Does Codex JSON-RPC protocol support MCP server injection at session start (to replace `codexBrowserTools.ts`)? Or is it a different mechanism? | Audit `codexAppServer.ts` + Codex protocol docs |
+| Q3 | Does `node-cron` or `cron-parser` (already installed via Sprint 77) expose a scheduler we can use for R8, or do we need an additional dep? | Check Sprint 77 dep in package.json |
+| Q4 | Should `agent-execute` replace the webview messages immediately (breaking) or should we keep old messages and add new ones with a migration period? | Jarmo decision — clean break preferred; migration window only if webview regression risk is high |

--- a/docs/development/sprints/sprint-79-runtime-unification/spec.md
+++ b/docs/development/sprints/sprint-79-runtime-unification/spec.md
@@ -131,6 +131,7 @@ Acceptance criteria:
 - No background daemon execution (OS service, launchd, systemd) — Phase 2, post-Sprint 80.
 - No changes to the webview bundle architecture or Vite config.
 - No VS Code patches added or removed.
+- **No cross-runtime conversation context sharing (GH#97).** When a user switches agents mid-conversation, context is not carried between runtimes. This is a pre-existing behavior; the unified message protocol introduced in R2 does not require solving it. The decision on how to handle context across runtimes must happen before Sprint 80 daemon wiring — see ARCH-13 in `docs/development/architecture.md`.
 
 ## Open Questions
 
@@ -140,3 +141,4 @@ Acceptance criteria:
 | Q2 | Does Codex JSON-RPC protocol support MCP server injection at session start (to replace `codexBrowserTools.ts`)? Or is it a different mechanism? | Audit `codexAppServer.ts` + Codex protocol docs |
 | Q3 | Does `node-cron` or `cron-parser` (already installed via Sprint 77) expose a scheduler we can use for R8, or do we need an additional dep? | Check Sprint 77 dep in package.json |
 | Q4 | Should `agent-execute` replace the webview messages immediately (breaking) or should we keep old messages and add new ones with a migration period? | Jarmo decision — clean break preferred; migration window only if webview regression risk is high |
+| Q5 | **Cross-runtime conversation context (GH#97, ARCH-13).** The `AgentRuntime` interface as designed is compatible with future context-sharing (each runtime receives `start()` which could accept replay context). But the Sprint 80 daemon wiring needs a decision: when daemon results appear alongside interactive history in the Agent Library, what constitutes "context"? This does not block Sprint 79 implementation — record the design decision as an explicit prerequisite for Sprint 80 planning. | Jarmo decision before Sprint 80 kickoff |

--- a/docs/development/sprints/sprint-79-runtime-unification/sprint-plan.md
+++ b/docs/development/sprints/sprint-79-runtime-unification/sprint-plan.md
@@ -1,0 +1,69 @@
+# Sprint 79 Plan — Runtime Unification
+
+**Status:** PLANNING — awaiting Jarmo approval
+**Branch:** `sprint-79-runtime-unification` (create after approval)
+**Estimated size:** Large (structural refactor across 5 subsystems)
+**Risk:** Medium — no user-visible behavior change expected; main risk is integration regressions caught by manual testing
+
+## What This Sprint Does
+
+Structural refactor of the Ritemark extension's agent runtime layer. Introduces an `AgentRuntime` interface and `RuntimeRegistry` so all three runtimes (Claude Code, Codex, ACP/OpenCode) are interchangeable plugins. Collapses `UnifiedViewProvider` from 2480 to ≤1100 LOC. Fixes broken file attachments for Codex and ACP. Unifies the approval system to one message type and one UI card. Standardizes browser tool injection. Consolidates model config. Cleans up five architectural debt items. Lays the daemon scheduling foundation (inactive — Sprint 80 activates it).
+
+## What This Sprint Does NOT Do
+
+- No new user-visible features (except fixing file attachment support for Codex/ACP).
+- No fourth runtime bundled.
+- No background/OS-level daemon execution.
+- No VS Code patches.
+- No UI changes.
+
+## Phase 0 — Audits (before code approval)
+
+Three short audits must complete before implementation begins:
+1. ACP browser MCP injection — can OpenCode accept MCP servers in `initialize`?
+2. Codex MCP injection — can Codex receive MCP server list at session start?
+3. `@agentclientprotocol/sdk` esbuild bundleability.
+
+These answer the two open implementation paths (browser injection Path A vs Path B) and clear ARCH-1.
+
+## Phase 1 → Phase 7 (standard SDD track)
+
+Follows the standard sprint-manager phases:
+
+| Phase | Content |
+|---|---|
+| Phase 0 | Audits (above) |
+| Phase 1 | Spec + tech plan + scenarios (this doc — DONE) |
+| Phase 2 | **Jarmo approval gate** |
+| Phase 3 | Implementation (W1→W7, see tasks.md) |
+| Phase 4 | Integration testing (S1–S11, see scenarios.md) |
+| Phase 5 | QA gate (`qa-validator`, pre-commit hook, LOC check) |
+| Phase 6 | PR + merge |
+| Phase 7 | Architecture doc update (R9 — mandatory deliverable) |
+
+## Architectural Decisions Made
+
+These are locked for this sprint. Changes require Jarmo sign-off:
+
+| Decision | Rationale |
+|---|---|
+| Adapter pattern (not protocol unification) | Preserve existing runtime internals; minimize regression risk |
+| `UnifiedAttachment` in `runtime/` layer | Single source of truth for attachment types; adapters convert to native |
+| Daemon is inactive in Sprint 79 | UI wiring is Sprint 80 scope; foundation only this sprint |
+| Approval gate uses Promise-based pending Map | Matches existing pattern in `src/acp/` and `src/codex/` |
+| Codex browser Path A preferred | Reduces code duplication; contingent on audit |
+
+## Open Questions (require Jarmo input)
+
+| Q | Question | Default if Jarmo unavailable |
+|---|---|---|
+| Q4 | Clean break on message rename (`agent-execute` replaces `ai-execute-agent` etc.) vs migration period? | Clean break (no migration window) — conversation history is reset on upgrade anyway |
+
+## Definition of Done
+
+- [ ] All tasks in `tasks.md` checked
+- [ ] All scenarios in `scenarios.md` pass (manual + automated)
+- [ ] `UnifiedViewProvider.ts` ≤ 1100 LOC
+- [ ] `qa-validator` passes
+- [ ] `docs/development/architecture.md` updated (Last updated = sprint close date)
+- [ ] PR merged to `main`

--- a/docs/development/sprints/sprint-79-runtime-unification/tasks.md
+++ b/docs/development/sprints/sprint-79-runtime-unification/tasks.md
@@ -1,0 +1,97 @@
+# Sprint 79 Tasks
+
+## Phase 0 — Audits
+
+- [ ] `research/acp-browser-audit.md` — Can ACP `initialize` accept MCP servers? Verify with `opencode acp` binary. Decide Path A or B for W3.
+- [ ] `research/codex-mcp-injection-audit.md` — Does Codex protocol support MCP injection at session start? Read `codexAppServer.ts` + Codex protocol spec. Decide Path A or B for W3.
+- [ ] `research/arch-1-esbuild-audit.md` — Run prod build, check `@agentclientprotocol/sdk` bundling, no dynamic-require warnings.
+- [ ] Check `cron-parser` installed version in `package.json` (v4 or v5 API for R8).
+
+## Phase 3 — Implementation
+
+### W1: `src/runtime/` interface + registry
+
+- [ ] Create `src/runtime/AgentRuntime.ts` — interface + all shared types
+- [ ] Create `src/runtime/RuntimeRegistry.ts`
+- [ ] Create `src/runtime/UnifiedApprovalGate.ts`
+- [ ] Create `src/runtime/BrowserToolsInjector.ts`
+- [ ] Create `src/runtime/index.ts`
+- [ ] `RuntimeRegistry.test.ts` — lifecycle tests
+
+### W6: Daemon foundation
+
+- [ ] Create `src/daemon/AgentDaemon.ts` — cron scheduler using `RuntimeRegistry`
+- [ ] Create `src/daemon/DaemonSession.ts` — headless turn + auto-approval block policy
+- [ ] Create `src/daemon/DaemonResultStore.ts` — workspaceState persistence
+- [ ] Create `src/daemon/DaemonStatusEvents.ts` — output channel trace
+- [ ] `AgentDaemon.test.ts` — register/fire/cancel; headless blocks; result stored
+- [ ] Register `AgentDaemon` in `extension.ts` (instantiated, not activated)
+
+### W4: Runtime adapters
+
+- [ ] `src/agent/ClaudeCodeRuntime.ts` implements `AgentRuntime` — wraps `AgentRunner`/`AgentSession`
+- [ ] `ClaudeCodeRuntime.test.ts` — mock manager, verify interface contract
+- [ ] `src/codex/CodexRuntime.ts` implements `AgentRuntime` — wraps `CodexManager`
+- [ ] `CodexRuntime.test.ts`
+- [ ] `src/acp/AcpRuntime.ts` implements `AgentRuntime` — wraps `AcpManager`
+- [ ] `AcpRuntime.test.ts`
+- [ ] Wire `RuntimeRegistry` in `UnifiedViewProvider` constructor
+
+### W2: Unified dispatch
+
+- [ ] Rename webview message types: `agent-execute`, `agent-cancel`, `agent-approve` (extension host)
+- [ ] Update `UnifiedViewProvider` switch — 3 cases replace 9
+- [ ] Delete `_handleAgentExecution`, `_handleCodexExecution`, `_handleAcpExecution` private methods
+- [ ] Update webview side (`AgentSelector.tsx`, AI sidebar message posts) to send new message types
+- [ ] `UnifiedApprovalGate` wired to webview in `UnifiedViewProvider`
+- [ ] Verify `UnifiedViewProvider` ≤ 1100 LOC (`wc -l`)
+
+### W3: Browser injection
+
+- [ ] Implement per Phase 0 audit decision (Path A or B — see tech plan)
+- [ ] If Path A: delete `codexBrowserTools.ts`, verify Codex browser tests pass
+- [ ] If Path B: move `codexBrowserTools.ts` logic inside `CodexRuntime`, delete from `UnifiedViewProvider`
+- [ ] Delete `_codexBrowserToolsEnabledForThread` from `UnifiedViewProvider`
+- [ ] `BrowserToolsInjector.test.ts`
+
+### W5: File attachments
+
+- [ ] `UnifiedAttachment` type plumbed through `agent-execute` webview message
+- [ ] `CodexRuntime.prompt()` — PDF/text inlined; image as data URL
+- [ ] `AcpRuntime.prompt()` — image multimodal if provider supports; text/PDF inlined
+- [ ] Webview `agent-execute` payload includes `attachments?: UnifiedAttachment[]`
+- [ ] Test S7 (PDF attachment, Codex) manually in dev mode
+
+### W7: Cleanup + docs
+
+- [ ] `flags.ts`: `document-search` → `status: 'disabled'`
+- [ ] Delete `CODEX_MODELS` from `agent/types.ts`
+- [ ] Move `CLAUDE_MODELS` + `DEFAULT_MODEL` to `modelConfig.ts`; update all import sites
+- [ ] Delete `codexApproval.ts` (logic absorbed into `CodexRuntime`)
+- [ ] Update `docs/development/architecture.md`:
+  - `Last updated` date
+  - AS IS section → post-sprint state
+  - Close ARCH-2,3,4,5 (and 6/8 per audit outcomes)
+  - Add Version History entry
+- [ ] `CLAUDE.md` model config section — confirm post-sprint wording is accurate
+
+## Phase 4 — Integration Testing
+
+- [ ] S1: Claude Code prompt, no regression
+- [ ] S2: Codex prompt, no regression
+- [ ] S3: ACP/OpenCode prompt, no regression
+- [ ] S4: Unified file-write approval (Codex)
+- [ ] S5: Unified plan approval (Claude Code)
+- [ ] S6: Image attachment, Claude Code
+- [ ] S7: PDF attachment, Codex (new behavior)
+- [ ] S8: Browser action, Claude Code
+- [ ] S9: Browser action, Codex
+- [ ] S10: Cancel mid-run (all 3 runtimes)
+- [ ] S11: Daemon registration (unit test)
+
+## Phase 5 — QA Gate
+
+- [ ] `qa-validator` passes
+- [ ] Pre-commit hook passes
+- [ ] `wc -l extensions/ritemark/src/views/UnifiedViewProvider.ts` ≤ 1100
+- [ ] `docs/development/architecture.md` `Last updated` = sprint close date

--- a/docs/development/sprints/sprint-79-runtime-unification/technical-plan.md
+++ b/docs/development/sprints/sprint-79-runtime-unification/technical-plan.md
@@ -42,6 +42,7 @@ Webview (AI sidebar)                Extension Host                    External p
 - Run a production build with `@agentclientprotocol/sdk` included.
 - Check for `dynamic require` warnings in the Gulp/esbuild output.
 - Decision: **no issue** / **needs bundler config fix** / **needs SDK version pin change**.
+- If work is needed: record the required fix as **ARCH-8** in `docs/development/architecture.md` (extension host esbuild bundling) and add to Sprint 80 planning. The full esbuild bundling win (ARCH-8) is out of Sprint 79 scope regardless of this audit outcome — the audit only validates that `@agentclientprotocol/sdk` will not block the future bundling sprint.
 
 ## Workstream 1: `src/runtime/` — Interface + Registry (R1)
 

--- a/docs/development/sprints/sprint-79-runtime-unification/technical-plan.md
+++ b/docs/development/sprints/sprint-79-runtime-unification/technical-plan.md
@@ -1,0 +1,300 @@
+# Sprint 79 Technical Plan — Runtime Unification
+
+## Architecture Diagram (Target State)
+
+```
+Webview (AI sidebar)                Extension Host                    External processes
+┌───────────────────┐  agent-        ┌───────────────────────────┐
+│ AgentSelector      │  execute       │ UnifiedViewProvider        │
+│ ApprovalCard       │──────────────▶│   (≤1100 LOC post-sprint) │
+│ ProgressStream     │  agent-approve │   ↓                        │
+│                    │◀──────────────│ RuntimeRegistry             │
+│ [unified msgs]     │  agent-approve │   ↓ get(agentId)           │
+└───────────────────┘  -request      │ AgentRuntime (interface)   │
+                                     │   ├─ ClaudeCodeRuntime ────▶ claude binary (SDK)
+                                     │   ├─ CodexRuntime ─────────▶ codex-app-server (stdio)
+                                     │   └─ AcpRuntime ───────────▶ opencode acp (stdio)
+                                     │                              │
+                                     │ UnifiedApprovalGate         │
+                                     │   └─ one Promise per req    │
+                                     │                              │
+                                     │ BrowserToolsInjector        │
+                                     │   └─ mcpServers → all runtimes
+                                     │                              │
+                                     │ AgentDaemon (inactive)      │
+                                     │   └─ uses RuntimeRegistry   │
+                                     └───────────────────────────┘
+```
+
+## Phase 0: Audits (before any code — Phase 3 starts only after Q1+Q2 answered)
+
+### `research/acp-browser-audit.md`
+- Spawn `opencode acp` and send an `initialize` request with an MCP server entry.
+- Verify: does OpenCode expose injected MCP tools to the agent? What's the field name in `initialize`?
+- Decision: **use MCP injection** / **fallback: inject browser context as system prompt only** / **defer browser support for ACP**.
+
+### `research/codex-mcp-injection-audit.md`
+- Read `codexAppServer.ts` initialize flow and Codex protocol docs.
+- Determine: can we pass an MCP server list at session start (replacing the dynamic tool injection in `codexBrowserTools.ts`)?
+- Decision: **replace with MCP** / **keep dynamic injection but move into CodexRuntime adapter** / **two-step: keep dynamic, MCP in follow-up sprint**.
+
+### `research/arch-1-esbuild-audit.md`
+- Run a production build with `@agentclientprotocol/sdk` included.
+- Check for `dynamic require` warnings in the Gulp/esbuild output.
+- Decision: **no issue** / **needs bundler config fix** / **needs SDK version pin change**.
+
+## Workstream 1: `src/runtime/` — Interface + Registry (R1)
+
+### Files
+
+| File | Content |
+|---|---|
+| `src/runtime/AgentRuntime.ts` | Interface + all shared types (`RuntimeSessionConfig`, `RuntimeTurnConfig`, `RuntimeStatus`, `UnifiedAttachment`) |
+| `src/runtime/RuntimeRegistry.ts` | `class RuntimeRegistry { get(id): AgentRuntime; getAll(): AgentRuntime[]; dispose(): void }` |
+| `src/runtime/UnifiedApprovalGate.ts` | `class UnifiedApprovalGate { request(params): Promise<ApprovalResult>; respond(requestId, result): void }` — holds pending Map, wired to webview by `UnifiedViewProvider` |
+| `src/runtime/BrowserToolsInjector.ts` | `getServers(enabled: boolean): MCP servers config` — wraps `createBrowserMcpServer` from `src/browser/` |
+| `src/runtime/index.ts` | Public exports |
+
+### `AgentRuntime` interface (full)
+
+```typescript
+export interface AgentRuntime {
+  readonly id: AgentId;
+
+  /** Initialize the runtime. Called once per workspace session. */
+  start(config: RuntimeSessionConfig): Promise<void>;
+
+  /** Send a prompt turn. Streams progress via config.onProgress. */
+  prompt(turn: RuntimeTurnConfig): Promise<void>;
+
+  /** Cancel the current turn. Must resolve within 3 seconds. */
+  cancel(): Promise<void>;
+
+  /** Handle an approval response from the webview. */
+  respondToApproval(requestId: string, approved: boolean, alwaysAllow: boolean): void;
+
+  /** Runtime-specific status (auth, binary, version). */
+  getStatus(): Promise<RuntimeStatus>;
+
+  /** Clean up process handles and event listeners. */
+  dispose(): void;
+}
+
+export interface RuntimeSessionConfig {
+  workspacePath: string;
+  model?: string;
+  excludedFolders?: string[];
+  extraSystemPrompt?: string;
+  mcpServers?: Record<string, unknown>;
+  onProgress: (p: AgentProgress) => void;
+  onApprovalRequest: (req: UnifiedApprovalRequest) => void;
+}
+
+export interface RuntimeTurnConfig {
+  prompt: string;
+  attachments?: UnifiedAttachment[];
+  activeFile?: ActiveFileContext;
+  timeoutMinutes?: number;
+}
+
+export interface UnifiedAttachment {
+  id: string;
+  kind: 'image' | 'pdf' | 'text';
+  name: string;
+  data: string;       // base64 for image/pdf; raw text for text
+  mediaType: string;
+}
+
+export interface UnifiedApprovalRequest {
+  requestId: string;
+  agentId: AgentId;
+  kind: 'file-write' | 'shell-command' | 'permission' | 'plan';
+  // kind-specific optional fields:
+  filePath?: string;       // file-write
+  diff?: string;           // file-write
+  command?: string;        // shell-command
+  workingDir?: string;     // shell-command
+  permissionLabel?: string; // permission
+  planText?: string;       // plan
+}
+
+export interface RuntimeStatus {
+  ready: boolean;
+  authState: 'authenticated' | 'needs-auth' | 'not-installed' | 'error';
+  version?: string;
+  diagnostics: string[];
+}
+```
+
+### Adapter implementation notes
+
+**`ClaudeCodeRuntime`** (`src/agent/ClaudeCodeRuntime.ts`):
+- `start()` → creates `AgentSession` from existing `AgentRunner`
+- `prompt()` → calls `session.prompt(turn)`, maps SDK events to `AgentProgress` (existing logic from `_handleAgentExecution`)
+- `cancel()` → `session.interrupt()`
+- `respondToApproval()` → `_handleAgentPlanAnswer()` / `_handleAgentQuestionAnswer()` (existing)
+- MCP servers → `AgentSessionConfig.mcpServers` (no change needed)
+
+**`CodexRuntime`** (`src/codex/CodexRuntime.ts`):
+- `start()` → initializes `CodexManager` (existing)
+- `prompt()` → `codexManager.execute(...)`, maps Codex events to `AgentProgress` (from `_handleCodexExecution`)
+- `cancel()` → `codexManager.cancel()`
+- `respondToApproval()` → routes to `codexManager.approveRequest(...)` or `rejectRequest(...)`
+- Browser: Phase 0 audit determines if MCP injection replaces `codexBrowserTools.ts`
+
+**`AcpRuntime`** (`src/acp/AcpRuntime.ts`):
+- `start()` → `acpManager.start()`
+- `prompt()` → `acpManager.prompt(...)`, maps `session/update` to `AgentProgress` (existing)
+- `cancel()` → `acpManager.cancel()`
+- `respondToApproval()` → routes to `acpManager.respondPermission(...)` or `respondFsWrite(...)`
+- Browser: MCP server list passed in ACP `initialize` (pending Phase 0 audit)
+
+## Workstream 2: Unified Approval Gate (R3)
+
+### Approval flow (new)
+
+```
+Runtime adapter receives native approval request
+  → calls config.onApprovalRequest(UnifiedApprovalRequest)
+  → UnifiedViewProvider receives it
+  → sends { type: 'agent-approval-request', ...request } to webview
+  → webview renders ApprovalCard
+  → user clicks Approve/Reject
+  → webview sends { type: 'agent-approve', requestId, approved, alwaysAllow }
+  → UnifiedViewProvider calls runtime.respondToApproval(requestId, approved, alwaysAllow)
+  → runtime adapter resolves native Promise and continues
+```
+
+### Webview changes (R2 + R3 combined)
+
+Old messages (deleted):
+- `ai-execute-agent`, `codex-execute`, `acp-execute` → replaced by `agent-execute { agentId, prompt, model, attachments }`
+- `ai-cancel-agent`, `codex-cancel`, `acp-cancel` → `agent-cancel { agentId }`
+- `codex-approve`, `acp-approval-response`, `agent-answer-plan` → `agent-approve { agentId, requestId, approved, alwaysAllow, kind }`
+
+New messages (extension → webview):
+- `agent-approval-request { agentId, requestId, kind, ...payload }`
+- `agent-progress { agentId, progress }` (unifies existing per-runtime progress posts)
+
+`ApprovalCard.tsx` (new unified component):
+- Receives `kind` prop — renders appropriate content for file-write / shell-command / permission / plan
+- Replaces: `PlanApprovalCard.tsx`, `CodexApprovalCard.tsx`, `AcpApprovalCard.tsx` (if it exists separately)
+
+## Workstream 3: Browser Tool Injection (R4)
+
+Dependent on Phase 0 audits. Two paths:
+
+**Path A (preferred if audits confirm MCP injection works for both):**
+- `BrowserToolsInjector.getServers()` returns MCP server config
+- All three runtime adapters call it in `start()` and pass to their native session config
+- `codexBrowserTools.ts` deleted
+- `UnifiedViewProvider._codexBrowserToolsEnabledForThread` state deleted
+
+**Path B (fallback if Codex MCP injection is blocked):**
+- `BrowserToolsInjector` has two modes: `mode: 'mcp'` (Claude Code, ACP) and `mode: 'dynamic-tools'` (Codex fallback)
+- `codexBrowserTools.ts` is kept but wrapped inside `CodexRuntime`, no longer directly in `UnifiedViewProvider`
+- `_codexBrowserToolsEnabledForThread` moves from `UnifiedViewProvider` to `CodexRuntime`
+- Record Path B as ARCH-8 debt in `architecture.md` for resolution in a future sprint
+
+Decision captured in `research/codex-mcp-injection-audit.md`.
+
+## Workstream 4: File Attachments (R5)
+
+### Codex attachment handling in `CodexRuntime.prompt()`:
+
+```typescript
+function prepareCodexPrompt(prompt: string, attachments: UnifiedAttachment[]): string {
+  const blocks = attachments
+    .filter(a => a.kind !== 'image') // images handled as data URLs below
+    .map(a => `**Attachment: ${a.name}**\n\`\`\`\n${a.data}\n\`\`\``);
+  return blocks.length ? `${blocks.join('\n\n')}\n\n${prompt}` : prompt;
+}
+
+function toDataUrl(a: UnifiedAttachment): string {
+  return `data:${a.mediaType};base64,${a.data}`;
+}
+```
+
+### ACP attachment handling in `AcpRuntime.prompt()`:
+- Check if selected provider supports multimodal (lookup `BYOK_PROVIDER_MODELS[provider].supportsMultimodal`).
+- If yes: pass images as inline base64 in the ACP prompt content array (OpenCode BYOK models that support images accept the Anthropic/OpenAI multimodal format — verify during Phase 0).
+- If no: downgrade to fenced block (same as Codex), emit `{ type: 'text', message: 'Note: image attached as text (provider does not support multimodal)' }`.
+
+## Workstream 5: Model Config Consolidation (R6)
+
+Changes in `src/ai/modelConfig.ts`:
+- Add `CLAUDE_MODELS: ModelOption[]` (copied from `agent/types.ts`)
+- Add `DEFAULT_MODEL: string` (copied from `agent/types.ts`)
+- Existing: `OPENAI_LLM_MODELS`, `BYOK_PROVIDER_MODELS` (already here)
+
+Changes in `src/agent/types.ts`:
+- Remove `CLAUDE_MODELS`, `DEFAULT_MODEL` (replaced by re-exports from modelConfig.ts or direct import)
+- Remove `CODEX_MODELS` entirely (deprecated, no live callers after migration)
+- Keep all interface and type definitions unchanged
+
+Run `grep -rn "CLAUDE_MODELS\|DEFAULT_MODEL\|CODEX_MODELS" src/` before starting — migrate all imports.
+
+## Workstream 6: Daemon Foundation (R8)
+
+```
+src/daemon/
+├── AgentDaemon.ts          cron registration, scheduling, fire
+├── DaemonSession.ts        headless RuntimeTurnConfig execution + auto-approval policy
+├── DaemonResultStore.ts    workspaceState persistence
+└── DaemonStatusEvents.ts   VS Code notification + output channel trace
+```
+
+`AgentDaemon` is **registered but not activated** in `extension.ts`. The wiring to `schedule:` frontmatter and the Agent Library UI is Sprint 80's job.
+
+Dependencies:
+- `cron-parser` (already installed via Sprint 77, check version — use v4 API if v4 is what's installed)
+- No new npm packages expected
+
+## Workstream 7: Cleanup + Docs (R7, R9)
+
+Deletions:
+- `src/codex/codexApproval.ts` (logic absorbed into `CodexRuntime`)
+- `codexBrowserTools.ts` (if Path A confirmed)
+- `CODEX_MODELS` from `types.ts`
+
+Modifications:
+- `flags.ts`: `document-search` status → `'disabled'`
+- `docs/development/architecture.md`: update AS IS → post-sprint state; close ARCH-2,3,4,5 (or 6 if Path B); add Version History entry
+- `CLAUDE.md`: model config section (already updated pre-sprint)
+
+## Implementation Order
+
+```
+Phase 0: Audits (W0) — gate for W3 browser injection path
+  ↓
+W1: src/runtime/ — interface + registry + approval gate (no behavior change yet)
+  ↓
+W6: AgentDaemon foundation (depends on W1 interface only)
+  ↓
+W4: Adapter wrappers (ClaudeCodeRuntime, CodexRuntime, AcpRuntime) — start() and prompt() only
+  ↓
+W2: Replace UnifiedViewProvider dispatch — switch to registry.get(agentId).prompt(...)
+    (runtime-specific handlers deleted; approval gate wired)
+  ↓
+W3: Browser injection (Path A or B per audits)
+  ↓
+W5: File attachments (R5) — UnifiedAttachment plumbed through
+  ↓
+W7: Cleanup + architecture doc update
+```
+
+## Test Strategy
+
+- **Unit:** `RuntimeRegistry.test.ts`, `UnifiedApprovalGate.test.ts`, `AgentDaemon.test.ts`, `BrowserToolsInjector.test.ts`
+- **Adapter unit:** `ClaudeCodeRuntime.test.ts`, `CodexRuntime.test.ts`, `AcpRuntime.test.ts` — mock the underlying manager, verify `AgentRuntime` contract
+- **Integration (manual):** Run all three runtimes in dev mode, send a prompt, attach a file, trigger an approval, cancel mid-run. Verify no regression from v1.7.3 behavior.
+- **Browser integration:** Claude Code + browser action; Codex + browser action (regression test post-`codexBrowserTools.ts` removal or migration)
+
+## Risk Register
+
+| Risk | Likelihood | Impact | Mitigation |
+|---|---|---|---|
+| Codex MCP injection blocked (Path B needed) | Medium | Low — Path B is well-defined | Audit first; Path B adds 0 LOC to W3 scope |
+| ACP browser support not achievable this sprint | Medium | Low — ACP browser not shipped yet | Stub `AcpRuntime` browser as "unsupported" with a note in ARCH-8 |
+| Webview message rename breaks conversation history for in-progress sessions | Low | Low — history is by agentId not message type | Session reset on upgrade acceptable |
+| `cron-parser` v4 vs v5 API break in daemon | Low | Low — Sprint 77 already pinned a version | Check installed version before using |

--- a/docs/releases/v1.7.3/release-notes.md
+++ b/docs/releases/v1.7.3/release-notes.md
@@ -1,5 +1,5 @@
 ---
-date: 'TBD'
+date: '2026-06-06'
 title: 'Ritemark v1.7.3 — Agent Library, Agent Configurator, Browser UX & AI sidebar polish'
 author: Jarmo Tuisk
 tags:
@@ -21,14 +21,12 @@ tags:
   - queue
   - edit-link
   - code-blocks
-  - draft
 ---
 
 # Ritemark v1.7.3 — Agent Library, Agent Configurator, OpenCode runtime, Browser UX & AI sidebar polish
 
-**Status:** DRAFT / unreleased
+**Status:** Released 2026-06-06
 **Type:** Minor release (Agent Library + Agent Configurator, OpenCode BYOK runtime, Browser UX, AI sidebar & composer polish)
-**Ships after:** v1.7.2 (this release is the next one in the train; v1.7.2 must ship first)
 **Focus:** Sprint 77 ships the unified Agent Library and a visual Agent Configurator built on the real Claude Code agent format — create, browse, and configure AI agents without touching YAML. Sprint 76 adds **OpenCode** as a third, bring-your-own-key AI runtime (alongside Claude Code and Codex) via the Agent Client Protocol. Sprint 78 makes the integrated browser a better partner for AI agents — a `browser_snapshot` tool for re-observing page state and a live screenshot chip in the composer when annotation mode is on. Sprint 74 sharpens the AI sidebar's two most-used surfaces — the composer and the plan-approval flow — and fixes two smaller editor annoyances.
 
 **User guide:** [How to Configure and Use AI Agents in Ritemark](./agent-configurator-guide.md) — full how-to written for this release; source material for marketing and the user-docs refresh.
@@ -37,13 +35,11 @@ tags:
 
 ## Downloads
 
-> _v1.7.3 is a DRAFT and has not been built. Download links and the build date are filled in at release-cut time._
-
 | Asset | Platform | URL |
 |-------|----------|-----|
-| Ritemark.dmg | macOS (Apple Silicon, arm64) | TBD on release |
-| Ritemark x64 DMG | macOS (Intel, x64) | TBD on release |
-| Windows installer | Windows x64 | TBD on release |
+| Ritemark-arm64.dmg | macOS (Apple Silicon, arm64) — notarized | [Download](https://github.com/jarmo-productory/ritemark-public/releases/download/v1.7.3/Ritemark-arm64.dmg) |
+| Ritemark-x64.dmg | macOS (Intel, x64) — notarized | [Download](https://github.com/jarmo-productory/ritemark-public/releases/download/v1.7.3/Ritemark-x64.dmg) |
+| Ritemark-Setup.exe | Windows x64 | [Download](https://github.com/jarmo-productory/ritemark-public/releases/download/v1.7.3/Ritemark-Setup.exe) |
 
 * * *
 
@@ -184,4 +180,4 @@ Saving a provider key (Google AI, OpenAI, Anthropic, OpenRouter) in Settings use
 ## Tests and Validation
 
 - Regression coverage for the composer queue (#82) and plan-approval text (#86) lands as `ai-sidebar/composerQueue.ts` tests and `ai-sidebar/planText.test.ts`, run via `npm test`.
-- Gate 2 (manual install + test of the cut build) is pending — this is a draft and no DMG has been built.
+- Gate 1/2: Jarmo tested the signed macOS arm64 build before notarization. The x64 macOS DMG and Windows installer ship the same app code (x64 Gate-2 test waived by Jarmo as the app code is identical to the tested arm64 build). All three platform artifacts are notarized (macOS) / signed and published with a verified update-feed.json.


### PR DESCRIPTION
## Summary

- **`docs/development/architecture.md`** (new) — living architecture document. Captures current AS IS state (3 parallel runtime stacks post-Sprint 78) and TO BE target (AgentRuntime interface, unified approval, browser injection, daemon foundation). Tracks open debt ARCH-1 through ARCH-7 with sprint targets. Includes Sprint Architecture Gate rule.

- **`CLAUDE.md`** — patch table 6→10 (adds 007–010 descriptions), Architecture table updated (build targets, agent runtimes, approval, browser, model IDs), repository structure expanded with full `src/` subsystem map, model config section clarified (3 files pre-sprint-79, 1 after), feature flag zombie rule, routing table adds `open`/`start`/`scripts/code.sh` triggers.

- **`AGENTS.md`** — Architecture Awareness section: Sprint Architecture Gate rule, invariants for new runtimes/approvals/browser tools/feature flags.

- **`docs/development/sprints/sprint-79-runtime-unification/`** — full SDD sprint package (spec, technical-plan, scenarios, tasks, sprint-plan) for the combined runtime unification refactor.

## ⚠️ Draft — needs local reconciliation

This PR is a **draft**. The architecture document was written from codebase analysis (sprint docs, source code) in a remote session — Jarmo has an existing local TO BE architecture document that should be reconciled with this before merge. Open this branch locally, compare with your existing doc, and update `docs/development/architecture.md` accordingly.

## What the sprint-79 plan covers

- `AgentRuntime` interface + `RuntimeRegistry` — all 3 runtimes as plugins
- Unified approval gate (one webview message type for all runtimes — TO BE #2)
- Browser tool injection via `BrowserToolsInjector` (replaces runtime-specific paths)
- File attachment unification (fixes broken PDF/text attachments for Codex + ACP)
- Model config consolidation to `modelConfig.ts`
- Architectural debt cleanup (ARCH-2 through ARCH-5)
- `AgentDaemon` foundation for scheduled tasks (inactive — Sprint 80 activates it)
- `UnifiedViewProvider` 2480 → ≤1100 LOC

---
_Generated by [Claude Code](https://claude.ai/code/session_01EwgUcgXTNQ2ZRaZ8DbAw3A)_