### PR TITLE
fix(build): stamp Info.plist with Ritemark version, not VS Code's

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 > **In progress.** Sprint 102 — AI Transparency (#163); Sprint 103 — Truthful Agent Plans (#132, #161); Sprint 104 — Reliable Multi-Prompt Queue (#162); Sprint 105 — Comments Command Center (#164, #165); Sprint 106 — Home Launcher (#74); Sprint 107 R4 — welcome-card removal (shipped early). Later v1.8.6 sprints will extend this entry.
 
+### Fixed
+- **Finder showed "Ritemark.app (1.117.0)".** The macOS bundle's `CFBundleShortVersionString` was left at the upstream VS Code version by the build; `build-prod.sh` now stamps `Info.plist` with the Ritemark version (takes effect from the next full app build)
+
 ### Removed
 - **"Claude is ready — Get Started" welcome card (Sprint 107 R4).** A ready Claude sidebar with no conversation now opens straight into the chat composer — the interstitial card and its extra click are gone. Its bookkeeping (`hasSeenClaudeWelcome`) still records automatically, and the real setup states (install, repair, sign-in, Codex/OpenCode setup, first-run onboarding) are unchanged
 

--- a/scripts/build-prod.sh
+++ b/scripts/build-prod.sh
@@ -245,6 +245,17 @@ else
 fi
 echo ""
 
+# Stamp the macOS bundle with the Ritemark marketing version. Finder's
+# "Open With" / Get Info reads CFBundleShortVersionString, which VS Code's
+# gulp build sets to the UPSTREAM VS Code version (e.g. 1.117.0) — users saw
+# "Ritemark.app (1.117.0)". product.json's internal "version" stays untouched;
+# this runs before codesign-app.sh so the signature covers the edited plist.
+INFO_PLIST="$APP_PATH/Contents/Info.plist"
+/usr/libexec/PlistBuddy -c "Set :CFBundleShortVersionString $RITEMARK_VERSION" "$INFO_PLIST"
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $RITEMARK_VERSION" "$INFO_PLIST"
+echo -e "${GREEN}Info.plist stamped: CFBundleShortVersionString=$RITEMARK_VERSION${NC}"
+echo ""
+
 # Floor the BUNDLED extension's version to X.Y.Z-0 so over-the-air X.Y.Z-ext.N
 # patches win VS Code's extension scanner (GH #142). Shared with the CI release
 # workflows via scripts/floor-bundled-extension.sh.


### PR DESCRIPTION
Finder's Open With / Get Info showed "Ritemark.app (1.117.0)" — the upstream VS Code version. `build-prod.sh` now stamps `CFBundleShortVersionString` + `CFBundleVersion` with `ritemarkVersion` from `branding/product.json`, before signing. Verified the PlistBuddy commands against the current bundle's plist on a copy (→ 1.8.6/1.8.6). Shell-tier; takes effect with the v1.8.6 full app build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)