### PR TITLE
fix(ui): secondary sidebar tabs are icons by default (v1.8.5 canon)

### DIFF
--- a/branding/product.json
+++ b/branding/product.json
@@ -194,6 +194,7 @@
     "security.workspace.trust.enabled": false,
     "workbench.tree.indent": 12,
     "workbench.editor.enablePreview": false,
+    "workbench.secondarySideBar.showLabels": false,
     "workbench.editorAssociations": {
       "*.md": "ritemark.editor",
       "*.markdown": "ritemark.editor",


### PR DESCRIPTION
Jarmo's Gate 2 catch: the aux-bar top showed TEXT tabs ('RITEMARK AI', 'TERMINAL') in the candidate — upstream's `workbench.secondarySideBar.showLabels` defaults to labels, while Ritemark's canon (and v1.8.5's look) is the icon strip (patch 002 explicitly styles `.action-item.icon` there). Branding default `showLabels: false` restores icons, delivered on desktop via patch 013. Verified in dev on a fresh profile: ritemark-ai + chat + terminal icons render ([aux-icons-restored.png](docs/development/releases/v1.8.6/screenshots/aux-icons-restored.png)).

🤖 Generated with [Claude Code](https://claude.com/claude-code)