### PR TITLE
chore(process): default-drift prevention (pins + parity gate + bump-scan rule)

### DIFF
--- a/.claude/skills/vscode-development/SKILL.md
+++ b/.claude/skills/vscode-development/SKILL.md
@@ -501,6 +501,8 @@ Three runtime crashes appeared only in prod bundle (dev mode unaffected): `onboa
 
 ### Native module arch check after submodule bump
 
+**Default-drift scan (mandatory on every upstream bump, added 2026-08-05):** upstream changes workbench SETTING DEFAULTS silently — e.g. `workbench.secondarySideBar.showLabels` flipped the aux-bar tabs from icons to text and surfaced only on FRESH profiles at release-candidate stage. After any bump: `git -C vscode diff <old>..<new> -- src/vs/workbench/browser/workbench.contribution.ts` and review every new/changed `'default':` that touches visible chrome; pin anything Ritemark's look depends on in `branding/product.json` `configurationDefaults` (live on desktop via patch 013). The shell's appearance must never ride an unpinned upstream default. Also test chrome on a FRESH `--user-data-dir` — seasoned profiles can mask default changes.
+
 After `update-vscode.sh`, verify `vscode/node_modules` doesn't carry stale x86_64 native modules (GH #39) and `out/` of html/css/json language-features isn't stale CJS post-ESM-flip (GH #41). `update-vscode.sh` + `check-native-modules.sh` enforce this since 2026-05-02.
 
 ## References

--- a/branding/product.json
+++ b/branding/product.json
@@ -195,6 +195,7 @@
     "workbench.tree.indent": 12,
     "workbench.editor.enablePreview": false,
     "workbench.secondarySideBar.showLabels": false,
+    "workbench.panel.showLabels": false,
     "workbench.editorAssociations": {
       "*.md": "ritemark.editor",
       "*.markdown": "ritemark.editor",

--- a/docs/releases/v1.8.6/TEST-CHECKLIST.md
+++ b/docs/releases/v1.8.6/TEST-CHECKLIST.md
@@ -77,3 +77,9 @@
 - [ ] OpenCode selected: no Plan chip (needs BYOK-keyed profile — Jarmo)
 - [ ] Dark + light pass on packaged candidate (dev pass done with Ritemark Dark — the slate/indigo theme; earlier "black skin" observation was VS Code default Dark+ applied by a mislabeled setting in the automation profile, not a theme regression)
 - [ ] Old thread saved with mode "plan" opens as Auto + Plan chip on
+
+## Visual parity gate (added 2026-08-05 — default-drift lesson)
+
+- [ ] Launch the candidate on a **FRESH profile** (`--user-data-dir` to an empty dir) — never judge chrome from a seasoned profile; several renderings (aux tabs, tree, preview tabs) differ on first run.
+- [ ] Side-by-side against the previous release, compare: Activity Bar order/icons, secondary-sidebar top strip (ICONS, not text), File menu contents, explorer tree (indent/selection), editor surface (hr spacing, fonts).
+- [ ] Any unexplained difference = upstream default drift → pin the setting in `branding/product.json` `configurationDefaults` (live on desktop since patch 013).


### PR DESCRIPTION
Systemic follow-up to the aux-tabs icons→text regression: pin `workbench.panel.showLabels` (same upstream feature family), add a FRESH-profile visual-parity gate to the release checklist, and make a workbench-defaults drift scan mandatory on every VS Code bump in the vscode-development skill. The shell's look must never ride an unpinned upstream default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)