### PR TITLE
chore(release): bump version to 1.8.6 (candidate)

### DIFF
--- a/branding/product.json
+++ b/branding/product.json
@@ -2,7 +2,7 @@
   "nameShort": "Ritemark",
   "nameLong": "Ritemark",
   "applicationName": "ritemark",
-  "ritemarkVersion": "1.8.5",
+  "ritemarkVersion": "1.8.6",
   "builtInExtensionsEnabledWithAutoUpdates": [],
   "defaultChatAgent": {
     "providerExtensionId": "vscode.github-authentication",

--- a/extensions/ritemark/package.json
+++ b/extensions/ritemark/package.json
@@ -2,7 +2,7 @@
   "name": "ritemark",
   "displayName": "Ritemark Editor",
   "description": "WYSIWYG Markdown Editor",
-  "version": "1.8.5",
+  "version": "1.8.6",
   "publisher": "ritemark",
   "license": "MIT",
   "engines": {


### PR DESCRIPTION
Version bump for the v1.8.6 release candidate build (branding ritemarkVersion + extension version).

🤖 Generated with [Claude Code](https://claude.com/claude-code)