### PR TITLE
fix(ui): tree indent 20 → 12

### DIFF
--- a/branding/product.json
+++ b/branding/product.json
@@ -192,7 +192,7 @@
     "workbench.layoutControl.enabled": true,
     "workbench.layoutControl.type": "toggles",
     "security.workspace.trust.enabled": false,
-    "workbench.tree.indent": 20,
+    "workbench.tree.indent": 12,
     "workbench.editor.enablePreview": false,
     "workbench.editorAssociations": {
       "*.md": "ritemark.editor",


### PR DESCRIPTION
Jarmo: level-1 indent read too deep — the hidden twistie box already provides a 16px baseline, so 20px/level over-indented. 12px/level keeps the hierarchy readable without eating filename width. Applied live to dev profiles for immediate verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)