### PR TITLE
Fix #142: extension fast-lane never loads (semver floor + reload/cleanup guards)

### DIFF
--- a/.github/workflows/build-macos-x64.yml
+++ b/.github/workflows/build-macos-x64.yml
@@ -199,6 +199,24 @@ jobs:
           fi
 
       # =========================================================================
+      # Step 9b: Floor bundled extension version (GH #142)
+      # The built-in must sort below any X.Y.Z-ext.N OTA patch so VS Code's
+      # extension scanner prefers a user-installed update. Shared logic with
+      # build-prod.sh via scripts/floor-bundled-extension.sh.
+      # =========================================================================
+      - name: Floor bundled extension version
+        working-directory: r
+        run: |
+          RITEMARK_VERSION=$(python3 -c "import json; print(json.load(open('branding/product.json')).get('ritemarkVersion', ''))")
+          if [ -z "$RITEMARK_VERSION" ]; then
+            echo "ERROR: ritemarkVersion not found in branding/product.json"
+            exit 1
+          fi
+          ./scripts/floor-bundled-extension.sh \
+            "VSCode-darwin-x64/Ritemark.app/Contents/Resources/app/extensions/ritemark" \
+            "$RITEMARK_VERSION"
+
+      # =========================================================================
       # Step 10: Validate build
       # =========================================================================
       - name: Validate build

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -390,6 +390,22 @@ jobs:
           ./scripts/copy-welcome-assets.sh "$WELCOME_DEST"
           echo "Extension copied successfully"
 
+      - name: Floor bundled extension version
+        # GH #142: the built-in must sort below any X.Y.Z-ext.N OTA patch so
+        # VS Code's extension scanner prefers a user-installed update. Shared
+        # logic with build-prod-windows.sh via floor-bundled-extension.sh.
+        shell: bash
+        working-directory: r
+        run: |
+          RITEMARK_VERSION=$(python -c "import json; print(json.load(open('branding/product.json')).get('ritemarkVersion', ''))")
+          if [ -z "$RITEMARK_VERSION" ]; then
+            echo "ERROR: ritemarkVersion not found in branding/product.json"
+            exit 1
+          fi
+          ./scripts/floor-bundled-extension.sh \
+            "VSCode-win32-x64/resources/app/extensions/ritemark" \
+            "$RITEMARK_VERSION"
+
       - name: Strip bundled copilot extension from output
         # VS Code 1.117 bundles GitHub Copilot Chat as a built-in extension.
         # gulp requires it during build, but the final Ritemark app doesn't

--- a/extensions/ritemark/src/update/activationIntegrity.test.ts
+++ b/extensions/ritemark/src/update/activationIntegrity.test.ts
@@ -62,6 +62,24 @@ async function run() {
     console.log('✓ Test 1: cleanupOldVersions keeps exactly the N versions passed');
   }
 
+  // Test 1b (#142 bug B): cleanup must NOT delete a staged version newer than
+  // everything in the keep list. The built-in floor's own activation passes
+  // keepVersions = ['1.8.2-0']; the freshly-staged '1.8.2-ext.1' must survive
+  // so a pending restart can load it.
+  {
+    rmSync(tempRoot, { recursive: true, force: true });
+    const extDir = join(tempRoot, 'extensions');
+    mkdirSync(join(extDir, 'ritemark-1.8.2-ext.1'), { recursive: true });
+    mkdirSync(join(extDir, 'ritemark-1.8.1'), { recursive: true });
+
+    const installer = new UserExtensionInstaller(tempRoot);
+    await installer.cleanupOldVersions(['1.8.2-0']);
+
+    assert.strictEqual(existsSync(join(extDir, 'ritemark-1.8.2-ext.1')), true, 'staged newer version must be preserved (not deleted by the floor cleanup)');
+    assert.strictEqual(existsSync(join(extDir, 'ritemark-1.8.1')), false, 'a genuinely older version must still be removed');
+    console.log('✓ Test 1b: cleanupOldVersions preserves a staged version newer than all keeps (#142 bug B)');
+  }
+
   // Test 2: removeInstalledVersion quarantines a single specific version.
   {
     rmSync(tempRoot, { recursive: true, force: true });
@@ -114,7 +132,7 @@ async function run() {
     console.log('✓ Test 6: a dangling attempt for a different version does not false-positive');
   }
 
-  console.log('\nAll 6 tests passed!');
+  console.log('\nAll 7 tests passed!');
 }
 
 run()

--- a/extensions/ritemark/src/update/updateResolver.test.ts
+++ b/extensions/ritemark/src/update/updateResolver.test.ts
@@ -85,10 +85,14 @@ test('prefers full update when app version is behind latest full release', () =>
 });
 
 test('offers extension update when app base is current', () => {
+  // A fresh production install ships the built-in extension at the semver
+  // "floor" 1.5.0-0 (GH #142), NOT plain 1.5.0 — the floor sorts below any
+  // 1.5.0-ext.N patch so VS Code's scanner prefers the OTA update. The patch
+  // 1.5.0-ext.1 is therefore a valid upgrade over the running floor.
   const result = resolveUpdate({
     feed: createFeed(),
     currentAppVersion: '1.5.0',
-    currentExtensionVersion: '1.5.0',
+    currentExtensionVersion: '1.5.0-0',
     platform: 'darwin',
     arch: 'arm64'
   });

--- a/extensions/ritemark/src/update/updateService.ts
+++ b/extensions/ritemark/src/update/updateService.ts
@@ -229,7 +229,24 @@ export class UpdateService {
 
     const currentVersion = getCurrentVersion();
     if (compareVersions(currentVersion, pendingRestartVersion) >= 0) {
+      // The staged version (or newer) is now running — restart succeeded.
       await this.storage.clearPendingRestartVersion();
+      return;
+    }
+
+    // #142 guard (bug A): if the staged version is no longer installed on
+    // disk it can never load, so a stale pendingRestartVersion would prompt
+    // "Reload to update" forever. Clear it once the staged directory is gone.
+    try {
+      const installed = await this.installer.listInstalledVersions();
+      if (!installed.includes(pendingRestartVersion)) {
+        console.warn(
+          `Clearing pendingRestartVersion ${pendingRestartVersion}: no longer installed on disk`
+        );
+        await this.storage.clearPendingRestartVersion();
+      }
+    } catch (error) {
+      console.error('Failed to reconcile pending restart version:', error);
     }
   }
 

--- a/extensions/ritemark/src/update/userExtensionInstaller.ts
+++ b/extensions/ritemark/src/update/userExtensionInstaller.ts
@@ -13,6 +13,7 @@ import * as fs from 'fs';
 import * as crypto from 'crypto';
 import * as os from 'os';
 import { UpdateManifest, UpdateFile } from './updateManifest';
+import { compareVersions } from './versionComparison';
 
 /**
  * Progress callback for download operations
@@ -171,6 +172,12 @@ export class UserExtensionInstaller {
    * update can keep N-1 alongside current — a rollback target stays on disk
    * instead of every prior version being deleted the moment a new one
    * activates.
+   *
+   * #142 guard (bug B): never delete a version NEWER than everything in the
+   * keep list. Such a version is a staged update waiting for a restart, not
+   * stale garbage. Without this, the built-in floor's own activation
+   * (keepVersions = ['X.Y.Z-0']) would delete the freshly-staged
+   * 'X.Y.Z-ext.N' before it ever gets a chance to load.
    */
   async cleanupOldVersions(keepVersions: string[]): Promise<void> {
     try {
@@ -179,16 +186,30 @@ export class UserExtensionInstaller {
       }
 
       const keepDirNames = new Set(keepVersions.map(v => `ritemark-${v}`));
+      const newestKeep = keepVersions.reduce<string | null>(
+        (max, v) => (max === null || compareVersions(v, max) > 0 ? v : max),
+        null
+      );
       const entries = await fs.promises.readdir(this.extensionsDir, { withFileTypes: true });
 
       for (const entry of entries) {
-        if (entry.isDirectory() &&
-            entry.name.startsWith('ritemark-') &&
-            !keepDirNames.has(entry.name)) {
-          const dirPath = path.join(this.extensionsDir, entry.name);
-          console.log(`Cleaning up old extension version: ${entry.name}`);
-          await this.removeDir(dirPath);
+        if (!entry.isDirectory() ||
+            !entry.name.startsWith('ritemark-') ||
+            keepDirNames.has(entry.name)) {
+          continue;
         }
+
+        const version = entry.name.replace('ritemark-', '');
+        if (newestKeep !== null && compareVersions(version, newestKeep) > 0) {
+          // Staged update newer than anything we keep — preserve it so a
+          // pending restart can load it (#142 bug B).
+          console.log(`Preserving staged newer extension version: ${entry.name}`);
+          continue;
+        }
+
+        const dirPath = path.join(this.extensionsDir, entry.name);
+        console.log(`Cleaning up old extension version: ${entry.name}`);
+        await this.removeDir(dirPath);
       }
     } catch (error) {
       console.error('Failed to cleanup old versions:', error);

--- a/extensions/ritemark/src/update/versionComparison.test.ts
+++ b/extensions/ritemark/src/update/versionComparison.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Tests for semver-correct version ordering, focused on the #142 fix: the
+ * built-in "floor" version X.Y.Z-0 must sort strictly BELOW an over-the-air
+ * patch X.Y.Z-ext.N, which must sort below the plain release X.Y.Z — exactly
+ * matching VS Code's own standard-semver extension scanner.
+ *
+ * Run: npx tsx src/update/versionComparison.test.ts
+ */
+
+import * as assert from 'assert';
+import {
+  compareVersions,
+  isNewerVersion,
+  getBaseVersion,
+  determineUpdateType,
+  isValidUpgrade,
+  shouldNotifyUpdate
+} from './versionComparison';
+
+function run() {
+  // ── Core #142 ordering: floor < ext.N < release ──────────────────────────
+  {
+    assert.ok(compareVersions('1.8.2-0', '1.8.2-ext.1') < 0, 'floor -0 must sort below -ext.1');
+    assert.ok(compareVersions('1.8.2-ext.1', '1.8.2-0') > 0, 'symmetry: -ext.1 above floor');
+    assert.ok(compareVersions('1.8.2-0', '1.8.2') < 0, 'floor -0 must sort below the plain release');
+    assert.ok(compareVersions('1.8.2-ext.1', '1.8.2') < 0, '-ext.1 (pre-release) sorts below the plain release');
+    assert.ok(compareVersions('1.8.2-ext.2', '1.8.2-ext.1') > 0, '-ext.2 above -ext.1');
+    assert.ok(compareVersions('1.8.2-ext.10', '1.8.2-ext.9') > 0, '-ext.N compares numerically, not lexically');
+    console.log('✓ Test 1: floor -0 < ext.N < release ordering (the #142 root-cause guarantee)');
+  }
+
+  // ── The exact live-test scenario from #142 ───────────────────────────────
+  {
+    // Bundled built-in is floored to 1.8.2-0; the OTA patch is 1.8.2-ext.1.
+    // VS Code must prefer ext.1, i.e. ext.1 must be the greater version.
+    assert.ok(isNewerVersion('1.8.2-ext.1', '1.8.2-0'), 'the ext patch must outrank the bundled floor so VS Code loads it');
+    assert.strictEqual(determineUpdateType('1.8.2-0', '1.8.2-ext.1'), 'extension', 'floor→ext must be an extension-tier update');
+    assert.ok(isValidUpgrade('1.8.2-0', '1.8.2-ext.1'), 'floor→ext must be a valid (non-downgrade) upgrade');
+    console.log('✓ Test 2: bundled floor 1.8.2-0 correctly yields to OTA patch 1.8.2-ext.1');
+  }
+
+  // ── Base-version extraction across all forms ─────────────────────────────
+  {
+    assert.strictEqual(getBaseVersion('1.8.2'), '1.8.2', 'plain');
+    assert.strictEqual(getBaseVersion('1.8.2-0'), '1.8.2', 'floor');
+    assert.strictEqual(getBaseVersion('1.8.2-ext.5'), '1.8.2', 'ext');
+    assert.strictEqual(getBaseVersion('v1.8.2-ext.5'), '1.8.2', 'v-prefixed');
+    assert.strictEqual(getBaseVersion('1.8.2+build.7'), '1.8.2', 'build metadata stripped');
+    console.log('✓ Test 3: getBaseVersion strips every suffix form to the clean base');
+  }
+
+  // ── Cross-base ordering: next full release outranks any prior ext patch ───
+  {
+    assert.ok(compareVersions('1.8.3-0', '1.8.2-ext.9') > 0, 'next release floor outranks any prior-base ext patch');
+    assert.ok(compareVersions('1.9.0', '1.8.2-ext.1') > 0, 'higher minor outranks prior ext patch');
+    assert.strictEqual(determineUpdateType('1.8.2-ext.1', '1.8.3-ext.1'), 'full', 'different base = full update');
+    assert.strictEqual(determineUpdateType('1.8.2-ext.1', '1.8.2-ext.1'), 'none', 'same version = no update');
+    console.log('✓ Test 4: cross-base ordering and update-type classification');
+  }
+
+  // ── Notification gating unaffected by the floor ──────────────────────────
+  {
+    // The floor is only ever a CURRENT version, never a feed target. A feed
+    // offering ext.1 while current is the floor should notify.
+    assert.ok(shouldNotifyUpdate('1.8.2-0', '1.8.2-ext.1'), 'notify when a patch is available over the floor');
+    assert.ok(!shouldNotifyUpdate('1.8.2-ext.1', '1.8.2-0'), 'never notify about "downgrading" to the floor');
+    assert.ok(!shouldNotifyUpdate('1.8.2', '1.8.2-beta.1'), 'never notify about a -beta pre-release');
+    console.log('✓ Test 5: update notifications gate correctly around the floor');
+  }
+
+  console.log('\nAll 5 tests passed!');
+}
+
+try {
+  run();
+} catch (error) {
+  console.error(error);
+  process.exitCode = 1;
+}

--- a/extensions/ritemark/src/update/versionComparison.ts
+++ b/extensions/ritemark/src/update/versionComparison.ts
@@ -1,57 +1,139 @@
 /**
  * Version Comparison Utilities
  *
- * Handles semantic versioning with extension build suffix.
- * Format: {major}.{minor}.{patch} or {major}.{minor}.{patch}-ext.{build}
+ * Handles semantic versioning with two Ritemark-specific pre-release forms
+ * layered on top of a standard {major}.{minor}.{patch} base:
  *
- * Examples:
- * - "1.0.1" - Base app version
- * - "1.0.1-ext.5" - Extension build 5 for app 1.0.1
+ * - "1.0.1"        - plain release (the base app version)
+ * - "1.0.1-0"      - the BUILT-IN FLOOR shipped inside a production app bundle
+ *                    (see #142). Sorts strictly BELOW any "-ext.N" patch so a
+ *                    user-installed extension update always wins VS Code's own
+ *                    extension scanner.
+ * - "1.0.1-ext.5"  - extension build 5, an over-the-air patch for app 1.0.1
+ *
+ * Ordering within one base is exactly standard semver precedence:
+ *   1.0.1-0  <  1.0.1-ext.1  <  1.0.1-ext.2  <  1.0.1
+ * (numeric pre-release identifiers rank below alphanumeric ones, and a plain
+ * release outranks every pre-release of the same base). Matching semver here
+ * is the whole point: VS Code's scanner uses standard semver, so Ritemark's
+ * own resolver MUST agree or it offers updates that never load (#142).
  */
 
 /**
- * Parsed version with base and extension build number
+ * Parsed version with base numbers and the raw pre-release identifiers.
  */
 interface ParsedVersion {
   major: number;
   minor: number;
   patch: number;
-  extBuild: number; // 0 if no -ext suffix
+  /**
+   * Dot-separated pre-release identifiers (the tokens after '-'), or an empty
+   * array for a plain release. Compared per semver: numeric identifiers rank
+   * below alphanumeric ones, and an empty pre-release outranks any non-empty
+   * one at the same base.
+   */
+  preRelease: string[];
+  /** Back-compat convenience: N for "X.Y.Z-ext.N", else 0. */
+  extBuild: number;
 }
 
 /**
- * Parse a version string into components
- * Handles formats: "1.2.3", "v1.2.3", "1.2.3-ext.5", "v1.2.3-ext.5"
+ * Parse a version string into components.
+ * Handles: "1.2.3", "v1.2.3", "1.2.3-0", "1.2.3-ext.5", "v1.2.3-ext.5".
+ * Build metadata ("+...") is stripped and ignored for precedence, per semver.
  */
 function parseVersion(version: string): ParsedVersion {
   // Remove 'v' prefix if present
   let cleanVersion = version.startsWith('v') ? version.slice(1) : version;
 
-  // Check for -ext.N suffix
-  let extBuild = 0;
-  const extMatch = cleanVersion.match(/-ext\.(\d+)$/);
-  if (extMatch) {
-    extBuild = parseInt(extMatch[1], 10);
-    cleanVersion = cleanVersion.replace(/-ext\.\d+$/, '');
+  // Strip build metadata — ignored for precedence.
+  const plusIndex = cleanVersion.indexOf('+');
+  if (plusIndex !== -1) {
+    cleanVersion = cleanVersion.slice(0, plusIndex);
   }
 
-  // Parse base version
-  const parts = cleanVersion.split('.');
+  // Split base from pre-release at the first hyphen.
+  let base = cleanVersion;
+  let preRelease: string[] = [];
+  const hyphenIndex = cleanVersion.indexOf('-');
+  if (hyphenIndex !== -1) {
+    base = cleanVersion.slice(0, hyphenIndex);
+    const pre = cleanVersion.slice(hyphenIndex + 1);
+    preRelease = pre.length > 0 ? pre.split('.') : [];
+  }
+
+  const parts = base.split('.');
+
+  let extBuild = 0;
+  if (preRelease[0] === 'ext' && /^\d+$/.test(preRelease[1] ?? '')) {
+    extBuild = parseInt(preRelease[1], 10);
+  }
 
   return {
     major: parseInt(parts[0] || '0', 10),
     minor: parseInt(parts[1] || '0', 10),
     patch: parseInt(parts[2] || '0', 10),
+    preRelease,
     extBuild
   };
 }
 
 /**
- * Extract the base app version (without -ext suffix)
+ * Compare a single pair of semver pre-release identifiers.
+ * Numeric identifiers always rank below alphanumeric ones (semver §11.4.3).
+ */
+function compareIdentifier(a: string, b: string): number {
+  const aNum = /^\d+$/.test(a);
+  const bNum = /^\d+$/.test(b);
+  if (aNum && bNum) {
+    return parseInt(a, 10) - parseInt(b, 10);
+  }
+  if (aNum) {
+    return -1; // numeric < alphanumeric
+  }
+  if (bNum) {
+    return 1;
+  }
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+/**
+ * Compare two pre-release identifier lists per semver §11.4.
+ * An empty list (a plain release) outranks any non-empty list.
+ */
+function comparePreRelease(a: string[], b: string[]): number {
+  if (a.length === 0 && b.length === 0) {
+    return 0;
+  }
+  if (a.length === 0) {
+    return 1; // release > pre-release
+  }
+  if (b.length === 0) {
+    return -1;
+  }
+  const shared = Math.min(a.length, b.length);
+  for (let i = 0; i < shared; i++) {
+    const cmp = compareIdentifier(a[i], b[i]);
+    if (cmp !== 0) {
+      return cmp;
+    }
+  }
+  // All shared identifiers equal — the longer list has higher precedence.
+  return a.length - b.length;
+}
+
+/**
+ * Extract the base app version (without any pre-release / build suffix).
+ * "1.0.1", "1.0.1-0" and "1.0.1-ext.5" all yield "1.0.1".
  */
 export function getBaseVersion(version: string): string {
-  const cleanVersion = version.startsWith('v') ? version.slice(1) : version;
-  return cleanVersion.replace(/-ext\.\d+$/, '');
+  let clean = version.startsWith('v') ? version.slice(1) : version;
+  const plusIndex = clean.indexOf('+');
+  if (plusIndex !== -1) {
+    clean = clean.slice(0, plusIndex);
+  }
+  const hyphenIndex = clean.indexOf('-');
+  return hyphenIndex === -1 ? clean : clean.slice(0, hyphenIndex);
 }
 
 /**
@@ -110,8 +192,9 @@ export function compareVersions(v1: string, v2: string): number {
     return a.patch - b.patch;
   }
 
-  // Compare extension build
-  return a.extBuild - b.extBuild;
+  // Compare pre-release identifiers per semver:
+  //   X.Y.Z-0  <  X.Y.Z-ext.1  <  X.Y.Z-ext.2  <  X.Y.Z
+  return comparePreRelease(a.preRelease, b.preRelease);
 }
 
 /**

--- a/scripts/build-prod-windows.sh
+++ b/scripts/build-prod-windows.sh
@@ -111,6 +111,39 @@ fi
 # Copy extension source
 cp -r "$EXTENSION_DIR" "extensions/ritemark"
 echo "  Copied extension from $EXTENSION_DIR"
+
+# Stamp the BUNDLED extension's version to the semver "floor" X.Y.Z-0 (GH #142).
+# The built-in must sort strictly BELOW any over-the-air patch X.Y.Z-ext.N so
+# VS Code's standard-semver extension scanner always prefers a user-installed
+# update. Source extensions/ritemark/package.json stays at clean X.Y.Z; only
+# this build copy (which gulp bundles into the app) is floored. See build-prod.sh.
+FLOOR_BASE=$(grep '"ritemarkVersion"' "$ROOT_DIR/branding/product.json" | sed 's/.*"ritemarkVersion"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
+if [ -n "$FLOOR_BASE" ]; then
+    FLOOR_VERSION="${FLOOR_BASE}-0"
+    echo "  Flooring bundled extension version to: $FLOOR_VERSION"
+    python -c '
+import json, sys
+path = "extensions/ritemark/package.json"
+with open(path) as f:
+    data = json.load(f)
+data["version"] = sys.argv[1]
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+' "$FLOOR_VERSION" || python3 -c '
+import json, sys
+path = "extensions/ritemark/package.json"
+with open(path) as f:
+    data = json.load(f)
+data["version"] = sys.argv[1]
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+' "$FLOOR_VERSION"
+else
+    echo -e "${RED}ERROR: could not read ritemarkVersion from branding/product.json to floor bundled extension${NC}"
+    exit 1
+fi
 echo ""
 
 # Step 4: Compile extension

--- a/scripts/build-prod-windows.sh
+++ b/scripts/build-prod-windows.sh
@@ -112,38 +112,15 @@ fi
 cp -r "$EXTENSION_DIR" "extensions/ritemark"
 echo "  Copied extension from $EXTENSION_DIR"
 
-# Stamp the BUNDLED extension's version to the semver "floor" X.Y.Z-0 (GH #142).
-# The built-in must sort strictly BELOW any over-the-air patch X.Y.Z-ext.N so
-# VS Code's standard-semver extension scanner always prefers a user-installed
-# update. Source extensions/ritemark/package.json stays at clean X.Y.Z; only
-# this build copy (which gulp bundles into the app) is floored. See build-prod.sh.
+# Floor the BUNDLED extension's version to X.Y.Z-0 so over-the-air X.Y.Z-ext.N
+# patches win VS Code's extension scanner (GH #142). gulp bundles this copy into
+# the app. Shared with the CI workflows via scripts/floor-bundled-extension.sh.
 FLOOR_BASE=$(grep '"ritemarkVersion"' "$ROOT_DIR/branding/product.json" | sed 's/.*"ritemarkVersion"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/')
-if [ -n "$FLOOR_BASE" ]; then
-    FLOOR_VERSION="${FLOOR_BASE}-0"
-    echo "  Flooring bundled extension version to: $FLOOR_VERSION"
-    python -c '
-import json, sys
-path = "extensions/ritemark/package.json"
-with open(path) as f:
-    data = json.load(f)
-data["version"] = sys.argv[1]
-with open(path, "w") as f:
-    json.dump(data, f, indent=2)
-    f.write("\n")
-' "$FLOOR_VERSION" || python3 -c '
-import json, sys
-path = "extensions/ritemark/package.json"
-with open(path) as f:
-    data = json.load(f)
-data["version"] = sys.argv[1]
-with open(path, "w") as f:
-    json.dump(data, f, indent=2)
-    f.write("\n")
-' "$FLOOR_VERSION"
-else
+if [ -z "$FLOOR_BASE" ]; then
     echo -e "${RED}ERROR: could not read ritemarkVersion from branding/product.json to floor bundled extension${NC}"
     exit 1
 fi
+"$ROOT_DIR/scripts/floor-bundled-extension.sh" "extensions/ritemark" "$FLOOR_BASE"
 echo ""
 
 # Step 4: Compile extension

--- a/scripts/build-prod.sh
+++ b/scripts/build-prod.sh
@@ -245,31 +245,12 @@ else
 fi
 echo ""
 
-# Stamp the BUNDLED extension's version to the semver "floor" X.Y.Z-0 (GH #142).
-# The built-in extension must sort strictly BELOW any over-the-air patch
-# X.Y.Z-ext.N so that VS Code's own extension scanner — which uses standard
-# semver, where "-0" (numeric) ranks below "-ext.N" (alphanumeric) and below a
-# plain release — always prefers a user-installed update over the built-in.
-# Without this, X.Y.Z-ext.N is a pre-release BELOW the bundled X.Y.Z and never
-# loads. The source extensions/ritemark/package.json stays at the clean X.Y.Z
-# (it is the source of truth release-extension.sh validates); only the copy
-# inside the .app bundle is floored here.
-EXT_PACKAGE_JSON="$APP_PATH/Contents/Resources/app/extensions/ritemark/package.json"
-FLOOR_VERSION="${RITEMARK_VERSION}-0"
-echo "Flooring bundled extension version to: $FLOOR_VERSION"
-python3 -c '
-import json
-path = "'"$EXT_PACKAGE_JSON"'"
-with open(path) as f:
-    data = json.load(f)
-data["version"] = "'"$FLOOR_VERSION"'"
-with open(path, "w") as f:
-    json.dump(data, f, indent=2)
-    f.write("\n")
-'
-
-if python3 -c "import json; assert json.load(open('$EXT_PACKAGE_JSON'))['version'] == '$FLOOR_VERSION'" 2>/dev/null; then
-  echo -e "${GREEN}Bundled extension version floored to $FLOOR_VERSION${NC}"
+# Floor the BUNDLED extension's version to X.Y.Z-0 so over-the-air X.Y.Z-ext.N
+# patches win VS Code's extension scanner (GH #142). Shared with the CI release
+# workflows via scripts/floor-bundled-extension.sh.
+if "$PROJECT_DIR/scripts/floor-bundled-extension.sh" \
+    "$APP_PATH/Contents/Resources/app/extensions/ritemark" "$RITEMARK_VERSION"; then
+  echo -e "${GREEN}Bundled extension version floored${NC}"
 else
   echo -e "${RED}ERROR: Failed to floor bundled extension version${NC}"
   exit 1

--- a/scripts/build-prod.sh
+++ b/scripts/build-prod.sh
@@ -245,6 +245,37 @@ else
 fi
 echo ""
 
+# Stamp the BUNDLED extension's version to the semver "floor" X.Y.Z-0 (GH #142).
+# The built-in extension must sort strictly BELOW any over-the-air patch
+# X.Y.Z-ext.N so that VS Code's own extension scanner — which uses standard
+# semver, where "-0" (numeric) ranks below "-ext.N" (alphanumeric) and below a
+# plain release — always prefers a user-installed update over the built-in.
+# Without this, X.Y.Z-ext.N is a pre-release BELOW the bundled X.Y.Z and never
+# loads. The source extensions/ritemark/package.json stays at the clean X.Y.Z
+# (it is the source of truth release-extension.sh validates); only the copy
+# inside the .app bundle is floored here.
+EXT_PACKAGE_JSON="$APP_PATH/Contents/Resources/app/extensions/ritemark/package.json"
+FLOOR_VERSION="${RITEMARK_VERSION}-0"
+echo "Flooring bundled extension version to: $FLOOR_VERSION"
+python3 -c '
+import json
+path = "'"$EXT_PACKAGE_JSON"'"
+with open(path) as f:
+    data = json.load(f)
+data["version"] = "'"$FLOOR_VERSION"'"
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+'
+
+if python3 -c "import json; assert json.load(open('$EXT_PACKAGE_JSON'))['version'] == '$FLOOR_VERSION'" 2>/dev/null; then
+  echo -e "${GREEN}Bundled extension version floored to $FLOOR_VERSION${NC}"
+else
+  echo -e "${RED}ERROR: Failed to floor bundled extension version${NC}"
+  exit 1
+fi
+echo ""
+
 # =============================================================================
 # Step 4.5: Remove unwanted built-in extensions (VS Code 1.117+)
 # Microsoft started bundling GitHub Copilot Chat + Mermaid Chat Features as

--- a/scripts/floor-bundled-extension.sh
+++ b/scripts/floor-bundled-extension.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+#
+# floor-bundled-extension.sh - Stamp a bundled extension copy's version to the
+# semver "floor" X.Y.Z-0 (GH #142).
+#
+# The built-in extension inside a production app bundle MUST sort strictly
+# BELOW any over-the-air patch X.Y.Z-ext.N, so VS Code's extension scanner —
+# which uses standard semver, where "-0" (numeric) ranks below "-ext.N"
+# (alphanumeric) and below a plain release — always prefers a user-installed
+# update over the built-in. Without this, X.Y.Z-ext.N is a pre-release BELOW
+# the bundled X.Y.Z and never loads.
+#
+# The SOURCE extensions/ritemark/package.json stays at the clean X.Y.Z (it is
+# the source of truth release-extension.sh validates); only the copy bundled
+# into the app is floored here. Every build path that assembles a release
+# bundle (build-prod.sh, build-prod-windows.sh, and the CI workflows
+# build-macos-x64.yml / build-windows.yml) MUST call this so the fast lane
+# works on every platform.
+#
+# Usage: floor-bundled-extension.sh <bundled-ext-dir> <base-version>
+#   <bundled-ext-dir>  Path to the extension copy inside the app bundle
+#                      (the directory containing package.json).
+#   <base-version>     Clean base app version, e.g. "1.8.2". Any pre-release /
+#                      build suffix is stripped before appending "-0".
+set -euo pipefail
+
+EXT_DIR="${1:?usage: floor-bundled-extension.sh <bundled-ext-dir> <base-version>}"
+RAW_VERSION="${2:?usage: floor-bundled-extension.sh <bundled-ext-dir> <base-version>}"
+
+# Strip any existing pre-release/build suffix, then floor to X.Y.Z-0.
+BASE_VERSION="${RAW_VERSION%%-*}"
+BASE_VERSION="${BASE_VERSION%%+*}"
+FLOOR_VERSION="${BASE_VERSION}-0"
+
+PKG="$EXT_DIR/package.json"
+if [ ! -f "$PKG" ]; then
+  echo "ERROR: bundled extension package.json not found at $PKG" >&2
+  exit 1
+fi
+
+PY=python3
+command -v "$PY" >/dev/null 2>&1 || PY=python
+
+"$PY" - "$PKG" "$FLOOR_VERSION" <<'PYEOF'
+import json, sys
+path, floor = sys.argv[1], sys.argv[2]
+with open(path) as f:
+    data = json.load(f)
+data["version"] = floor
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+PYEOF
+
+ACTUAL=$("$PY" -c "import json,sys; print(json.load(open(sys.argv[1]))['version'])" "$PKG")
+if [ "$ACTUAL" != "$FLOOR_VERSION" ]; then
+  echo "ERROR: failed to floor bundled extension version (got '$ACTUAL', want '$FLOOR_VERSION')" >&2
+  exit 1
+fi
+
+echo "Floored bundled extension version to $FLOOR_VERSION"


### PR DESCRIPTION
## What

Fixes #142 — the seamless extension-update fast-lane never worked end-to-end. An extension-tier update `X.Y.Z-ext.N` is a semver **pre-release** ranking **below** the bundled `X.Y.Z`, so VS Code's extension scanner always kept the built-in and ignored the staged update.

> The agent issue-triage workflow that originally shared this branch was split into #145 (docs-only, mergeable independently). This PR is now purely the #142 code fix.

Closes #142

## How it works

Make Ritemark's own version ordering standard-semver correct, and ship the bundled built-in at the **floor** `X.Y.Z-0`:

- `versionComparison.ts`: real semver pre-release precedence → `X.Y.Z-0 < X.Y.Z-ext.N < X.Y.Z`, matching VS Code's scanner. `getBaseVersion` strips every suffix (`-0`, `-ext.N`, `+build`) to the clean base.
- `scripts/floor-bundled-extension.sh` (new, shared): stamps the **bundled copy**'s version to `X.Y.Z-0`. Wired into all four release-bundle paths — `build-prod.sh`, `build-prod-windows.sh`, `build-macos-x64.yml`, `build-windows.yml` (the source `package.json` stays clean `X.Y.Z`). A user-installed `X.Y.Z-ext.N` now wins VS Code's builtin-vs-user resolution.

Compounding bugs fixed:
- **Bug A** (infinite "Reload to update"): `reconcilePendingRestartVersion` clears a pending version once its staged dir is gone.
- **Bug B** (staged update deleted): `cleanupOldVersions` never deletes a version newer than everything in its keep list.

## ⚠️ Shell-tier

Touches build scripts + CI workflows, so it ships with the **next full app release** (not the extension fast-lane). Existing plain-`X.Y.Z` installs self-heal on that DMG/installer update; no user is currently harmed (1.8.2 is the first client and has nothing to update to yet). From the first floored release (e.g. 1.8.3) onward, all `X.Y.Z-ext.N` patches ship purely extension-tier.

## How to Test

```
cd extensions/ritemark && npm run compile
npx tsx src/update/versionComparison.test.ts      # floor/ext/release ordering + the live #142 scenario
npx tsx src/update/activationIntegrity.test.ts    # + bug-B guard case
npx tsx src/update/updateResolver.test.ts
npx tsx src/update/updateService.test.ts
```

End-to-end (next full release): build prod → confirm bundled `extensions/ritemark/package.json` inside the app reads `X.Y.Z-0` → publish a throwaway `X.Y.Z-ext.1` → Install → Reload → app reports `X.Y.Z-ext.1`, no reload-loop, staged dir survives.

## Lifecycle

- **Release:** next full app release (shell-tier)
- **User-facing change:** yes (updates actually install)
- **Release notes needed:** yes
- **Architecture doc touched/needed:** no

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VnNfQJSMBhesuLSUttjono