### PR TITLE
docs(release): make agent-fix PRs discoverable for release notes

### DIFF
--- a/.claude/agents/product-marketer.md
+++ b/.claude/agents/product-marketer.md
@@ -79,7 +79,7 @@ release_date: "2025-01-14"
 If not provided, gather from:
 1. Release plan: `docs/development/releases/vX.Y.Z/release-plan.md` (release thesis, headlines, sprint tracker, feature-complete state)
 2. Sprint docs under `docs/development/releases/vX.Y.Z/sprint-N/`
-3. Merged agent-fix issues since the last release: `is:issue is:closed label:agent-pr-open closed:>=<date-of-last-release>` against `ProductoryHQ/ritemark-native` — the scheduled issue-triage routine ships these as standalone PRs outside any sprint, so they're absent from sources 1 and 2 above. Do not skip this source; it's the only place these fixes are discoverable.
+3. Merged agent-fix issues since the last release: `gh issue list --repo ProductoryHQ/ritemark-native --state closed --search "label:agent-pr-open closed:>=<date-of-last-release>"` — the scheduled issue-triage routine ships these as standalone PRs outside any sprint, so they're absent from sources 1 and 2 above. Do not skip this source; it's the only place these fixes are discoverable. (Use this exact `gh issue list --search` form — `gh search issues` with the compound query string silently returns 0 results.)
 4. Git log: Recent commits since last release
 5. Extension package.json: `/extensions/ritemark/package.json`
 

--- a/.claude/agents/product-marketer.md
+++ b/.claude/agents/product-marketer.md
@@ -79,8 +79,9 @@ release_date: "2025-01-14"
 If not provided, gather from:
 1. Release plan: `docs/development/releases/vX.Y.Z/release-plan.md` (release thesis, headlines, sprint tracker, feature-complete state)
 2. Sprint docs under `docs/development/releases/vX.Y.Z/sprint-N/`
-3. Git log: Recent commits since last release
-4. Extension package.json: `/extensions/ritemark/package.json`
+3. Merged agent-fix issues since the last release: `is:issue is:closed label:agent-pr-open closed:>=<date-of-last-release>` against `ProductoryHQ/ritemark-native` — the scheduled issue-triage routine ships these as standalone PRs outside any sprint, so they're absent from sources 1 and 2 above. Do not skip this source; it's the only place these fixes are discoverable.
+4. Git log: Recent commits since last release
+5. Extension package.json: `/extensions/ritemark/package.json`
 
 ### Phase 1: Create Release Folder
 

--- a/.claude/agents/release-manager.md
+++ b/.claude/agents/release-manager.md
@@ -141,13 +141,16 @@ Report the latest version and determine the NEXT valid version. NEVER suggest a 
 
 ### Step 0b — Merged agent-fix issues since last release
 
-The scheduled issue-triage routine (`docs/development/issue-triage-policy.md`) ships small fixes as standalone PRs outside any sprint — they will not show up in sprint docs or a release plan. Find them with:
+The scheduled issue-triage routine (`docs/development/issue-triage-policy.md`) ships small fixes as standalone PRs outside any sprint — they will not show up in sprint docs or a release plan. Find them with (use the previous version's publish date from Step 0's `gh release list` output as the date):
 
-```
-is:issue is:closed label:agent-pr-open closed:>=<date-of-last-release>
+```bash
+gh issue list --repo ProductoryHQ/ritemark-native --state closed \
+  --search "label:agent-pr-open closed:>=<date-of-last-release>"
 ```
 
-against `ProductoryHQ/ritemark-native` (the `agent-pr-open` label survives issue closure, so this is reliable after merge). Fold any results into the release's feature/fix list before handing off to `product-marketer` — otherwise these fixes ship silently with no release-note credit.
+Do NOT use `gh search issues "<compound query string>"` — gh mis-tokenizes the quoted compound string and silently returns 0 results (no error). Only the `gh issue list --search` form above (or fully flag-based `gh search issues --label agent-pr-open --state closed --closed ">=DATE"`) is reliable.
+
+The `agent-pr-open` label survives issue closure, so this is reliable after merge. Fold any results into the release's feature/fix list before handing off to `product-marketer` — otherwise these fixes ship silently with no release-note credit.
 
 ### Step 1 — Build state verification
 

--- a/.claude/agents/release-manager.md
+++ b/.claude/agents/release-manager.md
@@ -139,6 +139,16 @@ gh release list --repo jarmo-productory/ritemark-public --limit 10
 
 Report the latest version and determine the NEXT valid version. NEVER suggest a version that already exists.
 
+### Step 0b — Merged agent-fix issues since last release
+
+The scheduled issue-triage routine (`docs/development/issue-triage-policy.md`) ships small fixes as standalone PRs outside any sprint — they will not show up in sprint docs or a release plan. Find them with:
+
+```
+is:issue is:closed label:agent-pr-open closed:>=<date-of-last-release>
+```
+
+against `ProductoryHQ/ritemark-native` (the `agent-pr-open` label survives issue closure, so this is reliable after merge). Fold any results into the release's feature/fix list before handing off to `product-marketer` — otherwise these fixes ship silently with no release-note credit.
+
 ### Step 1 — Build state verification
 
 Verify the local build:

--- a/docs/development/issue-triage-policy.md
+++ b/docs/development/issue-triage-policy.md
@@ -63,11 +63,12 @@ Do not design solutions in the comment. It is pre-analysis for sprint planning, 
 
 Merged `agent-fix` PRs are not tied to any sprint, so they are invisible to `release-manager`/`product-marketer`'s default release-notes sources (release plan + sprint docs). The `agent-pr-open` label survives issue closure, so it's the durable pointer: when compiling release notes, the query
 
-```
-is:issue is:closed label:agent-pr-open closed:>=<date-of-last-release>
+```bash
+gh issue list --repo ProductoryHQ/ritemark-native --state closed \
+  --search "label:agent-pr-open closed:>=<date-of-last-release>"
 ```
 
-against `ProductoryHQ/ritemark-native` returns every triage-workflow fix shipped since the last release. `release-manager`'s Pre-Release Audit and `product-marketer`'s Phase 1 information-gathering both include this check — see those docs for where it slots in. This routine's only obligation is to keep applying `agent-pr-open` correctly (see Agent-fix procedure above); it does not need to do anything extra at triage time for this to work.
+returns every triage-workflow fix shipped since the last release. (Use this `gh issue list --search` form — `gh search issues` with the compound query string silently returns 0 results.) `release-manager`'s Step 0b and `product-marketer`'s information-gathering fallback list (the "If not provided, gather from" sources) both include this check — see those docs for where it slots in. This routine's only obligation is to keep applying `agent-pr-open` correctly (see Agent-fix procedure above); it does not need to do anything extra at triage time for this to work.
 
 ## Run report
 

--- a/docs/development/issue-triage-policy.md
+++ b/docs/development/issue-triage-policy.md
@@ -59,6 +59,16 @@ For each `triage:product` issue, post ONE concise triage comment containing:
 
 Do not design solutions in the comment. It is pre-analysis for sprint planning, not a spec.
 
+## Release visibility
+
+Merged `agent-fix` PRs are not tied to any sprint, so they are invisible to `release-manager`/`product-marketer`'s default release-notes sources (release plan + sprint docs). The `agent-pr-open` label survives issue closure, so it's the durable pointer: when compiling release notes, the query
+
+```
+is:issue is:closed label:agent-pr-open closed:>=<date-of-last-release>
+```
+
+against `ProductoryHQ/ritemark-native` returns every triage-workflow fix shipped since the last release. `release-manager`'s Pre-Release Audit and `product-marketer`'s Phase 1 information-gathering both include this check — see those docs for where it slots in. This routine's only obligation is to keep applying `agent-pr-open` correctly (see Agent-fix procedure above); it does not need to do anything extra at triage time for this to work.
+
 ## Run report
 
 At the end of every run that did anything, post a summary as a comment on the tracking issue for the routine (or, if none exists, in the run's completion notification): issues triaged per bucket, PRs opened, WIP cap state, anything skipped and why. Silent runs (nothing new) produce no notifications.


### PR DESCRIPTION
## What

Jarmo flagged a gap: PRs opened by the scheduled issue-triage routine (`docs/development/issue-triage-policy.md`) aren't tied to any sprint, so `release-manager`/`product-marketer`'s existing release-notes sources (release plan + sprint docs) never surface them. A merged agent-fix could ship with zero release-note credit.

## How it works

The `agent-pr-open` label survives issue closure, so it's a reliable, durable pointer to "shipped via the triage workflow." Adds this query as an explicit, mandatory source (not just an implicit git-log fallback) in three places:

- `docs/development/issue-triage-policy.md` — new **Release visibility** section documenting the query and pointing to where it's consumed.
- `.claude/agents/release-manager.md` — new **Step 0b** in the Pre-Release Audit that runs the query and folds results into the release's feature/fix list.
- `.claude/agents/product-marketer.md` — added as source #3 in the release-content gathering list (was previously only reachable via the generic "git log" fallback, which nothing enforced).

Query used in all three:
```
is:issue is:closed label:agent-pr-open closed:>=<date-of-last-release>
```

## Test plan

- [ ] Documentation-only change — no code paths affected.
- [ ] Next real release: confirm `release-manager` actually runs Step 0b and any closed `agent-pr-open` issues since the prior release show up in the release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BpuwGk4QJT8bT7ZANur1vX

---
_Generated by [Claude Code](https://claude.ai/code/session_01BpuwGk4QJT8bT7ZANur1vX)_