### PR TITLE
fix(windows): isolate standard-user installer test

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -710,19 +710,62 @@ jobs:
             if ($initializeProfile.ExitCode -ne 0) { throw 'Could not initialize the standard-user profile.' }
             $profileRoot = "C:\Users\$userName"
             $installRoot = Join-Path $profileRoot 'AppData\Local\Programs\Ritemark'
+            $stagedInstaller = Join-Path $profileRoot 'Ritemark-Setup.exe'
+            $installLog = Join-Path $profileRoot 'Ritemark-install.log'
+            $uninstallLog = Join-Path $profileRoot 'Ritemark-uninstall.log'
+
+            # The hosted runner workspace is owned by the runner account and is
+            # not guaranteed to be readable by a newly-created standard user.
+            # Stage the exact signed bytes inside that user's profile, whose ACL
+            # is inherited by the copied file, before crossing the user boundary.
+            Copy-Item -LiteralPath $installer -Destination $stagedInstaller
+            $originalInstallerSha = (Get-FileHash -LiteralPath $installer -Algorithm SHA256).Hash
+            $stagedInstallerSha = (Get-FileHash -LiteralPath $stagedInstaller -Algorithm SHA256).Hash
+            if ($stagedInstallerSha -ne $originalInstallerSha) {
+              throw 'Standard-user installer staging changed the signed installer bytes.'
+            }
 
             $hiveName = 'RitemarkCiUser'
-            & reg.exe load "HKU\$hiveName" (Join-Path $profileRoot 'NTUSER.DAT') | Out-Null
-            if ($LASTEXITCODE -ne 0) { throw 'Could not load standard-user registry hive before install.' }
+            # This account was created immediately above, so its uninstall-key
+            # baseline is deterministically empty. Loading NTUSER.DAT before
+            # launching with -LoadUserProfile can leave the hive locked and make
+            # a correct per-user installer fail with Access Denied.
             $uninstallKey = "Registry::HKEY_USERS\$hiveName\Software\Microsoft\Windows\CurrentVersion\Uninstall"
-            $beforeKeys = @(Get-ChildItem $uninstallKey -ErrorAction SilentlyContinue | Select-Object -ExpandProperty PSChildName)
-            & reg.exe unload "HKU\$hiveName" | Out-Null
+            $beforeKeys = @()
 
-            $install = Start-Process -FilePath $installer -Credential $credential -LoadUserProfile -ArgumentList @(
+            function Mount-TestUserHive([string]$phase) {
+              for ($attempt = 1; $attempt -le 10; $attempt++) {
+                & reg.exe load "HKU\$hiveName" (Join-Path $profileRoot 'NTUSER.DAT') 2>$null | Out-Null
+                if ($LASTEXITCODE -eq 0) { return }
+                [gc]::Collect()
+                [gc]::WaitForPendingFinalizers()
+                Start-Sleep -Seconds 2
+              }
+              throw "Could not load standard-user registry hive $phase."
+            }
+
+            function Dismount-TestUserHive([string]$phase) {
+              for ($attempt = 1; $attempt -le 10; $attempt++) {
+                [gc]::Collect()
+                [gc]::WaitForPendingFinalizers()
+                & reg.exe unload "HKU\$hiveName" 2>$null | Out-Null
+                if ($LASTEXITCODE -eq 0) { return }
+                Start-Sleep -Seconds 2
+              }
+              throw "Could not unload standard-user registry hive $phase."
+            }
+
+            $install = Start-Process -FilePath $stagedInstaller -Credential $credential -LoadUserProfile -ArgumentList @(
               '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/SP-', '/CURRENTUSER',
-              "/DIR=`"$installRoot`""
+              "/DIR=`"$installRoot`"", "/LOG=`"$installLog`""
             ) -Wait -PassThru
-            if ($install.ExitCode -ne 0) { throw "Standard-user silent install failed ($($install.ExitCode))." }
+            if ($install.ExitCode -ne 0) {
+              if (Test-Path -LiteralPath $installLog) {
+                Write-Host '--- Inno Setup install log ---'
+                Get-Content -LiteralPath $installLog
+              }
+              throw "Standard-user silent install failed ($($install.ExitCode))."
+            }
 
             ./scripts/verify-windows-signatures.ps1 `
               -Mode Verify `
@@ -735,8 +778,7 @@ jobs:
             $appLinks = @(Get-ChildItem -LiteralPath $startMenu -Filter 'Ritemark.lnk' -File -ErrorAction Stop)
             if ($appLinks.Count -ne 1) { throw "Expected one Ritemark Start menu entry, found $($appLinks.Count)." }
 
-            & reg.exe load "HKU\$hiveName" (Join-Path $profileRoot 'NTUSER.DAT') | Out-Null
-            if ($LASTEXITCODE -ne 0) { throw 'Could not load standard-user registry hive.' }
+            Mount-TestUserHive 'after install'
             try {
               $afterEntries = @(Get-ChildItem $uninstallKey -ErrorAction SilentlyContinue)
               $newEntries = @($afterEntries | Where-Object { $beforeKeys -notcontains $_.PSChildName })
@@ -751,21 +793,28 @@ jobs:
                 throw 'Installed ProductName, Publisher, or Version is incorrect.'
               }
             } finally {
-              [gc]::Collect()
-              & reg.exe unload "HKU\$hiveName" | Out-Null
+              $registration = $null
+              $newEntries = $null
+              $afterEntries = $null
+              Dismount-TestUserHive 'after install checks'
             }
 
             $uninstaller = Get-ChildItem -LiteralPath $installRoot -Filter 'unins*.exe' -File | Select-Object -First 1
             if ($null -eq $uninstaller) { throw 'Signed uninstaller was not installed.' }
             $uninstall = Start-Process -FilePath $uninstaller.FullName -Credential $credential -LoadUserProfile -ArgumentList @(
-              '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART'
+              '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', "/LOG=`"$uninstallLog`""
             ) -Wait -PassThru
-            if ($uninstall.ExitCode -ne 0) { throw "Standard-user silent uninstall failed ($($uninstall.ExitCode))." }
+            if ($uninstall.ExitCode -ne 0) {
+              if (Test-Path -LiteralPath $uninstallLog) {
+                Write-Host '--- Inno Setup uninstall log ---'
+                Get-Content -LiteralPath $uninstallLog
+              }
+              throw "Standard-user silent uninstall failed ($($uninstall.ExitCode))."
+            }
             if (Test-Path -LiteralPath $installRoot) { throw 'Uninstall left the Ritemark install directory behind.' }
             if (Test-Path -LiteralPath $startMenu) { throw 'Uninstall left the Ritemark Start menu group behind.' }
 
-            & reg.exe load "HKU\$hiveName" (Join-Path $profileRoot 'NTUSER.DAT') | Out-Null
-            if ($LASTEXITCODE -ne 0) { throw 'Could not load standard-user registry hive after uninstall.' }
+            Mount-TestUserHive 'after uninstall'
             try {
               if (Test-Path -LiteralPath "$uninstallKey\$registrationKeyName") {
                 throw 'Uninstall left the Ritemark app registration behind.'
@@ -774,8 +823,8 @@ jobs:
                 Where-Object { (Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue).DisplayName -eq 'Ritemark' })
               if ($remainingRitemark.Count -ne 0) { throw 'Uninstall left a Ritemark app registration behind.' }
             } finally {
-              [gc]::Collect()
-              & reg.exe unload "HKU\$hiveName" | Out-Null
+              $remainingRitemark = $null
+              Dismount-TestUserHive 'after uninstall checks'
             }
           } finally {
             Remove-LocalUser -Name $userName -ErrorAction SilentlyContinue

--- a/docs/development/releases/v1.10.0/sprint-114-trusted-windows-install/sprint-plan.md
+++ b/docs/development/releases/v1.10.0/sprint-114-trusted-windows-install/sprint-plan.md
@@ -1,7 +1,8 @@
 # Sprint 114 — Trusted Windows Install
 
-**Status:** Reopened for Gate 2 build recovery after Windows run `33876792999` exposed an `EMFILE` deadlock in VS Code's eager local-extension packager. The signed candidate, immutable download URL, legal URLs, Partner Center certification, Kristiina SAC-On test, and Jarmo exact-hash approval remain v1.10.0 release gates.<br>
+**Status:** Reopened for Gate 2 build recovery. Run `33954203308` confirmed that the `EMFILE` recovery, Windows shell build, Azure signing, signed payload verification, validation, and signed installer build all pass; its standard-user install test then exposed a runner-workspace/profile-hive access race before artifact upload. The signed candidate, immutable download URL, legal URLs, Partner Center certification, Kristiina SAC-On test, and Jarmo exact-hash approval remain v1.10.0 release gates.<br>
 **Branch:** `codex/sprint-114-trusted-windows-install`<br>
+**Follow-up branch:** `codex/sprint-114-windows-standard-user-ci`<br>
 **Issue:** [#212](https://github.com/ProductoryHQ/ritemark-native/issues/212)<br>
 **Release:** [v1.10.0](../release-plan.md)
 
@@ -63,7 +64,12 @@ These checks require the final release-ready v1.10.0 bytes. They do not keep the
 - [x] Preserve the x64 app's symlinks and executable modes across GitHub artifact transport with a verified tar archive, and bind POSIX permission bits into the extension-tree digest.
 - [x] Restore the downloaded x64 archive through one fail-closed extractor before signing; keep the canonical Claude and Codex release playbooks aligned with that command.
 - [x] On Windows, bind every extension PE header/section/overlay byte and every non-PE byte to the staged attestation; normalize only Authenticode-owned checksum, Certificate Table metadata, and the exact Certificate Table range, then independently verify every PE signature.
+- [x] Preserve run `33954203308` as evidence that build, signing, payload validation, and signed-installer creation pass before the standard-user test fails with `Access is denied`.
+- [x] Stage the exact signed installer bytes inside the new standard user's own profile, verify the staged SHA-256 before launch, and never launch the runner-workspace path across the user boundary.
+- [x] Remove the unnecessary pre-install `NTUSER.DAT` mount for the newly created account; retry and explicitly verify the post-process hive mount/unmount transitions.
+- [x] Capture Inno Setup install and uninstall logs on failure, with a deterministic workflow-shape regression test.
 - [x] Pass repository QA and review.
+- [x] Pass follow-up QA and local PowerShell syntax validation for the standard-user CI recovery.
 - [ ] Pass a fresh Windows build from the merged canonical `main` commit.
 
 ## Decisions
@@ -76,3 +82,4 @@ These checks require the final release-ready v1.10.0 bytes. They do not keep the
 - No `docs/development/architecture.md` update is required because this sprint changes packaging and documentation only.
 - Ritemark is no longer packaged twice during the Windows build. VS Code builds the shell without Ritemark in its eager local-extension stream; the already compiled, pruned, target-specific extension is copied into the final shell exactly once and is then covered by the existing completeness, provenance, signing, install, and uninstall gates. Windows records and verifies its complete patched shell only after staging, with the extension's absence as part of that fingerprint. macOS keeps its physical extension copy in the complete fingerprint, so the Windows recovery cannot weaken another platform's provenance gate.
 - No changelog or public release-note entry is added for this recovery because it changes only the release build pipeline and does not change user-facing product behavior.
+- Run `33954203308` did not upload an artifact: fail-closed upload remained after the standard-user install/uninstall gate. The observed `Access is denied` happened only after the installer signature, Windows shell, signed payload, and installer-build checks had passed; the recovery therefore changes test-user isolation and diagnostics, not product payload or signing policy.

--- a/scripts/windows-extension-staging.test.mjs
+++ b/scripts/windows-extension-staging.test.mjs
@@ -104,3 +104,33 @@ test('Windows shell build stages Ritemark outside the eager VS Code packager', a
     'release patches must not record provenance before the extension is staged',
   );
 });
+
+test('Windows standard-user test stages exact installer bytes and avoids profile-hive races', async () => {
+  const workflow = await readFile(workflowPath, 'utf8');
+  const verificationStep = workflow.indexOf('- name: Verify install and uninstall as a standard user');
+  const uploadStep = workflow.indexOf('- name: Upload signed Windows artifacts');
+  assert.notEqual(verificationStep, -1, 'standard-user verification step must exist');
+  assert.notEqual(uploadStep, -1, 'Windows artifact upload step must exist');
+
+  const verification = workflow.slice(verificationStep, uploadStep);
+  const profileInitialization = verification.indexOf("Start-Process -FilePath 'cmd.exe'");
+  const stageInstaller = verification.indexOf('Copy-Item -LiteralPath $installer -Destination $stagedInstaller');
+  const compareInstallerHash = verification.indexOf("Get-FileHash -LiteralPath $stagedInstaller -Algorithm SHA256");
+  const launchInstaller = verification.indexOf('Start-Process -FilePath $stagedInstaller');
+  const firstHiveLoad = verification.indexOf("Mount-TestUserHive 'after install'");
+
+  assert.ok(profileInitialization >= 0, 'the standard-user profile must be initialized');
+  assert.ok(stageInstaller > profileInitialization, 'installer staging must happen after profile initialization');
+  assert.ok(compareInstallerHash > stageInstaller, 'staged installer bytes must be hashed after copying');
+  assert.ok(launchInstaller > compareInstallerHash, 'only the verified staged copy may be launched');
+  assert.ok(firstHiveLoad > launchInstaller, 'the test must not load NTUSER.DAT before -LoadUserProfile runs');
+  assert.match(verification, /\$beforeKeys = @\(\)/, 'a newly-created account must use an empty registration baseline');
+  assert.match(verification, /\/LOG=`"\$installLog`"/, 'installation failures must retain an Inno Setup log');
+  assert.match(verification, /\/LOG=`"\$uninstallLog`"/, 'uninstallation failures must retain an Inno Setup log');
+  assert.match(verification, /for \(\$attempt = 1; \$attempt -le 10; \$attempt\+\+\)/, 'registry hive transitions must retry');
+  assert.doesNotMatch(
+    verification.slice(0, launchInstaller),
+    /Mount-TestUserHive '/,
+    'the profile hive must not be mounted manually before launching the installer as that user',
+  );
+});


### PR DESCRIPTION
## Summary
- stage the exact signed installer inside the new standard user's profile and verify its SHA-256 before launch
- remove the pre-install NTUSER.DAT mount that can race with LoadUserProfile
- retry hive transitions and emit Inno install/uninstall logs on failure
- add deterministic workflow-shape regression coverage and update Sprint 114 evidence

## Evidence
- Windows run 33954203308 passed source verification, shell build, Azure signing, signed payload validation, and signed installer creation, then failed the standard-user install step with Access is denied
- node --test scripts/windows-extension-staging.test.mjs
- full ./scripts/validate-qa.sh
- PowerShell parser validation of the embedded workflow script

## Release impact
Pipeline/test-isolation fix only; no user-facing product behavior change. The next exact-main Windows run remains the release gate.