### PR TITLE
docs: align Sprint 102 release assets

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Technical
 - New `ai-sidebar/aiDisclosure.ts`, `AIInformation.tsx`, and `aiDisclosure.test.ts`; runtime-switching regression coverage extended for OpenCode attachment and active-file behavior
 - Product evidence matrix and counsel decision memo live under `docs/development/releases/v1.8.6/sprint-102-ai-transparency/`
-- Public EN/ET AI-information pages are live after `ritemark-web` PR #77; Productory Terms/Privacy corrections remain a counsel draft outside that repository
+- Public EN/ET AI-information pages are live after `ritemark-web` PR #77; counsel-approved Productory Terms/Privacy corrections are live after `productory-2026` PR #20
 
 ---
 

--- a/docs/development/releases/v1.8.6/release-plan.md
+++ b/docs/development/releases/v1.8.6/release-plan.md
@@ -438,11 +438,11 @@ The critical path is **Sprint 103 → Sprint 104 → Sprint 105**: truthful life
 
 ## Documentation / Release Assets
 
-- [ ] `docs/CHANGELOG.md`
-- [ ] `docs/releases/v1.8.6/release-notes.md`
+- [x] `docs/CHANGELOG.md` — Sprint 102 coverage added
+- [x] `docs/releases/v1.8.6/release-notes.md` — Sprint 102 coverage added
 - [ ] `docs/releases/v1.8.6/github-release-notes.md`
-- [ ] `docs/releases/v1.8.6/TEST-CHECKLIST.md`
-- [ ] Supporting user documentation, if behavior changes
+- [x] `docs/releases/v1.8.6/TEST-CHECKLIST.md` — Sprint 102 coverage added; packaged-candidate items remain
+- [x] Supporting user documentation for Sprint 102
 - [x] Live Productory Terms of Service
 - [x] Live Productory Privacy Policy
 - [x] In-app AI information/disclosure copy approved by counsel

--- a/docs/releases/v1.8.6/TEST-CHECKLIST.md
+++ b/docs/releases/v1.8.6/TEST-CHECKLIST.md
@@ -1,6 +1,6 @@
 # v1.8.6 Test Checklist
 
-**Status:** Draft — Sprint 102 section only  
+**Status:** Draft — Sprint 102 complete; unchecked items carry into packaged-candidate QA  
 **Release:** Ritemark v1.8.6 — Clear Start, Trustworthy AI  
 **Sprint:** 102 — AI Transparency and Policy Alignment (#163)
 


### PR DESCRIPTION
## Summary

- align the v1.8.6 changelog with the now-live Productory policy publication
- mark the Sprint 102 release-note, checklist, changelog, and user-doc coverage in the release plan
- clarify that remaining unchecked checklist items belong to packaged-candidate QA

## Validation

- `./scripts/validate-qa.sh`
- targeted release-document diff review
