### PR TITLE
fix(windows): isolate release test user environment

### DIFF
--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -43,7 +43,9 @@ jobs:
           path: ci-harness
           ref: ${{ github.sha }}
           fetch-depth: 1
-          sparse-checkout: scripts/windows-standard-user-registry-probe.ps1
+          sparse-checkout: |
+            scripts/windows-standard-user-registry-probe.ps1
+            scripts/verify-windows-installer-roundtrip.ps1
           sparse-checkout-cone-mode: false
 
       - name: Verify canonical release source
@@ -741,192 +743,14 @@ jobs:
           INSTALLER_PATH: ${{ steps.installer.outputs.installer_path }}
         run: |
           $ErrorActionPreference = 'Stop'
-          $installer = (Resolve-Path -LiteralPath $env:INSTALLER_PATH).Path
-
-          ./scripts/verify-windows-signatures.ps1 `
-            -Mode Verify `
-            -Root installer-output `
+          & (Resolve-Path '..\ci-harness\scripts\verify-windows-installer-roundtrip.ps1').Path `
+            -InstallerPath $env:INSTALLER_PATH `
+            -SignatureVerifierPath 'scripts\verify-windows-signatures.ps1' `
+            -RegistryProbePath '..\ci-harness\scripts\windows-standard-user-registry-probe.ps1' `
             -SignToolPath '${{ steps.signing-tools.outputs.signtool }}' `
             -ExpectedPublisher $env:WINDOWS_PUBLISHER `
-            -OwnedPathPattern '*'
-
-          $runId = [string]$env:GITHUB_RUN_ID
-          $runIdSuffix = if ($runId.Length -gt 15) { $runId.Substring($runId.Length - 15) } else { $runId }
-          $userName = "rmci-$runIdSuffix"
-          if ($userName.Length -gt 20) { throw "Generated Windows test username exceeds 20 characters: $userName" }
-          $plainPassword = "Ritemark!$([guid]::NewGuid().ToString('N'))"
-          $securePassword = ConvertTo-SecureString $plainPassword -AsPlainText -Force
-          $credential = [pscredential]::new("$env:COMPUTERNAME\$userName", $securePassword)
-          New-LocalUser -Name $userName -Password $securePassword -AccountNeverExpires | Out-Null
-          try {
-            $initializeProfile = Start-Process -FilePath 'cmd.exe' -Credential $credential -LoadUserProfile `
-              -WorkingDirectory $env:SystemRoot -ArgumentList '/c','exit 0' -Wait -PassThru
-            if ($initializeProfile.ExitCode -ne 0) { throw 'Could not initialize the standard-user profile.' }
-            $profileRoot = "C:\Users\$userName"
-            if (-not (Test-Path -LiteralPath $profileRoot -PathType Container)) {
-              throw "Standard-user profile was not created at $profileRoot."
-            }
-            $installRoot = Join-Path $profileRoot 'AppData\Local\Programs\Ritemark'
-            $localAppData = Join-Path $profileRoot 'AppData\Local'
-            $roamingAppData = Join-Path $profileRoot 'AppData\Roaming'
-            $userTemp = Join-Path $localAppData 'Temp'
-            $stagedInstaller = Join-Path $profileRoot 'Ritemark-Setup.exe'
-            $installLog = Join-Path $profileRoot 'Ritemark-install.log'
-            $uninstallLog = Join-Path $profileRoot 'Ritemark-uninstall.log'
-            $environmentProbeScript = Join-Path $profileRoot 'Ritemark-Ci-Environment-Probe.ps1'
-            $environmentProbeResult = Join-Path $profileRoot 'Ritemark-Ci-Environment-Probe.json'
-            $registryProbeScript = Join-Path $profileRoot 'Ritemark-Ci-Registry-Probe.ps1'
-            New-Item -ItemType Directory -Path $userTemp -Force | Out-Null
-
-            # The hosted runner workspace is owned by the runner account and is
-            # not guaranteed to be readable by a newly-created standard user.
-            # Stage the exact signed bytes inside that user's profile, whose ACL
-            # is inherited by the copied file, before crossing the user boundary.
-            Copy-Item -LiteralPath $installer -Destination $stagedInstaller
-            Copy-Item -LiteralPath (Resolve-Path '..\ci-harness\scripts\windows-standard-user-registry-probe.ps1').Path `
-              -Destination $registryProbeScript
-            $originalInstallerSha = (Get-FileHash -LiteralPath $installer -Algorithm SHA256).Hash
-            $stagedInstallerSha = (Get-FileHash -LiteralPath $stagedInstaller -Algorithm SHA256).Hash
-            if ($stagedInstallerSha -ne $originalInstallerSha) {
-              throw 'Standard-user installer staging changed the signed installer bytes.'
-            }
-
-            # Start-Process inherits the runner administrator's environment even
-            # when -Credential and -LoadUserProfile are supplied. Inno extracts
-            # its loader through TEMP and resolves per-user shell folders from
-            # these variables, so crossing the user boundary with the runner's
-            # USERPROFILE/TEMP/APPDATA can fail before Inno can create its log.
-            # Give every child the complete standard-user environment explicitly.
-            $userProcessEnvironment = @{
-              USERNAME = $userName
-              USERDOMAIN = $env:COMPUTERNAME
-              USERPROFILE = $profileRoot
-              HOMEDRIVE = 'C:'
-              HOMEPATH = "\Users\$userName"
-              LOCALAPPDATA = $localAppData
-              APPDATA = $roamingAppData
-              TEMP = $userTemp
-              TMP = $userTemp
-              RITEMARK_CI_INSTALLER = $stagedInstaller
-              RITEMARK_CI_PROBE = $environmentProbeResult
-              RITEMARK_CI_PUBLISHER = $env:WINDOWS_PUBLISHER
-              RITEMARK_CI_VERSION = '${{ steps.release.outputs.version }}'
-            }
-
-            # Prove the exact identity, working directory, environment, write
-            # access, and installer bytes from inside the alternate-user process
-            # before using an expensive signed installer as the canary.
-            $environmentProbeContents = @'
-            $ErrorActionPreference = 'Stop'
-            [ordered]@{
-              Identity = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
-              WorkingDirectory = (Get-Location).Path
-              UserName = $env:USERNAME
-              UserProfile = $env:USERPROFILE
-              LocalAppData = $env:LOCALAPPDATA
-              AppData = $env:APPDATA
-              Temp = $env:TEMP
-              Tmp = $env:TMP
-              InstallerSha256 = (Get-FileHash -LiteralPath $env:RITEMARK_CI_INSTALLER -Algorithm SHA256).Hash
-            } | ConvertTo-Json | Set-Content -LiteralPath $env:RITEMARK_CI_PROBE -Encoding utf8NoBOM
-          '@
-            Set-Content -LiteralPath $environmentProbeScript -Value $environmentProbeContents -Encoding utf8NoBOM
-
-            $environmentProbe = Start-Process -FilePath (Join-Path $PSHOME 'pwsh.exe') `
-              -Credential $credential -LoadUserProfile -WorkingDirectory $profileRoot `
-              -Environment $userProcessEnvironment `
-              -ArgumentList '-NoLogo','-NoProfile','-NonInteractive','-File',$environmentProbeScript `
-              -Wait -PassThru
-            if ($environmentProbe.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $environmentProbeResult)) {
-              throw "Standard-user environment probe failed ($($environmentProbe.ExitCode))."
-            }
-            $probe = Get-Content -LiteralPath $environmentProbeResult -Raw | ConvertFrom-Json
-            $expectedProbe = [ordered]@{
-              Identity = "$env:COMPUTERNAME\$userName"
-              WorkingDirectory = $profileRoot
-              UserName = $userName
-              UserProfile = $profileRoot
-              LocalAppData = $localAppData
-              AppData = $roamingAppData
-              Temp = $userTemp
-              Tmp = $userTemp
-              InstallerSha256 = $originalInstallerSha
-            }
-            foreach ($name in $expectedProbe.Keys) {
-              if ([string]$probe.$name -ine [string]$expectedProbe[$name]) {
-                throw "Standard-user environment probe mismatch for $name (got '$($probe.$name)', expected '$($expectedProbe[$name])')."
-              }
-            }
-
-            # HKCU belongs to the standard user, so inspect it inside that same
-            # credential boundary. Admin-side reg load/unload introduces an
-            # artificial hive-lock race that says nothing about the installer.
-            function Invoke-RegistryProbe([string]$mode) {
-              $resultPath = Join-Path $profileRoot "Ritemark-Ci-Registry-$mode.json"
-              Remove-Item -LiteralPath $resultPath -Force -ErrorAction SilentlyContinue
-              $userProcessEnvironment.RITEMARK_CI_REGISTRY_MODE = $mode
-              $userProcessEnvironment.RITEMARK_CI_REGISTRY_RESULT = $resultPath
-              $registryProbe = Start-Process -FilePath (Join-Path $PSHOME 'pwsh.exe') `
-                -Credential $credential -LoadUserProfile -WorkingDirectory $profileRoot `
-                -Environment $userProcessEnvironment `
-                -ArgumentList '-NoLogo','-NoProfile','-NonInteractive','-File',$registryProbeScript `
-                -Wait -PassThru
-              if ($registryProbe.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $resultPath)) {
-                throw "Standard-user registry probe '$mode' failed ($($registryProbe.ExitCode))."
-              }
-              $result = Get-Content -LiteralPath $resultPath -Raw | ConvertFrom-Json
-              if ([string]$result.Identity -ine "$env:COMPUTERNAME\$userName") {
-                throw "Registry probe '$mode' ran as '$($result.Identity)' instead of the standard user."
-              }
-              return $result
-            }
-
-            $install = Start-Process -FilePath $stagedInstaller -Credential $credential -LoadUserProfile `
-              -WorkingDirectory $profileRoot -Environment $userProcessEnvironment -ArgumentList @(
-              '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/SP-', '/CURRENTUSER',
-              "/DIR=$installRoot", "/LOG=$installLog"
-            ) -Wait -PassThru
-            if ($install.ExitCode -ne 0) {
-              if (Test-Path -LiteralPath $installLog) {
-                Write-Host '--- Inno Setup install log ---'
-                Get-Content -LiteralPath $installLog
-              }
-              throw "Standard-user silent install failed ($($install.ExitCode))."
-            }
-
-            ./scripts/verify-windows-signatures.ps1 `
-              -Mode Verify `
-              -Root $installRoot `
-              -SignToolPath '${{ steps.signing-tools.outputs.signtool }}' `
-              -ExpectedPublisher $env:WINDOWS_PUBLISHER `
-              -OwnedPathPattern 'Ritemark.exe','unins*.exe'
-
-            $startMenu = Join-Path $profileRoot 'AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Ritemark'
-            $appLinks = @(Get-ChildItem -LiteralPath $startMenu -Filter 'Ritemark.lnk' -File -ErrorAction Stop)
-            if ($appLinks.Count -ne 1) { throw "Expected one Ritemark Start menu entry, found $($appLinks.Count)." }
-            $installedRegistration = Invoke-RegistryProbe 'verify-installed'
-            Write-Host "Verified $($installedRegistration.Count) current-user Ritemark registration after install."
-
-            $uninstaller = Get-ChildItem -LiteralPath $installRoot -Filter 'unins*.exe' -File | Select-Object -First 1
-            if ($null -eq $uninstaller) { throw 'Signed uninstaller was not installed.' }
-            $uninstall = Start-Process -FilePath $uninstaller.FullName -Credential $credential -LoadUserProfile `
-              -WorkingDirectory $profileRoot -Environment $userProcessEnvironment -ArgumentList @(
-              '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', "/LOG=$uninstallLog"
-            ) -Wait -PassThru
-            if ($uninstall.ExitCode -ne 0) {
-              if (Test-Path -LiteralPath $uninstallLog) {
-                Write-Host '--- Inno Setup uninstall log ---'
-                Get-Content -LiteralPath $uninstallLog
-              }
-              throw "Standard-user silent uninstall failed ($($uninstall.ExitCode))."
-            }
-            if (Test-Path -LiteralPath $installRoot) { throw 'Uninstall left the Ritemark install directory behind.' }
-            if (Test-Path -LiteralPath $startMenu) { throw 'Uninstall left the Ritemark Start menu group behind.' }
-            $removedRegistration = Invoke-RegistryProbe 'verify-uninstalled'
-            Write-Host "Verified $($removedRegistration.Count) current-user Ritemark registrations after uninstall."
-          } finally {
-            Remove-LocalUser -Name $userName -ErrorAction SilentlyContinue
-          }
+            -ExpectedVersion '${{ steps.release.outputs.version }}' `
+            -EvidenceDirectory 'installer-output\roundtrip-evidence'
 
       - name: Upload signed Windows artifacts
         if: always()
@@ -936,6 +760,7 @@ jobs:
           path: |
             r/${{ steps.installer.outputs.installer_path }}
             r/installer-output/Ritemark-Setup.sha256.txt
+            r/installer-output/roundtrip-evidence
           if-no-files-found: warn
           retention-days: 30
 

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -2,6 +2,11 @@ name: Build Windows (x64)
 
 on:
   workflow_dispatch:
+    inputs:
+      source_commit:
+        description: 'Exact approved 40-character commit to build (must equal canonical origin/main)'
+        required: true
+        type: string
     # This paid larger-runner workflow stays manual and always produces a
     # fully signed installer. Missing credentials or any unsigned PE fails it.
 
@@ -28,6 +33,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           path: r
+          ref: ${{ inputs.source_commit }}
           fetch-depth: 0
           submodules: true
 
@@ -35,8 +41,24 @@ jobs:
         shell: bash
         working-directory: r
         run: |
+          SOURCE_COMMIT='${{ inputs.source_commit }}'
+          if [[ ! "$SOURCE_COMMIT" =~ ^[0-9a-fA-F]{40}$ ]]; then
+            echo "ERROR: source_commit must be an exact 40-character commit SHA." >&2
+            exit 1
+          fi
+          CHECKED_OUT_COMMIT="$(git rev-parse HEAD)"
+          if [ "$CHECKED_OUT_COMMIT" != "${SOURCE_COMMIT,,}" ]; then
+            echo "ERROR: checkout resolved to $CHECKED_OUT_COMMIT, expected ${SOURCE_COMMIT,,}." >&2
+            exit 1
+          fi
           git fetch origin main:refs/remotes/origin/main --force
           ./scripts/verify-release-source.sh --target win32-x64 --phase pristine
+          {
+            echo '### Release build identity'
+            echo "- Product source: $CHECKED_OUT_COMMIT"
+            echo "- Workflow definition: $GITHUB_WORKFLOW_REF"
+            echo "- Workflow commit: $GITHUB_SHA"
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Require signing credentials
         id: release
@@ -706,13 +728,22 @@ jobs:
           New-LocalUser -Name $userName -Password $securePassword -AccountNeverExpires | Out-Null
           try {
             $initializeProfile = Start-Process -FilePath 'cmd.exe' -Credential $credential -LoadUserProfile `
-              -ArgumentList '/c','exit 0' -Wait -PassThru
+              -WorkingDirectory $env:SystemRoot -ArgumentList '/c','exit 0' -Wait -PassThru
             if ($initializeProfile.ExitCode -ne 0) { throw 'Could not initialize the standard-user profile.' }
             $profileRoot = "C:\Users\$userName"
+            if (-not (Test-Path -LiteralPath $profileRoot -PathType Container)) {
+              throw "Standard-user profile was not created at $profileRoot."
+            }
             $installRoot = Join-Path $profileRoot 'AppData\Local\Programs\Ritemark'
+            $localAppData = Join-Path $profileRoot 'AppData\Local'
+            $roamingAppData = Join-Path $profileRoot 'AppData\Roaming'
+            $userTemp = Join-Path $localAppData 'Temp'
             $stagedInstaller = Join-Path $profileRoot 'Ritemark-Setup.exe'
             $installLog = Join-Path $profileRoot 'Ritemark-install.log'
             $uninstallLog = Join-Path $profileRoot 'Ritemark-uninstall.log'
+            $environmentProbeScript = Join-Path $profileRoot 'Ritemark-Ci-Environment-Probe.ps1'
+            $environmentProbeResult = Join-Path $profileRoot 'Ritemark-Ci-Environment-Probe.json'
+            New-Item -ItemType Directory -Path $userTemp -Force | Out-Null
 
             # The hosted runner workspace is owned by the runner account and is
             # not guaranteed to be readable by a newly-created standard user.
@@ -723,6 +754,71 @@ jobs:
             $stagedInstallerSha = (Get-FileHash -LiteralPath $stagedInstaller -Algorithm SHA256).Hash
             if ($stagedInstallerSha -ne $originalInstallerSha) {
               throw 'Standard-user installer staging changed the signed installer bytes.'
+            }
+
+            # Start-Process inherits the runner administrator's environment even
+            # when -Credential and -LoadUserProfile are supplied. Inno extracts
+            # its loader through TEMP and resolves per-user shell folders from
+            # these variables, so crossing the user boundary with the runner's
+            # USERPROFILE/TEMP/APPDATA can fail before Inno can create its log.
+            # Give every child the complete standard-user environment explicitly.
+            $userProcessEnvironment = @{
+              USERNAME = $userName
+              USERDOMAIN = $env:COMPUTERNAME
+              USERPROFILE = $profileRoot
+              HOMEDRIVE = 'C:'
+              HOMEPATH = "\Users\$userName"
+              LOCALAPPDATA = $localAppData
+              APPDATA = $roamingAppData
+              TEMP = $userTemp
+              TMP = $userTemp
+              RITEMARK_CI_INSTALLER = $stagedInstaller
+              RITEMARK_CI_PROBE = $environmentProbeResult
+            }
+
+            # Prove the exact identity, working directory, environment, write
+            # access, and installer bytes from inside the alternate-user process
+            # before using an expensive signed installer as the canary.
+            $environmentProbeContents = @'
+            $ErrorActionPreference = 'Stop'
+            [ordered]@{
+              Identity = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+              WorkingDirectory = (Get-Location).Path
+              UserName = $env:USERNAME
+              UserProfile = $env:USERPROFILE
+              LocalAppData = $env:LOCALAPPDATA
+              AppData = $env:APPDATA
+              Temp = $env:TEMP
+              Tmp = $env:TMP
+              InstallerSha256 = (Get-FileHash -LiteralPath $env:RITEMARK_CI_INSTALLER -Algorithm SHA256).Hash
+            } | ConvertTo-Json | Set-Content -LiteralPath $env:RITEMARK_CI_PROBE -Encoding utf8NoBOM
+          '@
+            Set-Content -LiteralPath $environmentProbeScript -Value $environmentProbeContents -Encoding utf8NoBOM
+
+            $environmentProbe = Start-Process -FilePath (Join-Path $PSHOME 'pwsh.exe') `
+              -Credential $credential -LoadUserProfile -WorkingDirectory $profileRoot `
+              -Environment $userProcessEnvironment `
+              -ArgumentList '-NoLogo','-NoProfile','-NonInteractive','-File',$environmentProbeScript `
+              -Wait -PassThru
+            if ($environmentProbe.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $environmentProbeResult)) {
+              throw "Standard-user environment probe failed ($($environmentProbe.ExitCode))."
+            }
+            $probe = Get-Content -LiteralPath $environmentProbeResult -Raw | ConvertFrom-Json
+            $expectedProbe = [ordered]@{
+              Identity = "$env:COMPUTERNAME\$userName"
+              WorkingDirectory = $profileRoot
+              UserName = $userName
+              UserProfile = $profileRoot
+              LocalAppData = $localAppData
+              AppData = $roamingAppData
+              Temp = $userTemp
+              Tmp = $userTemp
+              InstallerSha256 = $originalInstallerSha
+            }
+            foreach ($name in $expectedProbe.Keys) {
+              if ([string]$probe.$name -ine [string]$expectedProbe[$name]) {
+                throw "Standard-user environment probe mismatch for $name (got '$($probe.$name)', expected '$($expectedProbe[$name])')."
+              }
             }
 
             $hiveName = 'RitemarkCiUser'
@@ -755,9 +851,10 @@ jobs:
               throw "Could not unload standard-user registry hive $phase."
             }
 
-            $install = Start-Process -FilePath $stagedInstaller -Credential $credential -LoadUserProfile -ArgumentList @(
+            $install = Start-Process -FilePath $stagedInstaller -Credential $credential -LoadUserProfile `
+              -WorkingDirectory $profileRoot -Environment $userProcessEnvironment -ArgumentList @(
               '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/SP-', '/CURRENTUSER',
-              "/DIR=`"$installRoot`"", "/LOG=`"$installLog`""
+              "/DIR=$installRoot", "/LOG=$installLog"
             ) -Wait -PassThru
             if ($install.ExitCode -ne 0) {
               if (Test-Path -LiteralPath $installLog) {
@@ -801,8 +898,9 @@ jobs:
 
             $uninstaller = Get-ChildItem -LiteralPath $installRoot -Filter 'unins*.exe' -File | Select-Object -First 1
             if ($null -eq $uninstaller) { throw 'Signed uninstaller was not installed.' }
-            $uninstall = Start-Process -FilePath $uninstaller.FullName -Credential $credential -LoadUserProfile -ArgumentList @(
-              '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', "/LOG=`"$uninstallLog`""
+            $uninstall = Start-Process -FilePath $uninstaller.FullName -Credential $credential -LoadUserProfile `
+              -WorkingDirectory $profileRoot -Environment $userProcessEnvironment -ArgumentList @(
+              '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', "/LOG=$uninstallLog"
             ) -Wait -PassThru
             if ($uninstall.ExitCode -ne 0) {
               if (Test-Path -LiteralPath $uninstallLog) {
@@ -834,6 +932,9 @@ jobs:
           @(
             "installer=$([System.IO.Path]::GetFileName($installer))"
             "sha256=$sha256"
+            "source_commit=$((git rev-parse HEAD).Trim())"
+            "workflow_ref=$env:GITHUB_WORKFLOW_REF"
+            "workflow_commit=$env:GITHUB_SHA"
             "store_url=https://downloads.ritemark.app/windows/v${{ steps.release.outputs.version }}/Ritemark-Setup.exe"
             'Partner Center must receive this same file and SHA-256.'
           ) | Set-Content -LiteralPath installer-output/Ritemark-Setup.sha256.txt -Encoding utf8NoBOM

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -37,6 +37,15 @@ jobs:
           fetch-depth: 0
           submodules: true
 
+      - name: Checkout reviewed release harness
+        uses: actions/checkout@v4
+        with:
+          path: ci-harness
+          ref: ${{ github.sha }}
+          fetch-depth: 1
+          sparse-checkout: scripts/windows-standard-user-registry-probe.ps1
+          sparse-checkout-cone-mode: false
+
       - name: Verify canonical release source
         shell: bash
         working-directory: r
@@ -51,13 +60,18 @@ jobs:
             echo "ERROR: checkout resolved to $CHECKED_OUT_COMMIT, expected ${SOURCE_COMMIT,,}." >&2
             exit 1
           fi
+          HARNESS_COMMIT="$(git -C ../ci-harness rev-parse HEAD)"
+          if [ "$HARNESS_COMMIT" != "$GITHUB_SHA" ]; then
+            echo "ERROR: release harness resolved to $HARNESS_COMMIT, expected $GITHUB_SHA." >&2
+            exit 1
+          fi
           git fetch origin main:refs/remotes/origin/main --force
           ./scripts/verify-release-source.sh --target win32-x64 --phase pristine
           {
             echo '### Release build identity'
             echo "- Product source: $CHECKED_OUT_COMMIT"
             echo "- Workflow definition: $GITHUB_WORKFLOW_REF"
-            echo "- Workflow commit: $GITHUB_SHA"
+            echo "- Workflow/harness commit: $HARNESS_COMMIT"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Require signing credentials
@@ -702,6 +716,24 @@ jobs:
           Move-Item -LiteralPath $versionedInstaller -Destination $canonicalInstaller
           "installer_path=$($canonicalInstaller.Replace('\', '/'))" | Add-Content -LiteralPath $env:GITHUB_OUTPUT
 
+      - name: Record signed Windows installer identity
+        shell: pwsh
+        working-directory: r
+        env:
+          INSTALLER_PATH: ${{ steps.installer.outputs.installer_path }}
+        run: |
+          $installer = (Resolve-Path -LiteralPath $env:INSTALLER_PATH).Path
+          $sha256 = (Get-FileHash -LiteralPath $installer -Algorithm SHA256).Hash.ToLowerInvariant()
+          @(
+            "installer=$([System.IO.Path]::GetFileName($installer))"
+            "sha256=$sha256"
+            "source_commit=$((git rev-parse HEAD).Trim())"
+            "workflow_ref=$env:GITHUB_WORKFLOW_REF"
+            "workflow_commit=$env:GITHUB_SHA"
+            "store_url=https://downloads.ritemark.app/windows/v${{ steps.release.outputs.version }}/Ritemark-Setup.exe"
+            'Partner Center must receive this same file and SHA-256.'
+          ) | Set-Content -LiteralPath installer-output/Ritemark-Setup.sha256.txt -Encoding utf8NoBOM
+
       - name: Verify install and uninstall as a standard user
         shell: pwsh
         working-directory: r
@@ -743,6 +775,7 @@ jobs:
             $uninstallLog = Join-Path $profileRoot 'Ritemark-uninstall.log'
             $environmentProbeScript = Join-Path $profileRoot 'Ritemark-Ci-Environment-Probe.ps1'
             $environmentProbeResult = Join-Path $profileRoot 'Ritemark-Ci-Environment-Probe.json'
+            $registryProbeScript = Join-Path $profileRoot 'Ritemark-Ci-Registry-Probe.ps1'
             New-Item -ItemType Directory -Path $userTemp -Force | Out-Null
 
             # The hosted runner workspace is owned by the runner account and is
@@ -750,6 +783,8 @@ jobs:
             # Stage the exact signed bytes inside that user's profile, whose ACL
             # is inherited by the copied file, before crossing the user boundary.
             Copy-Item -LiteralPath $installer -Destination $stagedInstaller
+            Copy-Item -LiteralPath (Resolve-Path '..\ci-harness\scripts\windows-standard-user-registry-probe.ps1').Path `
+              -Destination $registryProbeScript
             $originalInstallerSha = (Get-FileHash -LiteralPath $installer -Algorithm SHA256).Hash
             $stagedInstallerSha = (Get-FileHash -LiteralPath $stagedInstaller -Algorithm SHA256).Hash
             if ($stagedInstallerSha -ne $originalInstallerSha) {
@@ -774,6 +809,8 @@ jobs:
               TMP = $userTemp
               RITEMARK_CI_INSTALLER = $stagedInstaller
               RITEMARK_CI_PROBE = $environmentProbeResult
+              RITEMARK_CI_PUBLISHER = $env:WINDOWS_PUBLISHER
+              RITEMARK_CI_VERSION = '${{ steps.release.outputs.version }}'
             }
 
             # Prove the exact identity, working directory, environment, write
@@ -821,34 +858,27 @@ jobs:
               }
             }
 
-            $hiveName = 'RitemarkCiUser'
-            # This account was created immediately above, so its uninstall-key
-            # baseline is deterministically empty. Loading NTUSER.DAT before
-            # launching with -LoadUserProfile can leave the hive locked and make
-            # a correct per-user installer fail with Access Denied.
-            $uninstallKey = "Registry::HKEY_USERS\$hiveName\Software\Microsoft\Windows\CurrentVersion\Uninstall"
-            $beforeKeys = @()
-
-            function Mount-TestUserHive([string]$phase) {
-              for ($attempt = 1; $attempt -le 10; $attempt++) {
-                & reg.exe load "HKU\$hiveName" (Join-Path $profileRoot 'NTUSER.DAT') 2>$null | Out-Null
-                if ($LASTEXITCODE -eq 0) { return }
-                [gc]::Collect()
-                [gc]::WaitForPendingFinalizers()
-                Start-Sleep -Seconds 2
+            # HKCU belongs to the standard user, so inspect it inside that same
+            # credential boundary. Admin-side reg load/unload introduces an
+            # artificial hive-lock race that says nothing about the installer.
+            function Invoke-RegistryProbe([string]$mode) {
+              $resultPath = Join-Path $profileRoot "Ritemark-Ci-Registry-$mode.json"
+              Remove-Item -LiteralPath $resultPath -Force -ErrorAction SilentlyContinue
+              $userProcessEnvironment.RITEMARK_CI_REGISTRY_MODE = $mode
+              $userProcessEnvironment.RITEMARK_CI_REGISTRY_RESULT = $resultPath
+              $registryProbe = Start-Process -FilePath (Join-Path $PSHOME 'pwsh.exe') `
+                -Credential $credential -LoadUserProfile -WorkingDirectory $profileRoot `
+                -Environment $userProcessEnvironment `
+                -ArgumentList '-NoLogo','-NoProfile','-NonInteractive','-File',$registryProbeScript `
+                -Wait -PassThru
+              if ($registryProbe.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $resultPath)) {
+                throw "Standard-user registry probe '$mode' failed ($($registryProbe.ExitCode))."
               }
-              throw "Could not load standard-user registry hive $phase."
-            }
-
-            function Dismount-TestUserHive([string]$phase) {
-              for ($attempt = 1; $attempt -le 10; $attempt++) {
-                [gc]::Collect()
-                [gc]::WaitForPendingFinalizers()
-                & reg.exe unload "HKU\$hiveName" 2>$null | Out-Null
-                if ($LASTEXITCODE -eq 0) { return }
-                Start-Sleep -Seconds 2
+              $result = Get-Content -LiteralPath $resultPath -Raw | ConvertFrom-Json
+              if ([string]$result.Identity -ine "$env:COMPUTERNAME\$userName") {
+                throw "Registry probe '$mode' ran as '$($result.Identity)' instead of the standard user."
               }
-              throw "Could not unload standard-user registry hive $phase."
+              return $result
             }
 
             $install = Start-Process -FilePath $stagedInstaller -Credential $credential -LoadUserProfile `
@@ -874,27 +904,8 @@ jobs:
             $startMenu = Join-Path $profileRoot 'AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Ritemark'
             $appLinks = @(Get-ChildItem -LiteralPath $startMenu -Filter 'Ritemark.lnk' -File -ErrorAction Stop)
             if ($appLinks.Count -ne 1) { throw "Expected one Ritemark Start menu entry, found $($appLinks.Count)." }
-
-            Mount-TestUserHive 'after install'
-            try {
-              $afterEntries = @(Get-ChildItem $uninstallKey -ErrorAction SilentlyContinue)
-              $newEntries = @($afterEntries | Where-Object { $beforeKeys -notcontains $_.PSChildName })
-              if ($newEntries.Count -ne 1) {
-                throw "Installer created $($newEntries.Count) app registrations; expected exactly one and no bundleware."
-              }
-              $registration = Get-ItemProperty $newEntries[0].PSPath
-              $registrationKeyName = $newEntries[0].PSChildName
-              if ($registration.DisplayName -ne 'Ritemark') { throw 'The new app registration is not Ritemark.' }
-              if ($registration.Publisher -ne $env:WINDOWS_PUBLISHER -or
-                  $registration.DisplayVersion -ne '${{ steps.release.outputs.version }}') {
-                throw 'Installed ProductName, Publisher, or Version is incorrect.'
-              }
-            } finally {
-              $registration = $null
-              $newEntries = $null
-              $afterEntries = $null
-              Dismount-TestUserHive 'after install checks'
-            }
+            $installedRegistration = Invoke-RegistryProbe 'verify-installed'
+            Write-Host "Verified $($installedRegistration.Count) current-user Ritemark registration after install."
 
             $uninstaller = Get-ChildItem -LiteralPath $installRoot -Filter 'unins*.exe' -File | Select-Object -First 1
             if ($null -eq $uninstaller) { throw 'Signed uninstaller was not installed.' }
@@ -911,41 +922,21 @@ jobs:
             }
             if (Test-Path -LiteralPath $installRoot) { throw 'Uninstall left the Ritemark install directory behind.' }
             if (Test-Path -LiteralPath $startMenu) { throw 'Uninstall left the Ritemark Start menu group behind.' }
-
-            Mount-TestUserHive 'after uninstall'
-            try {
-              if (Test-Path -LiteralPath "$uninstallKey\$registrationKeyName") {
-                throw 'Uninstall left the Ritemark app registration behind.'
-              }
-              $remainingRitemark = @(Get-ChildItem $uninstallKey -ErrorAction SilentlyContinue |
-                Where-Object { (Get-ItemProperty $_.PSPath -ErrorAction SilentlyContinue).DisplayName -eq 'Ritemark' })
-              if ($remainingRitemark.Count -ne 0) { throw 'Uninstall left a Ritemark app registration behind.' }
-            } finally {
-              $remainingRitemark = $null
-              Dismount-TestUserHive 'after uninstall checks'
-            }
+            $removedRegistration = Invoke-RegistryProbe 'verify-uninstalled'
+            Write-Host "Verified $($removedRegistration.Count) current-user Ritemark registrations after uninstall."
           } finally {
             Remove-LocalUser -Name $userName -ErrorAction SilentlyContinue
           }
 
-          $sha256 = (Get-FileHash -LiteralPath $installer -Algorithm SHA256).Hash.ToLowerInvariant()
-          @(
-            "installer=$([System.IO.Path]::GetFileName($installer))"
-            "sha256=$sha256"
-            "source_commit=$((git rev-parse HEAD).Trim())"
-            "workflow_ref=$env:GITHUB_WORKFLOW_REF"
-            "workflow_commit=$env:GITHUB_SHA"
-            "store_url=https://downloads.ritemark.app/windows/v${{ steps.release.outputs.version }}/Ritemark-Setup.exe"
-            'Partner Center must receive this same file and SHA-256.'
-          ) | Set-Content -LiteralPath installer-output/Ritemark-Setup.sha256.txt -Encoding utf8NoBOM
-
       - name: Upload signed Windows artifacts
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: ritemark-windows-installer
           path: |
             r/${{ steps.installer.outputs.installer_path }}
             r/installer-output/Ritemark-Setup.sha256.txt
+          if-no-files-found: warn
           retention-days: 30
 
       - name: Build summary

--- a/.github/workflows/windows-canary.yml
+++ b/.github/workflows/windows-canary.yml
@@ -11,8 +11,10 @@ name: Windows CI Canary
 # compile — every week on the FREE `windows-latest` standard runner, so a
 # toolchain regression surfaces on a Monday, not mid-release.
 #
-# SCOPE: this is an EARLY WARNING, not a gate. It does NOT clone/build VS Code
-# or produce an installer. `windows-latest` (standard) and `windows-8core`
+# SCOPE: the scheduled path is an EARLY WARNING, not a gate. It does NOT
+# clone/build VS Code or produce an installer. The manual replay path can also
+# download and verify an already preserved signed installer without rebuilding
+# or re-signing it. `windows-latest` (standard) and `windows-8core`
 # (larger) can run slightly different image versions, so a green canary does
 # not GUARANTEE the 8-core build is green — but a RED canary reliably means the
 # shared Windows toolchain (Node + node-gyp + MSVC/VS detection) has shifted and
@@ -23,6 +25,23 @@ on:
   schedule:
     - cron: '0 6 * * 1'   # Mondays 06:00 UTC
   workflow_dispatch:
+    inputs:
+      installer_run_id:
+        description: 'Optional completed Build Windows run ID whose preserved installer should be re-verified'
+        required: false
+        type: string
+      expected_source_commit:
+        description: 'Required with installer_run_id: exact 40-character product source commit'
+        required: false
+        type: string
+      expected_sha256:
+        description: 'Required with installer_run_id: exact installer SHA-256'
+        required: false
+        type: string
+      expected_version:
+        description: 'Required with installer_run_id: Ritemark release version'
+        required: false
+        type: string
 
 env:
   # Keep in lockstep with build-windows.yml so the canary exercises the same
@@ -31,6 +50,7 @@ env:
 
 jobs:
   canary:
+    if: ${{ github.event_name == 'schedule' || inputs.installer_run_id == '' }}
     runs-on: windows-latest
     timeout-minutes: 20
 
@@ -164,14 +184,24 @@ jobs:
 
             function Invoke-CanaryRegistryProbe([string]$mode, [int]$expectedCount) {
               $resultPath = Join-Path $profileRoot "Ritemark-Ci-Registry-$mode.json"
+              $stdoutPath = Join-Path $profileRoot "Ritemark-Ci-Registry-$mode.stdout.log"
+              $stderrPath = Join-Path $profileRoot "Ritemark-Ci-Registry-$mode.stderr.log"
               Remove-Item -LiteralPath $resultPath -Force -ErrorAction SilentlyContinue
+              Remove-Item -LiteralPath $stdoutPath,$stderrPath -Force -ErrorAction SilentlyContinue
               $userProcessEnvironment.RITEMARK_CI_REGISTRY_MODE = $mode
               $userProcessEnvironment.RITEMARK_CI_REGISTRY_RESULT = $resultPath
               $process = Start-Process -FilePath (Join-Path $PSHOME 'pwsh.exe') `
                 -Credential $credential -LoadUserProfile -WorkingDirectory $profileRoot `
                 -Environment $userProcessEnvironment `
                 -ArgumentList '-NoLogo','-NoProfile','-NonInteractive','-File',$probeScript `
+                -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath `
                 -Wait -PassThru
+              foreach ($entry in @(@{ Name = 'stdout'; Path = $stdoutPath }, @{ Name = 'stderr'; Path = $stderrPath })) {
+                if (Test-Path -LiteralPath $entry.Path) {
+                  Write-Host "--- registry canary $mode $($entry.Name) ---"
+                  Get-Content -LiteralPath $entry.Path | ForEach-Object { Write-Host $_ }
+                }
+              }
               if ($process.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $resultPath)) {
                 throw "Standard-user registry canary '$mode' failed ($($process.ExitCode))."
               }
@@ -189,3 +219,96 @@ jobs:
           } finally {
             Remove-LocalUser -Name $userName -ErrorAction SilentlyContinue
           }
+
+  verify-preserved-installer:
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.installer_run_id != '' }}
+    runs-on: windows-latest
+    timeout-minutes: 20
+    permissions:
+      actions: read
+      contents: read
+
+    steps:
+      - name: Checkout reviewed verification harness
+        uses: actions/checkout@v4
+
+      - name: Download preserved signed installer
+        uses: actions/download-artifact@v4
+        with:
+          name: ritemark-windows-installer
+          path: installer-artifact
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ inputs.installer_run_id }}
+
+      - name: Verify immutable installer identity
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $expectedSource = '${{ inputs.expected_source_commit }}'.ToLowerInvariant()
+          $expectedSha = '${{ inputs.expected_sha256 }}'.ToLowerInvariant()
+          $expectedVersion = '${{ inputs.expected_version }}'
+          if ($expectedSource -notmatch '^[0-9a-f]{40}$') {
+            throw 'expected_source_commit must be exactly 40 hexadecimal characters.'
+          }
+          if ($expectedSha -notmatch '^[0-9a-f]{64}$') {
+            throw 'expected_sha256 must be exactly 64 hexadecimal characters.'
+          }
+          if ([string]::IsNullOrWhiteSpace($expectedVersion)) {
+            throw 'expected_version is required when replaying a preserved installer.'
+          }
+
+          $installer = (Resolve-Path 'installer-artifact\Ritemark-Setup.exe').Path
+          $manifestPath = (Resolve-Path 'installer-artifact\Ritemark-Setup.sha256.txt').Path
+          $manifest = @{}
+          foreach ($line in Get-Content -LiteralPath $manifestPath) {
+            if ($line -match '^(?<key>[^=]+)=(?<value>.*)$') {
+              $manifest[$Matches.key] = $Matches.value
+            }
+          }
+          $actualSha = (Get-FileHash -LiteralPath $installer -Algorithm SHA256).Hash.ToLowerInvariant()
+          if ($actualSha -ne $expectedSha -or [string]$manifest.sha256 -ne $expectedSha) {
+            throw "Preserved installer SHA-256 mismatch (actual '$actualSha', manifest '$($manifest.sha256)', expected '$expectedSha')."
+          }
+          if ([string]$manifest.source_commit -ne $expectedSource) {
+            throw "Preserved installer source mismatch (manifest '$($manifest.source_commit)', expected '$expectedSource')."
+          }
+          Write-Host "Verified preserved installer from run ${{ inputs.installer_run_id }}: $actualSha"
+
+      - name: Resolve Windows signature verifier
+        id: signing-tools
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $candidates = @(Get-ChildItem `
+            -Path "${env:ProgramFiles(x86)}\Windows Kits\10\bin\*\x64\signtool.exe" `
+            -File -ErrorAction SilentlyContinue | Sort-Object {
+              [version]$_.Directory.Parent.Name
+            } -Descending)
+          if ($candidates.Count -eq 0) {
+            throw 'signtool.exe was not found on the Windows runner.'
+          }
+          "signtool=$($candidates[0].FullName)" | Add-Content -LiteralPath $env:GITHUB_OUTPUT
+
+      - name: Verify install and uninstall as a standard user
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          ./scripts/verify-windows-installer-roundtrip.ps1 `
+            -InstallerPath 'installer-artifact\Ritemark-Setup.exe' `
+            -SignatureVerifierPath 'scripts\verify-windows-signatures.ps1' `
+            -RegistryProbePath 'scripts\windows-standard-user-registry-probe.ps1' `
+            -SignToolPath '${{ steps.signing-tools.outputs.signtool }}' `
+            -ExpectedPublisher 'Productory Services OÜ' `
+            -ExpectedVersion '${{ inputs.expected_version }}' `
+            -EvidenceDirectory 'roundtrip-evidence'
+
+      - name: Upload roundtrip evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ritemark-windows-roundtrip-${{ inputs.installer_run_id }}
+          path: |
+            installer-artifact/Ritemark-Setup.sha256.txt
+            roundtrip-evidence
+          if-no-files-found: warn
+          retention-days: 30

--- a/.github/workflows/windows-canary.yml
+++ b/.github/workflows/windows-canary.yml
@@ -35,6 +35,9 @@ jobs:
     timeout-minutes: 20
 
     steps:
+      - name: Checkout release harness
+        uses: actions/checkout@v4
+
       - name: Configure Git for Windows
         shell: bash
         run: |
@@ -120,3 +123,69 @@ jobs:
           # it from source exercises node-gyp -> MSVC end to end.
           npm install @vscode/spdlog --build-from-source --no-audit --no-fund --foreground-scripts --loglevel=error
           node -e "require('@vscode/spdlog'); console.log('Native compile + load OK (@vscode/spdlog)')"
+
+      - name: Verify standard-user process and HKCU boundary
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          $runId = [string]$env:GITHUB_RUN_ID
+          $runIdSuffix = if ($runId.Length -gt 15) { $runId.Substring($runId.Length - 15) } else { $runId }
+          $userName = "rmci-$runIdSuffix"
+          $plainPassword = "Ritemark!$([guid]::NewGuid().ToString('N'))"
+          $securePassword = ConvertTo-SecureString $plainPassword -AsPlainText -Force
+          $credential = [pscredential]::new("$env:COMPUTERNAME\$userName", $securePassword)
+          New-LocalUser -Name $userName -Password $securePassword -AccountNeverExpires | Out-Null
+          try {
+            $initializeProfile = Start-Process -FilePath 'cmd.exe' -Credential $credential -LoadUserProfile `
+              -WorkingDirectory $env:SystemRoot -ArgumentList '/c','exit 0' -Wait -PassThru
+            if ($initializeProfile.ExitCode -ne 0) { throw 'Could not initialize the standard-user profile.' }
+
+            $profileRoot = "C:\Users\$userName"
+            $localAppData = Join-Path $profileRoot 'AppData\Local'
+            $userTemp = Join-Path $localAppData 'Temp'
+            $probeScript = Join-Path $profileRoot 'Ritemark-Ci-Registry-Probe.ps1'
+            New-Item -ItemType Directory -Path $userTemp -Force | Out-Null
+            Copy-Item -LiteralPath (Resolve-Path 'scripts\windows-standard-user-registry-probe.ps1').Path `
+              -Destination $probeScript
+
+            $userProcessEnvironment = @{
+              USERNAME = $userName
+              USERDOMAIN = $env:COMPUTERNAME
+              USERPROFILE = $profileRoot
+              HOMEDRIVE = 'C:'
+              HOMEPATH = "\Users\$userName"
+              LOCALAPPDATA = $localAppData
+              APPDATA = (Join-Path $profileRoot 'AppData\Roaming')
+              TEMP = $userTemp
+              TMP = $userTemp
+              RITEMARK_CI_PUBLISHER = 'Productory Services OÜ'
+              RITEMARK_CI_VERSION = 'canary'
+            }
+
+            function Invoke-CanaryRegistryProbe([string]$mode, [int]$expectedCount) {
+              $resultPath = Join-Path $profileRoot "Ritemark-Ci-Registry-$mode.json"
+              Remove-Item -LiteralPath $resultPath -Force -ErrorAction SilentlyContinue
+              $userProcessEnvironment.RITEMARK_CI_REGISTRY_MODE = $mode
+              $userProcessEnvironment.RITEMARK_CI_REGISTRY_RESULT = $resultPath
+              $process = Start-Process -FilePath (Join-Path $PSHOME 'pwsh.exe') `
+                -Credential $credential -LoadUserProfile -WorkingDirectory $profileRoot `
+                -Environment $userProcessEnvironment `
+                -ArgumentList '-NoLogo','-NoProfile','-NonInteractive','-File',$probeScript `
+                -Wait -PassThru
+              if ($process.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $resultPath)) {
+                throw "Standard-user registry canary '$mode' failed ($($process.ExitCode))."
+              }
+              $result = Get-Content -LiteralPath $resultPath -Raw | ConvertFrom-Json
+              if ([string]$result.Identity -ine "$env:COMPUTERNAME\$userName" -or
+                  [int]$result.Count -ne $expectedCount) {
+                throw "Registry canary '$mode' returned the wrong identity or count."
+              }
+            }
+
+            Invoke-CanaryRegistryProbe 'seed-canary' 1
+            Invoke-CanaryRegistryProbe 'verify-installed' 1
+            Invoke-CanaryRegistryProbe 'remove-canary' 0
+            Invoke-CanaryRegistryProbe 'verify-uninstalled' 0
+          } finally {
+            Remove-LocalUser -Name $userName -ErrorAction SilentlyContinue
+          }

--- a/.github/workflows/windows-canary.yml
+++ b/.github/workflows/windows-canary.yml
@@ -199,7 +199,7 @@ jobs:
               foreach ($entry in @(@{ Name = 'stdout'; Path = $stdoutPath }, @{ Name = 'stderr'; Path = $stderrPath })) {
                 if (Test-Path -LiteralPath $entry.Path) {
                   Write-Host "--- registry canary $mode $($entry.Name) ---"
-                  Get-Content -LiteralPath $entry.Path | ForEach-Object { Write-Host $_ }
+                  Get-Content -LiteralPath $entry.Path -Encoding oem | ForEach-Object { Write-Host $_ }
                 }
               }
               if ($process.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $resultPath)) {

--- a/docs/development/releases/v1.10.0/sprint-114-trusted-windows-install/sprint-plan.md
+++ b/docs/development/releases/v1.10.0/sprint-114-trusted-windows-install/sprint-plan.md
@@ -1,6 +1,6 @@
 # Sprint 114 — Trusted Windows Install
 
-**Status:** Reopened for Gate 2 build recovery. Runs `33954203308` and `33965759422` confirmed that the Windows shell build, Azure signing, signed payload verification, validation, and signed installer build all pass. The first exposed runner-workspace/profile-hive isolation; the second removed those causes and isolated the remaining failure to the alternate-credential process inheriting the runner administrator's environment. The signed candidate, immutable download URL, legal URLs, Partner Center certification, Kristiina SAC-On test, and Jarmo exact-hash approval remain v1.10.0 release gates.<br>
+**Status:** Reopened for Gate 2 build recovery. Runs `33954203308`, `33965759422`, and `33968428932` progressively isolated CI-only standard-user harness faults after the Windows app, Azure signing, payload verification, validation, and signed installer build had passed. The third run proved the corrected process environment, successful install, and all 44 installed PE signatures; it then exposed an admin-side registry-hive unload race after install verification. The signed candidate, immutable download URL, legal URLs, Partner Center certification, Kristiina SAC-On test, and Jarmo exact-hash approval remain v1.10.0 release gates.<br>
 **Branch:** `codex/sprint-114-trusted-windows-install`<br>
 **Follow-up branch:** `codex/sprint-114-windows-standard-user-ci`<br>
 **Second follow-up branch:** `codex/sprint-114-windows-user-environment`<br>
@@ -75,11 +75,16 @@ These checks require the final release-ready v1.10.0 bytes. They do not keep the
 - [x] Replace that implicit environment boundary with an explicit standard-user working directory and identity/profile/temp/shell-folder environment shared by the canary, installer, and uninstaller.
 - [x] Require an alternate-user canary to prove identity, environment, working directory, write access, and the user-visible installer SHA-256 before installation.
 - [x] Decouple the immutable approved product-source SHA from the workflow revision: the paid workflow requires an explicit 40-character source commit, checks out that exact commit, still requires it to equal canonical `origin/main`, and records both source and workflow commits beside the installer hash.
+- [x] Preserve run `33968428932` as evidence that the isolated standard-user process installs the signed application and that all 44 installed PE files verify; classify the later `reg unload` failure as an admin-side test-harness race.
+- [x] Replace admin-side `HKEY_USERS` hive mounting with a shared verifier that inspects `HKCU` inside the same standard-user credential boundary before and after uninstall.
+- [ ] Pass the shared standard-user/HKCU verifier first in the free `windows-latest` canary.
 - [ ] Pass a fresh Windows build from the exact approved canonical `main` product commit using the reviewed workflow revision.
 
 ## Decisions
 
 - **2026-09-05 — Do not invalidate an approved Mac RC for a Windows-only CI harness correction.** The Windows workflow definition may advance independently, but the product checkout remains pinned to the exact Gate 1 source commit and must still pass the existing `origin/main` integrity and embedded provenance gates. Both identities are recorded in the workflow summary and Windows hash manifest.
+- **2026-09-05 — Inspect user-owned state as that user.** Do not mount a generated user's `NTUSER.DAT` into `HKEY_USERS` from the runner administrator. Run the registry verifier under the exact standard-user credentials and `HKCU`, and exercise that same verifier in the free Windows canary before paying for another release build.
+- **2026-09-05 — Preserve a completed signed installer even when the last test fails.** Record its SHA/source/workflow identity before the roundtrip and upload it with `if: always()`; this prevents a late harness failure from destroying the only debuggable artifact.
 
 - Existing repository-level Azure signing secrets remain in use.
 - GitHub Release continues as the secondary direct-download location; no channel redesign is needed.

--- a/docs/development/releases/v1.10.0/sprint-114-trusted-windows-install/sprint-plan.md
+++ b/docs/development/releases/v1.10.0/sprint-114-trusted-windows-install/sprint-plan.md
@@ -1,6 +1,6 @@
 # Sprint 114 — Trusted Windows Install
 
-**Status:** Reopened for Gate 2 build recovery. Runs `33954203308`, `33965759422`, and `33968428932` progressively isolated CI-only standard-user harness faults after the Windows app, Azure signing, payload verification, validation, and signed installer build had passed. The third run proved the corrected process environment, successful install, and all 44 installed PE signatures; it then exposed an admin-side registry-hive unload race after install verification. The signed candidate, immutable download URL, legal URLs, Partner Center certification, Kristiina SAC-On test, and Jarmo exact-hash approval remain v1.10.0 release gates.<br>
+**Status:** Reopened for Gate 2 build recovery. Runs `33954203308`, `33965759422`, `33968428932`, and `33970702424` progressively isolated CI-only standard-user harness faults after the Windows app, Azure signing, payload verification, validation, and signed installer build had passed. The latest run produced preserved installer SHA-256 `7ada28ad639eb798205a13f22bf1f9844e1856e032737c924738c1b8033232f3` from approved product commit `8698ce9900ec437067a40eda3f5209f79029786f`, installed it successfully as a standard user, and verified all 44 installed PE signatures. Its last failure was the harness expecting `DisplayName=Ritemark` although Inno Setup correctly writes the configured `AppVerName`, `Ritemark 1.10.0`. The corrected verifier and preserved-installer replay remain to pass before Gate 2. The immutable download URL, legal URLs, Partner Center certification, Kristiina SAC-On test, and Jarmo exact-hash approval remain v1.10.0 release gates.<br>
 **Branch:** `codex/sprint-114-trusted-windows-install`<br>
 **Follow-up branch:** `codex/sprint-114-windows-standard-user-ci`<br>
 **Second follow-up branch:** `codex/sprint-114-windows-user-environment`<br>
@@ -77,14 +77,21 @@ These checks require the final release-ready v1.10.0 bytes. They do not keep the
 - [x] Decouple the immutable approved product-source SHA from the workflow revision: the paid workflow requires an explicit 40-character source commit, checks out that exact commit, still requires it to equal canonical `origin/main`, and records both source and workflow commits beside the installer hash.
 - [x] Preserve run `33968428932` as evidence that the isolated standard-user process installs the signed application and that all 44 installed PE files verify; classify the later `reg unload` failure as an admin-side test-harness race.
 - [x] Replace admin-side `HKEY_USERS` hive mounting with a shared verifier that inspects `HKCU` inside the same standard-user credential boundary before and after uninstall.
-- [ ] Pass the shared standard-user/HKCU verifier first in the free `windows-latest` canary.
-- [ ] Pass a fresh Windows build from the exact approved canonical `main` product commit using the reviewed workflow revision.
+- [x] Pass the first shared standard-user/HKCU verifier in free `windows-latest` canary run `33970548341` before using it in the release workflow.
+- [x] Preserve run `33970702424` and its exact signed installer after it proved standard-user install plus all 44 installed PE signatures, then failed only because the shared verifier modeled Inno's uninstall `DisplayName` incorrectly.
+- [x] Match Inno Setup's documented registration contract: absent an explicit `UninstallDisplayName`, the registry `DisplayName` is `AppVerName` (`Ritemark 1.10.0`), while still detecting leftover or duplicate Ritemark registrations.
+- [x] Extract the complete standard-user install/signature/registration/uninstall sequence into one shared roundtrip script used by both the release build and the preserved-installer replay path.
+- [x] Capture every alternate-user child process's stdout/stderr and retain roundtrip evidence after the temporary user is deleted.
+- [ ] Pass the corrected standard-user/HKCU contract in the free `windows-latest` canary.
+- [ ] Replay and pass the preserved installer from run `33970702424` without rebuilding or re-signing product bytes.
 
 ## Decisions
 
 - **2026-09-05 — Do not invalidate an approved Mac RC for a Windows-only CI harness correction.** The Windows workflow definition may advance independently, but the product checkout remains pinned to the exact Gate 1 source commit and must still pass the existing `origin/main` integrity and embedded provenance gates. Both identities are recorded in the workflow summary and Windows hash manifest.
 - **2026-09-05 — Inspect user-owned state as that user.** Do not mount a generated user's `NTUSER.DAT` into `HKEY_USERS` from the runner administrator. Run the registry verifier under the exact standard-user credentials and `HKCU`, and exercise that same verifier in the free Windows canary before paying for another release build.
 - **2026-09-05 — Preserve a completed signed installer even when the last test fails.** Record its SHA/source/workflow identity before the roundtrip and upload it with `if: always()`; this prevents a late harness failure from destroying the only debuggable artifact.
+- **2026-09-05 — Re-verify immutable bytes instead of rebuilding after a harness-only failure.** A manual path in the free Windows canary accepts the source run ID, expected product commit, expected installer SHA-256, and version; it downloads the preserved artifact, fails closed on identity mismatch, and runs the same shared roundtrip script without compiling or signing a new product.
+- **2026-09-05 — Model the installer's declared contract, not a synthetic canary value.** Inno Setup uses `AppVerName` as the Add/Remove Programs display name when `UninstallDisplayName` is absent. Both the canary and release verifier therefore require `Ritemark <version>` and retain the observed key names, display names, publishers, and versions as evidence.
 
 - Existing repository-level Azure signing secrets remain in use.
 - GitHub Release continues as the secondary direct-download location; no channel redesign is needed.

--- a/docs/development/releases/v1.10.0/sprint-114-trusted-windows-install/sprint-plan.md
+++ b/docs/development/releases/v1.10.0/sprint-114-trusted-windows-install/sprint-plan.md
@@ -1,8 +1,9 @@
 # Sprint 114 — Trusted Windows Install
 
-**Status:** Reopened for Gate 2 build recovery. Run `33954203308` confirmed that the `EMFILE` recovery, Windows shell build, Azure signing, signed payload verification, validation, and signed installer build all pass; its standard-user install test then exposed a runner-workspace/profile-hive access race before artifact upload. The signed candidate, immutable download URL, legal URLs, Partner Center certification, Kristiina SAC-On test, and Jarmo exact-hash approval remain v1.10.0 release gates.<br>
+**Status:** Reopened for Gate 2 build recovery. Runs `33954203308` and `33965759422` confirmed that the Windows shell build, Azure signing, signed payload verification, validation, and signed installer build all pass. The first exposed runner-workspace/profile-hive isolation; the second removed those causes and isolated the remaining failure to the alternate-credential process inheriting the runner administrator's environment. The signed candidate, immutable download URL, legal URLs, Partner Center certification, Kristiina SAC-On test, and Jarmo exact-hash approval remain v1.10.0 release gates.<br>
 **Branch:** `codex/sprint-114-trusted-windows-install`<br>
 **Follow-up branch:** `codex/sprint-114-windows-standard-user-ci`<br>
+**Second follow-up branch:** `codex/sprint-114-windows-user-environment`<br>
 **Issue:** [#212](https://github.com/ProductoryHQ/ritemark-native/issues/212)<br>
 **Release:** [v1.10.0](../release-plan.md)
 
@@ -70,9 +71,15 @@ These checks require the final release-ready v1.10.0 bytes. They do not keep the
 - [x] Capture Inno Setup install and uninstall logs on failure, with a deterministic workflow-shape regression test.
 - [x] Pass repository QA and review.
 - [x] Pass follow-up QA and local PowerShell syntax validation for the standard-user CI recovery.
-- [ ] Pass a fresh Windows build from the merged canonical `main` commit.
+- [x] Preserve run `33965759422` as evidence that exact-main build, signing, validation, and installer creation pass while Inno exits `1` before log creation under the inherited runner-admin process environment.
+- [x] Replace that implicit environment boundary with an explicit standard-user working directory and identity/profile/temp/shell-folder environment shared by the canary, installer, and uninstaller.
+- [x] Require an alternate-user canary to prove identity, environment, working directory, write access, and the user-visible installer SHA-256 before installation.
+- [x] Decouple the immutable approved product-source SHA from the workflow revision: the paid workflow requires an explicit 40-character source commit, checks out that exact commit, still requires it to equal canonical `origin/main`, and records both source and workflow commits beside the installer hash.
+- [ ] Pass a fresh Windows build from the exact approved canonical `main` product commit using the reviewed workflow revision.
 
 ## Decisions
+
+- **2026-09-05 — Do not invalidate an approved Mac RC for a Windows-only CI harness correction.** The Windows workflow definition may advance independently, but the product checkout remains pinned to the exact Gate 1 source commit and must still pass the existing `origin/main` integrity and embedded provenance gates. Both identities are recorded in the workflow summary and Windows hash manifest.
 
 - Existing repository-level Azure signing secrets remain in use.
 - GitHub Release continues as the secondary direct-download location; no channel redesign is needed.

--- a/scripts/verify-windows-installer-roundtrip.ps1
+++ b/scripts/verify-windows-installer-roundtrip.ps1
@@ -1,0 +1,300 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory)]
+  [string]$InstallerPath,
+
+  [Parameter(Mandatory)]
+  [string]$SignatureVerifierPath,
+
+  [Parameter(Mandatory)]
+  [string]$RegistryProbePath,
+
+  [Parameter(Mandatory)]
+  [string]$SignToolPath,
+
+  [Parameter(Mandatory)]
+  [string]$ExpectedPublisher,
+
+  [Parameter(Mandatory)]
+  [string]$ExpectedVersion,
+
+  [Parameter(Mandatory)]
+  [string]$EvidenceDirectory
+)
+
+$ErrorActionPreference = 'Stop'
+
+$installer = (Resolve-Path -LiteralPath $InstallerPath).Path
+$signatureVerifier = (Resolve-Path -LiteralPath $SignatureVerifierPath).Path
+$registryProbeSource = (Resolve-Path -LiteralPath $RegistryProbePath).Path
+$signTool = (Resolve-Path -LiteralPath $SignToolPath).Path
+$evidenceRoot = [System.IO.Path]::GetFullPath($EvidenceDirectory)
+New-Item -ItemType Directory -Path $evidenceRoot -Force | Out-Null
+
+& $signatureVerifier `
+  -Mode Verify `
+  -Root (Split-Path -Parent $installer) `
+  -SignToolPath $signTool `
+  -ExpectedPublisher $ExpectedPublisher `
+  -OwnedPathPattern ([System.IO.Path]::GetFileName($installer))
+
+$runIdentity = [string]$env:GITHUB_RUN_ID
+if ([string]::IsNullOrWhiteSpace($runIdentity)) {
+  $runIdentity = [guid]::NewGuid().ToString('N').Substring(0, 12)
+}
+$runIdSuffix = if ($runIdentity.Length -gt 15) {
+  $runIdentity.Substring($runIdentity.Length - 15)
+} else {
+  $runIdentity
+}
+$userName = "rmci-$runIdSuffix"
+if ($userName.Length -gt 20) {
+  throw "Generated Windows test username exceeds 20 characters: $userName"
+}
+
+$plainPassword = "Ritemark!$([guid]::NewGuid().ToString('N'))"
+$securePassword = ConvertTo-SecureString $plainPassword -AsPlainText -Force
+$credential = [pscredential]::new("$env:COMPUTERNAME\$userName", $securePassword)
+$profileRoot = $null
+$userEvidence = $null
+$installLog = $null
+$uninstallLog = $null
+
+New-LocalUser -Name $userName -Password $securePassword -AccountNeverExpires | Out-Null
+try {
+  $initializeProfile = Start-Process -FilePath 'cmd.exe' -Credential $credential -LoadUserProfile `
+    -WorkingDirectory $env:SystemRoot -ArgumentList '/c','exit 0' -Wait -PassThru
+  if ($initializeProfile.ExitCode -ne 0) {
+    throw 'Could not initialize the standard-user profile.'
+  }
+
+  $profileRoot = "C:\Users\$userName"
+  if (-not (Test-Path -LiteralPath $profileRoot -PathType Container)) {
+    throw "Standard-user profile was not created at $profileRoot."
+  }
+
+  $installRoot = Join-Path $profileRoot 'AppData\Local\Programs\Ritemark'
+  $localAppData = Join-Path $profileRoot 'AppData\Local'
+  $roamingAppData = Join-Path $profileRoot 'AppData\Roaming'
+  $userTemp = Join-Path $localAppData 'Temp'
+  $stagedInstaller = Join-Path $profileRoot 'Ritemark-Setup.exe'
+  $installLog = Join-Path $profileRoot 'Ritemark-install.log'
+  $uninstallLog = Join-Path $profileRoot 'Ritemark-uninstall.log'
+  $environmentProbeScript = Join-Path $profileRoot 'Ritemark-Ci-Environment-Probe.ps1'
+  $environmentProbeResult = Join-Path $profileRoot 'Ritemark-Ci-Environment-Probe.json'
+  $registryProbeScript = Join-Path $profileRoot 'Ritemark-Ci-Registry-Probe.ps1'
+  $userEvidence = Join-Path $profileRoot 'Ritemark-Ci-Evidence'
+  New-Item -ItemType Directory -Path $userTemp -Force | Out-Null
+  New-Item -ItemType Directory -Path $userEvidence -Force | Out-Null
+
+  # The hosted runner workspace is owned by the runner account and is not
+  # guaranteed to be readable by a newly-created standard user. Stage the exact
+  # signed bytes and the reviewed probe inside the user's own profile first.
+  Copy-Item -LiteralPath $installer -Destination $stagedInstaller
+  Copy-Item -LiteralPath $registryProbeSource -Destination $registryProbeScript
+  $originalInstallerSha = (Get-FileHash -LiteralPath $installer -Algorithm SHA256).Hash
+  $stagedInstallerSha = (Get-FileHash -LiteralPath $stagedInstaller -Algorithm SHA256).Hash
+  if ($stagedInstallerSha -ne $originalInstallerSha) {
+    throw 'Standard-user installer staging changed the signed installer bytes.'
+  }
+
+  # Start-Process inherits the runner administrator's environment even with
+  # -Credential and -LoadUserProfile. Supply the full standard-user boundary.
+  $userProcessEnvironment = @{
+    USERNAME = $userName
+    USERDOMAIN = $env:COMPUTERNAME
+    USERPROFILE = $profileRoot
+    HOMEDRIVE = 'C:'
+    HOMEPATH = "\Users\$userName"
+    LOCALAPPDATA = $localAppData
+    APPDATA = $roamingAppData
+    TEMP = $userTemp
+    TMP = $userTemp
+    RITEMARK_CI_INSTALLER = $stagedInstaller
+    RITEMARK_CI_PROBE = $environmentProbeResult
+    RITEMARK_CI_PUBLISHER = $ExpectedPublisher
+    RITEMARK_CI_VERSION = $ExpectedVersion
+  }
+
+  function Write-ChildProcessDiagnostics([string]$label, [string]$stdoutPath, [string]$stderrPath) {
+    foreach ($entry in @(
+      @{ Name = 'stdout'; Path = $stdoutPath },
+      @{ Name = 'stderr'; Path = $stderrPath }
+    )) {
+      if (Test-Path -LiteralPath $entry.Path) {
+        Write-Host "--- $label $($entry.Name) ---"
+        Get-Content -LiteralPath $entry.Path | ForEach-Object { Write-Host $_ }
+      }
+    }
+  }
+
+  function Invoke-UserProcess {
+    param(
+      [Parameter(Mandatory)][string]$Label,
+      [Parameter(Mandatory)][string]$FilePath,
+      [Parameter(Mandatory)][string[]]$ArgumentList,
+      [Parameter(Mandatory)][hashtable]$Environment
+    )
+
+    $safeLabel = $Label -replace '[^A-Za-z0-9_.-]', '-'
+    $stdoutPath = Join-Path $userEvidence "$safeLabel.stdout.log"
+    $stderrPath = Join-Path $userEvidence "$safeLabel.stderr.log"
+    Remove-Item -LiteralPath $stdoutPath,$stderrPath -Force -ErrorAction SilentlyContinue
+    $process = Start-Process -FilePath $FilePath `
+      -Credential $credential -LoadUserProfile -WorkingDirectory $profileRoot `
+      -Environment $Environment -ArgumentList $ArgumentList `
+      -RedirectStandardOutput $stdoutPath -RedirectStandardError $stderrPath `
+      -Wait -PassThru
+    Write-ChildProcessDiagnostics $Label $stdoutPath $stderrPath
+    return $process
+  }
+
+  # Prove identity, environment, working directory, write access, and the exact
+  # installer bytes from inside the alternate-user process before installation.
+  $environmentProbeContents = @'
+$ErrorActionPreference = 'Stop'
+[ordered]@{
+  Identity = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+  WorkingDirectory = (Get-Location).Path
+  UserName = $env:USERNAME
+  UserProfile = $env:USERPROFILE
+  LocalAppData = $env:LOCALAPPDATA
+  AppData = $env:APPDATA
+  Temp = $env:TEMP
+  Tmp = $env:TMP
+  InstallerSha256 = (Get-FileHash -LiteralPath $env:RITEMARK_CI_INSTALLER -Algorithm SHA256).Hash
+} | ConvertTo-Json | Set-Content -LiteralPath $env:RITEMARK_CI_PROBE -Encoding utf8NoBOM
+'@
+  Set-Content -LiteralPath $environmentProbeScript -Value $environmentProbeContents -Encoding utf8NoBOM
+
+  $environmentProbe = Invoke-UserProcess `
+    -Label 'environment-probe' `
+    -FilePath (Join-Path $PSHOME 'pwsh.exe') `
+    -Environment $userProcessEnvironment `
+    -ArgumentList '-NoLogo','-NoProfile','-NonInteractive','-File',$environmentProbeScript
+  if ($environmentProbe.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $environmentProbeResult)) {
+    throw "Standard-user environment probe failed ($($environmentProbe.ExitCode))."
+  }
+
+  $probe = Get-Content -LiteralPath $environmentProbeResult -Raw | ConvertFrom-Json
+  $expectedProbe = [ordered]@{
+    Identity = "$env:COMPUTERNAME\$userName"
+    WorkingDirectory = $profileRoot
+    UserName = $userName
+    UserProfile = $profileRoot
+    LocalAppData = $localAppData
+    AppData = $roamingAppData
+    Temp = $userTemp
+    Tmp = $userTemp
+    InstallerSha256 = $originalInstallerSha
+  }
+  foreach ($name in $expectedProbe.Keys) {
+    if ([string]$probe.$name -ine [string]$expectedProbe[$name]) {
+      throw "Standard-user environment probe mismatch for $name (got '$($probe.$name)', expected '$($expectedProbe[$name])')."
+    }
+  }
+
+  # HKCU must be inspected inside the same proven standard-user boundary.
+  function Invoke-RegistryProbe([string]$mode) {
+    $resultPath = Join-Path $profileRoot "Ritemark-Ci-Registry-$mode.json"
+    Remove-Item -LiteralPath $resultPath -Force -ErrorAction SilentlyContinue
+    $userProcessEnvironment.RITEMARK_CI_REGISTRY_MODE = $mode
+    $userProcessEnvironment.RITEMARK_CI_REGISTRY_RESULT = $resultPath
+    $registryProbe = Invoke-UserProcess `
+      -Label "registry-$mode" `
+      -FilePath (Join-Path $PSHOME 'pwsh.exe') `
+      -Environment $userProcessEnvironment `
+      -ArgumentList '-NoLogo','-NoProfile','-NonInteractive','-File',$registryProbeScript
+    if ($registryProbe.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $resultPath)) {
+      throw "Standard-user registry probe '$mode' failed ($($registryProbe.ExitCode))."
+    }
+    $result = Get-Content -LiteralPath $resultPath -Raw | ConvertFrom-Json
+    if ([string]$result.Identity -ine "$env:COMPUTERNAME\$userName") {
+      throw "Registry probe '$mode' ran as '$($result.Identity)' instead of the standard user."
+    }
+    return $result
+  }
+
+  $install = Invoke-UserProcess `
+    -Label 'installer' `
+    -FilePath $stagedInstaller `
+    -Environment $userProcessEnvironment `
+    -ArgumentList @(
+      '/VERYSILENT', '/SUPPRESSMSGBOXES', '/NORESTART', '/SP-', '/CURRENTUSER',
+      "/DIR=$installRoot", "/LOG=$installLog"
+    )
+  if ($install.ExitCode -ne 0) {
+    if (Test-Path -LiteralPath $installLog) {
+      Write-Host '--- Inno Setup install log ---'
+      Get-Content -LiteralPath $installLog
+    }
+    throw "Standard-user silent install failed ($($install.ExitCode))."
+  }
+
+  & $signatureVerifier `
+    -Mode Verify `
+    -Root $installRoot `
+    -SignToolPath $signTool `
+    -ExpectedPublisher $ExpectedPublisher `
+    -OwnedPathPattern 'Ritemark.exe','unins*.exe'
+
+  $startMenu = Join-Path $profileRoot 'AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Ritemark'
+  $appLinks = @(Get-ChildItem -LiteralPath $startMenu -Filter 'Ritemark.lnk' -File -ErrorAction Stop)
+  if ($appLinks.Count -ne 1) {
+    throw "Expected one Ritemark Start menu entry, found $($appLinks.Count)."
+  }
+  $installedRegistration = Invoke-RegistryProbe 'verify-installed'
+  Write-Host "Verified $($installedRegistration.Count) current-user Ritemark registration after install."
+
+  $uninstaller = Get-ChildItem -LiteralPath $installRoot -Filter 'unins*.exe' -File | Select-Object -First 1
+  if ($null -eq $uninstaller) {
+    throw 'Signed uninstaller was not installed.'
+  }
+  $uninstall = Invoke-UserProcess `
+    -Label 'uninstaller' `
+    -FilePath $uninstaller.FullName `
+    -Environment $userProcessEnvironment `
+    -ArgumentList '/VERYSILENT','/SUPPRESSMSGBOXES','/NORESTART',"/LOG=$uninstallLog"
+  if ($uninstall.ExitCode -ne 0) {
+    if (Test-Path -LiteralPath $uninstallLog) {
+      Write-Host '--- Inno Setup uninstall log ---'
+      Get-Content -LiteralPath $uninstallLog
+    }
+    throw "Standard-user silent uninstall failed ($($uninstall.ExitCode))."
+  }
+
+  # Inno's cleanup helper may outlive the uninstaller process briefly. Poll a
+  # bounded interval so a correct asynchronous cleanup is not reported as a race.
+  $cleanupDeadline = [DateTime]::UtcNow.AddSeconds(15)
+  while (((Test-Path -LiteralPath $installRoot) -or (Test-Path -LiteralPath $startMenu)) -and
+         [DateTime]::UtcNow -lt $cleanupDeadline) {
+    Start-Sleep -Milliseconds 250
+  }
+  if (Test-Path -LiteralPath $installRoot) {
+    throw 'Uninstall left the Ritemark install directory behind.'
+  }
+  if (Test-Path -LiteralPath $startMenu) {
+    throw 'Uninstall left the Ritemark Start menu group behind.'
+  }
+  $removedRegistration = Invoke-RegistryProbe 'verify-uninstalled'
+  Write-Host "Verified $($removedRegistration.Count) current-user Ritemark registrations after uninstall."
+
+  [ordered]@{
+    status = 'passed'
+    installer = [System.IO.Path]::GetFileName($installer)
+    sha256 = $originalInstallerSha.ToLowerInvariant()
+    publisher = $ExpectedPublisher
+    version = $ExpectedVersion
+    standardUser = "$env:COMPUTERNAME\$userName"
+  } | ConvertTo-Json | Set-Content -LiteralPath (Join-Path $evidenceRoot 'roundtrip-result.json') -Encoding utf8NoBOM
+} finally {
+  foreach ($path in @($installLog, $uninstallLog)) {
+    if (-not [string]::IsNullOrWhiteSpace($path) -and (Test-Path -LiteralPath $path)) {
+      Copy-Item -LiteralPath $path -Destination $evidenceRoot -Force
+    }
+  }
+  if (-not [string]::IsNullOrWhiteSpace($userEvidence) -and (Test-Path -LiteralPath $userEvidence)) {
+    Copy-Item -Path (Join-Path $userEvidence '*') -Destination $evidenceRoot -Force -ErrorAction SilentlyContinue
+  }
+  Remove-LocalUser -Name $userName -ErrorAction SilentlyContinue
+}

--- a/scripts/verify-windows-installer-roundtrip.ps1
+++ b/scripts/verify-windows-installer-roundtrip.ps1
@@ -123,7 +123,7 @@ try {
     )) {
       if (Test-Path -LiteralPath $entry.Path) {
         Write-Host "--- $label $($entry.Name) ---"
-        Get-Content -LiteralPath $entry.Path | ForEach-Object { Write-Host $_ }
+        Get-Content -LiteralPath $entry.Path -Encoding oem | ForEach-Object { Write-Host $_ }
       }
     }
   }
@@ -175,6 +175,8 @@ $ErrorActionPreference = 'Stop'
   if ($environmentProbe.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $environmentProbeResult)) {
     throw "Standard-user environment probe failed ($($environmentProbe.ExitCode))."
   }
+  Copy-Item -LiteralPath $environmentProbeResult `
+    -Destination (Join-Path $userEvidence 'environment-probe.result.json') -Force
 
   $probe = Get-Content -LiteralPath $environmentProbeResult -Raw | ConvertFrom-Json
   $expectedProbe = [ordered]@{
@@ -208,6 +210,8 @@ $ErrorActionPreference = 'Stop'
     if ($registryProbe.ExitCode -ne 0 -or -not (Test-Path -LiteralPath $resultPath)) {
       throw "Standard-user registry probe '$mode' failed ($($registryProbe.ExitCode))."
     }
+    Copy-Item -LiteralPath $resultPath `
+      -Destination (Join-Path $userEvidence "registry-$mode.result.json") -Force
     $result = Get-Content -LiteralPath $resultPath -Raw | ConvertFrom-Json
     if ([string]$result.Identity -ine "$env:COMPUTERNAME\$userName") {
       throw "Registry probe '$mode' ran as '$($result.Identity)' instead of the standard user."

--- a/scripts/windows-extension-staging.test.mjs
+++ b/scripts/windows-extension-staging.test.mjs
@@ -171,6 +171,8 @@ test('Windows standard-user test uses one observable, replayable roundtrip harne
   assert.match(roundtrip, /\/LOG=\$installLog/, 'installation failures must retain an Inno Setup log');
   assert.match(roundtrip, /\/LOG=\$uninstallLog/, 'uninstallation failures must retain an Inno Setup log');
   assert.match(roundtrip, /-RedirectStandardOutput \$stdoutPath -RedirectStandardError \$stderrPath/, 'child-process failures must expose their diagnostics');
+  assert.match(roundtrip, /Get-Content -LiteralPath \$entry\.Path -Encoding oem/, 'redirected Windows console diagnostics must be decoded with the runner OEM code page');
+  assert.match(roundtrip, /registry-\$mode\.result\.json/, 'the exact UTF-8 registry result must be preserved independently from console output');
   assert.match(roundtrip, /Copy-Item -Path \(Join-Path \$userEvidence '\*'\) -Destination \$evidenceRoot/, 'roundtrip diagnostics must survive test-user deletion');
   assert.doesNotMatch(roundtrip, /HKEY_USERS|NTUSER\.DAT|reg\.exe (?:load|unload)|Mount-TestUserHive|Dismount-TestUserHive/, 'admin-side profile hive mounting must not return');
   assert.match(workflow.slice(uploadStep), /- name: Upload signed Windows artifacts\n\s+if: always\(\)/, 'a built signed installer must remain downloadable when the roundtrip test fails');

--- a/scripts/windows-extension-staging.test.mjs
+++ b/scripts/windows-extension-staging.test.mjs
@@ -7,6 +7,19 @@ import { fileURLToPath } from 'node:url';
 const projectRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const workflowPath = path.join(projectRoot, '.github', 'workflows', 'build-windows.yml');
 
+test('Windows release workflow separates immutable product source from workflow revision', async () => {
+  const workflow = await readFile(workflowPath, 'utf8');
+
+  assert.match(workflow, /source_commit:\s*\n\s+description:[^\n]+\n\s+required: true\n\s+type: string/);
+  assert.match(workflow, /uses: actions\/checkout@v4[\s\S]*?ref: \$\{\{ inputs\.source_commit \}\}/);
+  assert.match(workflow, /SOURCE_COMMIT='\$\{\{ inputs\.source_commit \}\}'/);
+  assert.match(workflow, /\^\[0-9a-fA-F\]\{40\}\$/);
+  assert.match(workflow, /CHECKED_OUT_COMMIT="\$\(git rev-parse HEAD\)"/);
+  assert.match(workflow, /verify-release-source\.sh --target win32-x64 --phase pristine/);
+  assert.match(workflow, /source_commit=\$\(\(git rev-parse HEAD\)\.Trim\(\)\)/);
+  assert.match(workflow, /workflow_commit=\$env:GITHUB_SHA/);
+});
+
 test('Windows shell build stages Ritemark outside the eager VS Code packager', async () => {
   const workflow = await readFile(workflowPath, 'utf8');
   const preserveFontStep = workflow.indexOf('- name: Preserve dependency-backed workbench font');
@@ -105,7 +118,7 @@ test('Windows shell build stages Ritemark outside the eager VS Code packager', a
   );
 });
 
-test('Windows standard-user test stages exact installer bytes and avoids profile-hive races', async () => {
+test('Windows standard-user test proves an isolated user environment before installing', async () => {
   const workflow = await readFile(workflowPath, 'utf8');
   const verificationStep = workflow.indexOf('- name: Verify install and uninstall as a standard user');
   const uploadStep = workflow.indexOf('- name: Upload signed Windows artifacts');
@@ -116,17 +129,40 @@ test('Windows standard-user test stages exact installer bytes and avoids profile
   const profileInitialization = verification.indexOf("Start-Process -FilePath 'cmd.exe'");
   const stageInstaller = verification.indexOf('Copy-Item -LiteralPath $installer -Destination $stagedInstaller');
   const compareInstallerHash = verification.indexOf("Get-FileHash -LiteralPath $stagedInstaller -Algorithm SHA256");
+  const defineUserEnvironment = verification.indexOf('$userProcessEnvironment = @{');
+  const environmentProbe = verification.indexOf('$environmentProbe = Start-Process');
+  const compareProbe = verification.indexOf('$expectedProbe = [ordered]@{');
   const launchInstaller = verification.indexOf('Start-Process -FilePath $stagedInstaller');
   const firstHiveLoad = verification.indexOf("Mount-TestUserHive 'after install'");
 
   assert.ok(profileInitialization >= 0, 'the standard-user profile must be initialized');
   assert.ok(stageInstaller > profileInitialization, 'installer staging must happen after profile initialization');
   assert.ok(compareInstallerHash > stageInstaller, 'staged installer bytes must be hashed after copying');
-  assert.ok(launchInstaller > compareInstallerHash, 'only the verified staged copy may be launched');
+  assert.ok(defineUserEnvironment > compareInstallerHash, 'the user environment must be defined after exact installer staging');
+  assert.ok(environmentProbe > defineUserEnvironment, 'the alternate-user environment must be probed before install');
+  assert.ok(compareProbe > environmentProbe, 'the probe result must be checked before install');
+  assert.ok(launchInstaller > compareProbe, 'only the user-readable, exact staged copy may be launched');
   assert.ok(firstHiveLoad > launchInstaller, 'the test must not load NTUSER.DAT before -LoadUserProfile runs');
   assert.match(verification, /\$beforeKeys = @\(\)/, 'a newly-created account must use an empty registration baseline');
-  assert.match(verification, /\/LOG=`"\$installLog`"/, 'installation failures must retain an Inno Setup log');
-  assert.match(verification, /\/LOG=`"\$uninstallLog`"/, 'uninstallation failures must retain an Inno Setup log');
+  for (const variable of ['USERNAME', 'USERDOMAIN', 'USERPROFILE', 'HOMEDRIVE', 'HOMEPATH', 'LOCALAPPDATA', 'APPDATA', 'TEMP', 'TMP']) {
+    assert.match(verification, new RegExp(`\\b${variable}\\s*=`), `${variable} must be explicit at the user boundary`);
+  }
+  const environmentProbeBlock = verification.slice(environmentProbe, compareProbe);
+  assert.match(environmentProbeBlock, /-WorkingDirectory \$profileRoot/, 'the environment canary must run from the user profile');
+  assert.match(environmentProbeBlock, /-Environment \$userProcessEnvironment/, 'the environment canary must receive the explicit user environment');
+  assert.equal(
+    (verification.match(/-Environment \$userProcessEnvironment/g) ?? []).length,
+    3,
+    'the canary, installer, and uninstaller must share the same proven user environment',
+  );
+  assert.equal(
+    (verification.match(/-WorkingDirectory \$profileRoot/g) ?? []).length,
+    3,
+    'the canary, installer, and uninstaller must share the user-owned working directory',
+  );
+  assert.match(verification, /InstallerSha256 = \$originalInstallerSha/, 'the user-side installer hash must match the signed source');
+  assert.match(verification, /\/LOG=\$installLog/, 'installation failures must retain an Inno Setup log');
+  assert.match(verification, /\/LOG=\$uninstallLog/, 'uninstallation failures must retain an Inno Setup log');
   assert.match(verification, /for \(\$attempt = 1; \$attempt -le 10; \$attempt\+\+\)/, 'registry hive transitions must retry');
   assert.doesNotMatch(
     verification.slice(0, launchInstaller),

--- a/scripts/windows-extension-staging.test.mjs
+++ b/scripts/windows-extension-staging.test.mjs
@@ -8,6 +8,7 @@ const projectRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const workflowPath = path.join(projectRoot, '.github', 'workflows', 'build-windows.yml');
 const canaryWorkflowPath = path.join(projectRoot, '.github', 'workflows', 'windows-canary.yml');
 const registryProbePath = path.join(projectRoot, 'scripts', 'windows-standard-user-registry-probe.ps1');
+const roundtripPath = path.join(projectRoot, 'scripts', 'verify-windows-installer-roundtrip.ps1');
 
 test('Windows release workflow separates immutable product source from workflow revision', async () => {
   const workflow = await readFile(workflowPath, 'utf8');
@@ -122,25 +123,33 @@ test('Windows shell build stages Ritemark outside the eager VS Code packager', a
   );
 });
 
-test('Windows standard-user test proves an isolated user environment before installing', async () => {
-  const workflow = await readFile(workflowPath, 'utf8');
+test('Windows standard-user test uses one observable, replayable roundtrip harness', async () => {
+  const [workflow, roundtrip] = await Promise.all([
+    readFile(workflowPath, 'utf8'),
+    readFile(roundtripPath, 'utf8'),
+  ]);
   const verificationStep = workflow.indexOf('- name: Verify install and uninstall as a standard user');
   const uploadStep = workflow.indexOf('- name: Upload signed Windows artifacts');
   assert.notEqual(verificationStep, -1, 'standard-user verification step must exist');
   assert.notEqual(uploadStep, -1, 'Windows artifact upload step must exist');
 
   const verification = workflow.slice(verificationStep, uploadStep);
-  const profileInitialization = verification.indexOf("Start-Process -FilePath 'cmd.exe'");
-  const stageInstaller = verification.indexOf('Copy-Item -LiteralPath $installer -Destination $stagedInstaller');
-  const compareInstallerHash = verification.indexOf("Get-FileHash -LiteralPath $stagedInstaller -Algorithm SHA256");
-  const defineUserEnvironment = verification.indexOf('$userProcessEnvironment = @{');
-  const environmentProbe = verification.indexOf('$environmentProbe = Start-Process');
-  const compareProbe = verification.indexOf('$expectedProbe = [ordered]@{');
-  const registryProbeFunction = verification.indexOf('function Invoke-RegistryProbe');
-  const launchInstaller = verification.indexOf('Start-Process -FilePath $stagedInstaller');
-  const verifyInstalled = verification.indexOf("Invoke-RegistryProbe 'verify-installed'");
-  const launchUninstaller = verification.indexOf('Start-Process -FilePath $uninstaller.FullName');
-  const verifyUninstalled = verification.indexOf("Invoke-RegistryProbe 'verify-uninstalled'");
+  assert.match(verification, /ci-harness\\scripts\\verify-windows-installer-roundtrip\.ps1/);
+  assert.match(verification, /ci-harness\\scripts\\windows-standard-user-registry-probe\.ps1/);
+  assert.match(verification, /-EvidenceDirectory 'installer-output\\roundtrip-evidence'/);
+  assert.doesNotMatch(verification, /New-LocalUser|Start-Process|HKEY_USERS|NTUSER\.DAT/);
+
+  const profileInitialization = roundtrip.indexOf("Start-Process -FilePath 'cmd.exe'");
+  const stageInstaller = roundtrip.indexOf('Copy-Item -LiteralPath $installer -Destination $stagedInstaller');
+  const compareInstallerHash = roundtrip.indexOf("Get-FileHash -LiteralPath $stagedInstaller -Algorithm SHA256");
+  const defineUserEnvironment = roundtrip.indexOf('$userProcessEnvironment = @{');
+  const environmentProbe = roundtrip.indexOf("-Label 'environment-probe'");
+  const compareProbe = roundtrip.indexOf('$expectedProbe = [ordered]@{');
+  const registryProbeFunction = roundtrip.indexOf('function Invoke-RegistryProbe');
+  const launchInstaller = roundtrip.indexOf("-Label 'installer'");
+  const verifyInstalled = roundtrip.indexOf("Invoke-RegistryProbe 'verify-installed'");
+  const launchUninstaller = roundtrip.indexOf("-Label 'uninstaller'");
+  const verifyUninstalled = roundtrip.indexOf("Invoke-RegistryProbe 'verify-uninstalled'");
 
   assert.ok(profileInitialization >= 0, 'the standard-user profile must be initialized');
   assert.ok(stageInstaller > profileInitialization, 'installer staging must happen after profile initialization');
@@ -154,27 +163,18 @@ test('Windows standard-user test proves an isolated user environment before inst
   assert.ok(launchUninstaller > verifyInstalled, 'uninstall must run after the installed HKCU state is proven');
   assert.ok(verifyUninstalled > launchUninstaller, 'HKCU must be checked as the standard user after uninstall');
   for (const variable of ['USERNAME', 'USERDOMAIN', 'USERPROFILE', 'HOMEDRIVE', 'HOMEPATH', 'LOCALAPPDATA', 'APPDATA', 'TEMP', 'TMP']) {
-    assert.match(verification, new RegExp(`\\b${variable}\\s*=`), `${variable} must be explicit at the user boundary`);
+    assert.match(roundtrip, new RegExp(`\\b${variable}\\s*=`), `${variable} must be explicit at the user boundary`);
   }
-  const environmentProbeBlock = verification.slice(environmentProbe, compareProbe);
-  assert.match(environmentProbeBlock, /-WorkingDirectory \$profileRoot/, 'the environment canary must run from the user profile');
-  assert.match(environmentProbeBlock, /-Environment \$userProcessEnvironment/, 'the environment canary must receive the explicit user environment');
-  assert.equal(
-    (verification.match(/-Environment \$userProcessEnvironment/g) ?? []).length,
-    4,
-    'the environment canary, registry probe, installer, and uninstaller must share the same proven user environment',
-  );
-  assert.equal(
-    (verification.match(/-WorkingDirectory \$profileRoot/g) ?? []).length,
-    4,
-    'the environment canary, registry probe, installer, and uninstaller must share the user-owned working directory',
-  );
-  assert.match(verification, /InstallerSha256 = \$originalInstallerSha/, 'the user-side installer hash must match the signed source');
-  assert.match(verification, /\/LOG=\$installLog/, 'installation failures must retain an Inno Setup log');
-  assert.match(verification, /\/LOG=\$uninstallLog/, 'uninstallation failures must retain an Inno Setup log');
-  assert.match(verification, /ci-harness\\scripts\\windows-standard-user-registry-probe\.ps1/, 'the reviewed registry probe must be copied into the user profile');
-  assert.doesNotMatch(verification, /HKEY_USERS|NTUSER\.DAT|reg\.exe (?:load|unload)|Mount-TestUserHive|Dismount-TestUserHive/, 'admin-side profile hive mounting must not return');
+  assert.match(roundtrip, /-WorkingDirectory \$profileRoot/, 'every alternate-user child must use the user profile');
+  assert.match(roundtrip, /-Environment \$Environment/, 'every alternate-user child must receive the explicit user environment');
+  assert.match(roundtrip, /InstallerSha256 = \$originalInstallerSha/, 'the user-side installer hash must match the signed source');
+  assert.match(roundtrip, /\/LOG=\$installLog/, 'installation failures must retain an Inno Setup log');
+  assert.match(roundtrip, /\/LOG=\$uninstallLog/, 'uninstallation failures must retain an Inno Setup log');
+  assert.match(roundtrip, /-RedirectStandardOutput \$stdoutPath -RedirectStandardError \$stderrPath/, 'child-process failures must expose their diagnostics');
+  assert.match(roundtrip, /Copy-Item -Path \(Join-Path \$userEvidence '\*'\) -Destination \$evidenceRoot/, 'roundtrip diagnostics must survive test-user deletion');
+  assert.doesNotMatch(roundtrip, /HKEY_USERS|NTUSER\.DAT|reg\.exe (?:load|unload)|Mount-TestUserHive|Dismount-TestUserHive/, 'admin-side profile hive mounting must not return');
   assert.match(workflow.slice(uploadStep), /- name: Upload signed Windows artifacts\n\s+if: always\(\)/, 'a built signed installer must remain downloadable when the roundtrip test fails');
+  assert.match(workflow.slice(uploadStep), /r\/installer-output\/roundtrip-evidence/, 'release artifacts must retain roundtrip diagnostics');
 });
 
 test('free Windows canary exercises the shared current-user registry verifier', async () => {
@@ -189,5 +189,28 @@ test('free Windows canary exercises the shared current-user registry verifier', 
     assert.match(registryProbe, new RegExp(`'${mode}'`));
   }
   assert.match(registryProbe, /HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall/);
+  assert.match(registryProbe, /\$expectedDisplayName = "Ritemark \$expectedVersion"/);
+  assert.match(registryProbe, /DisplayName -Value \$expectedDisplayName/);
+  assert.match(registryProbe, /DisplayName -ne \$expectedDisplayName/);
+  assert.match(canaryWorkflow, /-RedirectStandardOutput \$stdoutPath -RedirectStandardError \$stderrPath/);
   assert.doesNotMatch(registryProbe, /HKEY_USERS|NTUSER\.DAT|reg\.exe/);
+});
+
+test('free Windows workflow can replay an immutable preserved installer without rebuilding', async () => {
+  const canaryWorkflow = await readFile(canaryWorkflowPath, 'utf8');
+
+  for (const input of ['installer_run_id', 'expected_source_commit', 'expected_sha256', 'expected_version']) {
+    assert.match(canaryWorkflow, new RegExp(`\\n\\s{6}${input}:`), `${input} must be an explicit replay input`);
+  }
+  assert.match(canaryWorkflow, /verify-preserved-installer:/);
+  assert.match(canaryWorkflow, /uses: actions\/download-artifact@v4[\s\S]*?run-id: \$\{\{ inputs\.installer_run_id \}\}/);
+  assert.match(canaryWorkflow, /Get-FileHash -LiteralPath \$installer -Algorithm SHA256/);
+  assert.match(canaryWorkflow, /\$manifest\.source_commit -ne \$expectedSource/);
+  assert.match(canaryWorkflow, /verify-windows-installer-roundtrip\.ps1/);
+  assert.match(canaryWorkflow, /-EvidenceDirectory 'roundtrip-evidence'/);
+  assert.doesNotMatch(
+    canaryWorkflow.slice(canaryWorkflow.indexOf('verify-preserved-installer:')),
+    /gulp|ISCC|artifact-signing-action|Build VS Code/,
+    'the replay path must verify preserved bytes without compiling or signing a new product',
+  );
 });

--- a/scripts/windows-extension-staging.test.mjs
+++ b/scripts/windows-extension-staging.test.mjs
@@ -6,15 +6,19 @@ import { fileURLToPath } from 'node:url';
 
 const projectRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const workflowPath = path.join(projectRoot, '.github', 'workflows', 'build-windows.yml');
+const canaryWorkflowPath = path.join(projectRoot, '.github', 'workflows', 'windows-canary.yml');
+const registryProbePath = path.join(projectRoot, 'scripts', 'windows-standard-user-registry-probe.ps1');
 
 test('Windows release workflow separates immutable product source from workflow revision', async () => {
   const workflow = await readFile(workflowPath, 'utf8');
 
   assert.match(workflow, /source_commit:\s*\n\s+description:[^\n]+\n\s+required: true\n\s+type: string/);
   assert.match(workflow, /uses: actions\/checkout@v4[\s\S]*?ref: \$\{\{ inputs\.source_commit \}\}/);
+  assert.match(workflow, /- name: Checkout reviewed release harness[\s\S]*?ref: \$\{\{ github\.sha \}\}/);
   assert.match(workflow, /SOURCE_COMMIT='\$\{\{ inputs\.source_commit \}\}'/);
   assert.match(workflow, /\^\[0-9a-fA-F\]\{40\}\$/);
   assert.match(workflow, /CHECKED_OUT_COMMIT="\$\(git rev-parse HEAD\)"/);
+  assert.match(workflow, /HARNESS_COMMIT="\$\(git -C \.\.\/ci-harness rev-parse HEAD\)"/);
   assert.match(workflow, /verify-release-source\.sh --target win32-x64 --phase pristine/);
   assert.match(workflow, /source_commit=\$\(\(git rev-parse HEAD\)\.Trim\(\)\)/);
   assert.match(workflow, /workflow_commit=\$env:GITHUB_SHA/);
@@ -132,8 +136,11 @@ test('Windows standard-user test proves an isolated user environment before inst
   const defineUserEnvironment = verification.indexOf('$userProcessEnvironment = @{');
   const environmentProbe = verification.indexOf('$environmentProbe = Start-Process');
   const compareProbe = verification.indexOf('$expectedProbe = [ordered]@{');
+  const registryProbeFunction = verification.indexOf('function Invoke-RegistryProbe');
   const launchInstaller = verification.indexOf('Start-Process -FilePath $stagedInstaller');
-  const firstHiveLoad = verification.indexOf("Mount-TestUserHive 'after install'");
+  const verifyInstalled = verification.indexOf("Invoke-RegistryProbe 'verify-installed'");
+  const launchUninstaller = verification.indexOf('Start-Process -FilePath $uninstaller.FullName');
+  const verifyUninstalled = verification.indexOf("Invoke-RegistryProbe 'verify-uninstalled'");
 
   assert.ok(profileInitialization >= 0, 'the standard-user profile must be initialized');
   assert.ok(stageInstaller > profileInitialization, 'installer staging must happen after profile initialization');
@@ -141,9 +148,11 @@ test('Windows standard-user test proves an isolated user environment before inst
   assert.ok(defineUserEnvironment > compareInstallerHash, 'the user environment must be defined after exact installer staging');
   assert.ok(environmentProbe > defineUserEnvironment, 'the alternate-user environment must be probed before install');
   assert.ok(compareProbe > environmentProbe, 'the probe result must be checked before install');
+  assert.ok(registryProbeFunction > compareProbe, 'current-user registry inspection must share the proven user boundary');
   assert.ok(launchInstaller > compareProbe, 'only the user-readable, exact staged copy may be launched');
-  assert.ok(firstHiveLoad > launchInstaller, 'the test must not load NTUSER.DAT before -LoadUserProfile runs');
-  assert.match(verification, /\$beforeKeys = @\(\)/, 'a newly-created account must use an empty registration baseline');
+  assert.ok(verifyInstalled > launchInstaller, 'HKCU must be checked as the standard user after install');
+  assert.ok(launchUninstaller > verifyInstalled, 'uninstall must run after the installed HKCU state is proven');
+  assert.ok(verifyUninstalled > launchUninstaller, 'HKCU must be checked as the standard user after uninstall');
   for (const variable of ['USERNAME', 'USERDOMAIN', 'USERPROFILE', 'HOMEDRIVE', 'HOMEPATH', 'LOCALAPPDATA', 'APPDATA', 'TEMP', 'TMP']) {
     assert.match(verification, new RegExp(`\\b${variable}\\s*=`), `${variable} must be explicit at the user boundary`);
   }
@@ -152,21 +161,33 @@ test('Windows standard-user test proves an isolated user environment before inst
   assert.match(environmentProbeBlock, /-Environment \$userProcessEnvironment/, 'the environment canary must receive the explicit user environment');
   assert.equal(
     (verification.match(/-Environment \$userProcessEnvironment/g) ?? []).length,
-    3,
-    'the canary, installer, and uninstaller must share the same proven user environment',
+    4,
+    'the environment canary, registry probe, installer, and uninstaller must share the same proven user environment',
   );
   assert.equal(
     (verification.match(/-WorkingDirectory \$profileRoot/g) ?? []).length,
-    3,
-    'the canary, installer, and uninstaller must share the user-owned working directory',
+    4,
+    'the environment canary, registry probe, installer, and uninstaller must share the user-owned working directory',
   );
   assert.match(verification, /InstallerSha256 = \$originalInstallerSha/, 'the user-side installer hash must match the signed source');
   assert.match(verification, /\/LOG=\$installLog/, 'installation failures must retain an Inno Setup log');
   assert.match(verification, /\/LOG=\$uninstallLog/, 'uninstallation failures must retain an Inno Setup log');
-  assert.match(verification, /for \(\$attempt = 1; \$attempt -le 10; \$attempt\+\+\)/, 'registry hive transitions must retry');
-  assert.doesNotMatch(
-    verification.slice(0, launchInstaller),
-    /Mount-TestUserHive '/,
-    'the profile hive must not be mounted manually before launching the installer as that user',
-  );
+  assert.match(verification, /ci-harness\\scripts\\windows-standard-user-registry-probe\.ps1/, 'the reviewed registry probe must be copied into the user profile');
+  assert.doesNotMatch(verification, /HKEY_USERS|NTUSER\.DAT|reg\.exe (?:load|unload)|Mount-TestUserHive|Dismount-TestUserHive/, 'admin-side profile hive mounting must not return');
+  assert.match(workflow.slice(uploadStep), /- name: Upload signed Windows artifacts\n\s+if: always\(\)/, 'a built signed installer must remain downloadable when the roundtrip test fails');
+});
+
+test('free Windows canary exercises the shared current-user registry verifier', async () => {
+  const [canaryWorkflow, registryProbe] = await Promise.all([
+    readFile(canaryWorkflowPath, 'utf8'),
+    readFile(registryProbePath, 'utf8'),
+  ]);
+
+  assert.match(canaryWorkflow, /Verify standard-user process and HKCU boundary/);
+  for (const mode of ['seed-canary', 'verify-installed', 'remove-canary', 'verify-uninstalled']) {
+    assert.match(canaryWorkflow, new RegExp(`Invoke-CanaryRegistryProbe '${mode}'`));
+    assert.match(registryProbe, new RegExp(`'${mode}'`));
+  }
+  assert.match(registryProbe, /HKCU:\\Software\\Microsoft\\Windows\\CurrentVersion\\Uninstall/);
+  assert.doesNotMatch(registryProbe, /HKEY_USERS|NTUSER\.DAT|reg\.exe/);
 });

--- a/scripts/windows-standard-user-registry-probe.ps1
+++ b/scripts/windows-standard-user-registry-probe.ps1
@@ -6,6 +6,7 @@ $mode = $env:RITEMARK_CI_REGISTRY_MODE
 $resultPath = $env:RITEMARK_CI_REGISTRY_RESULT
 $expectedPublisher = $env:RITEMARK_CI_PUBLISHER
 $expectedVersion = $env:RITEMARK_CI_VERSION
+$expectedDisplayName = "Ritemark $expectedVersion"
 $uninstallRoot = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall'
 $canaryKey = Join-Path $uninstallRoot 'RitemarkCiCanary'
 
@@ -18,7 +19,7 @@ function Get-RitemarkRegistrations {
 
   return @(Get-ChildItem -LiteralPath $uninstallRoot -ErrorAction Stop | ForEach-Object {
     $registration = Get-ItemProperty -LiteralPath $_.PSPath -ErrorAction Stop
-    if ($registration.DisplayName -eq 'Ritemark') {
+    if ($registration.DisplayName -eq 'Ritemark' -or $registration.DisplayName -like 'Ritemark *') {
       [pscustomobject]@{
         KeyName = $_.PSChildName
         Path = $_.PSPath
@@ -33,7 +34,7 @@ function Get-RitemarkRegistrations {
 switch ($mode) {
   'seed-canary' {
     New-Item -Path $canaryKey -Force | Out-Null
-    New-ItemProperty -Path $canaryKey -Name DisplayName -Value 'Ritemark' -PropertyType String -Force | Out-Null
+    New-ItemProperty -Path $canaryKey -Name DisplayName -Value $expectedDisplayName -PropertyType String -Force | Out-Null
     New-ItemProperty -Path $canaryKey -Name Publisher -Value $expectedPublisher -PropertyType String -Force | Out-Null
     New-ItemProperty -Path $canaryKey -Name DisplayVersion -Value $expectedVersion -PropertyType String -Force | Out-Null
   }
@@ -42,22 +43,8 @@ switch ($mode) {
       Remove-Item -LiteralPath $canaryKey -Recurse -Force
     }
   }
-  'verify-installed' {
-    $registrations = @(Get-RitemarkRegistrations)
-    if ($registrations.Count -ne 1) {
-      throw "Expected exactly one Ritemark registration for the current user, found $($registrations.Count)."
-    }
-    if ($registrations[0].Publisher -ne $expectedPublisher -or
-        $registrations[0].DisplayVersion -ne $expectedVersion) {
-      throw 'Installed ProductName, Publisher, or Version is incorrect.'
-    }
-  }
-  'verify-uninstalled' {
-    $registrations = @(Get-RitemarkRegistrations)
-    if ($registrations.Count -ne 0) {
-      throw "Uninstall left $($registrations.Count) Ritemark registration(s) for the current user."
-    }
-  }
+  'verify-installed' {}
+  'verify-uninstalled' {}
   default {
     throw "Unsupported RITEMARK_CI_REGISTRY_MODE: $mode"
   }
@@ -69,7 +56,25 @@ $result = [ordered]@{
   Identity = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
   Count = $registrations.Count
   KeyNames = @($registrations | ForEach-Object { $_.KeyName })
+  DisplayNames = @($registrations | ForEach-Object { $_.DisplayName })
+  Publishers = @($registrations | ForEach-Object { $_.Publisher })
+  DisplayVersions = @($registrations | ForEach-Object { $_.DisplayVersion })
 }
 
 $result | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $resultPath -Encoding utf8NoBOM
 $result | ConvertTo-Json -Depth 4
+
+if ($mode -eq 'verify-installed') {
+  if ($registrations.Count -ne 1) {
+    throw "Expected exactly one Ritemark registration for the current user, found $($registrations.Count)."
+  }
+  if ($registrations[0].DisplayName -ne $expectedDisplayName -or
+      $registrations[0].Publisher -ne $expectedPublisher -or
+      $registrations[0].DisplayVersion -ne $expectedVersion) {
+    throw "Installed registration does not match DisplayName '$expectedDisplayName', Publisher '$expectedPublisher', and DisplayVersion '$expectedVersion'."
+  }
+}
+
+if ($mode -eq 'verify-uninstalled' -and $registrations.Count -ne 0) {
+  throw "Uninstall left $($registrations.Count) Ritemark registration(s) for the current user."
+}

--- a/scripts/windows-standard-user-registry-probe.ps1
+++ b/scripts/windows-standard-user-registry-probe.ps1
@@ -1,0 +1,75 @@
+param()
+
+$ErrorActionPreference = 'Stop'
+
+$mode = $env:RITEMARK_CI_REGISTRY_MODE
+$resultPath = $env:RITEMARK_CI_REGISTRY_RESULT
+$expectedPublisher = $env:RITEMARK_CI_PUBLISHER
+$expectedVersion = $env:RITEMARK_CI_VERSION
+$uninstallRoot = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall'
+$canaryKey = Join-Path $uninstallRoot 'RitemarkCiCanary'
+
+if ([string]::IsNullOrWhiteSpace($resultPath)) {
+  throw 'RITEMARK_CI_REGISTRY_RESULT is required.'
+}
+
+function Get-RitemarkRegistrations {
+  if (-not (Test-Path -LiteralPath $uninstallRoot)) { return @() }
+
+  return @(Get-ChildItem -LiteralPath $uninstallRoot -ErrorAction Stop | ForEach-Object {
+    $registration = Get-ItemProperty -LiteralPath $_.PSPath -ErrorAction Stop
+    if ($registration.DisplayName -eq 'Ritemark') {
+      [pscustomobject]@{
+        KeyName = $_.PSChildName
+        Path = $_.PSPath
+        DisplayName = [string]$registration.DisplayName
+        Publisher = [string]$registration.Publisher
+        DisplayVersion = [string]$registration.DisplayVersion
+      }
+    }
+  })
+}
+
+switch ($mode) {
+  'seed-canary' {
+    New-Item -Path $canaryKey -Force | Out-Null
+    New-ItemProperty -Path $canaryKey -Name DisplayName -Value 'Ritemark' -PropertyType String -Force | Out-Null
+    New-ItemProperty -Path $canaryKey -Name Publisher -Value $expectedPublisher -PropertyType String -Force | Out-Null
+    New-ItemProperty -Path $canaryKey -Name DisplayVersion -Value $expectedVersion -PropertyType String -Force | Out-Null
+  }
+  'remove-canary' {
+    if (Test-Path -LiteralPath $canaryKey) {
+      Remove-Item -LiteralPath $canaryKey -Recurse -Force
+    }
+  }
+  'verify-installed' {
+    $registrations = @(Get-RitemarkRegistrations)
+    if ($registrations.Count -ne 1) {
+      throw "Expected exactly one Ritemark registration for the current user, found $($registrations.Count)."
+    }
+    if ($registrations[0].Publisher -ne $expectedPublisher -or
+        $registrations[0].DisplayVersion -ne $expectedVersion) {
+      throw 'Installed ProductName, Publisher, or Version is incorrect.'
+    }
+  }
+  'verify-uninstalled' {
+    $registrations = @(Get-RitemarkRegistrations)
+    if ($registrations.Count -ne 0) {
+      throw "Uninstall left $($registrations.Count) Ritemark registration(s) for the current user."
+    }
+  }
+  default {
+    throw "Unsupported RITEMARK_CI_REGISTRY_MODE: $mode"
+  }
+}
+
+$registrations = @(Get-RitemarkRegistrations)
+$result = [ordered]@{
+  Mode = $mode
+  Identity = [System.Security.Principal.WindowsIdentity]::GetCurrent().Name
+  Count = $registrations.Count
+  KeyNames = @($registrations | ForEach-Object { $_.KeyName })
+}
+
+$result | ConvertTo-Json -Depth 4 | Set-Content -LiteralPath $resultPath -Encoding utf8NoBOM
+$result | ConvertTo-Json -Depth 4


### PR DESCRIPTION
## Summary
- isolate the Windows standard-user install test from the runner administrator environment
- prove identity, profile paths, working directory, write access, and installer hash before install
- pin product checkout independently from the reviewed workflow revision so Gate 1 Mac artifacts remain valid

## Validation
- ./scripts/validate-qa.sh
- focused Windows workflow tests: 3/3
- YAML parse and Start-Process parameter-set checks

## Release scope
CI/release harness only. Product source remains pinned to the approved canonical commit 8698ce9900ec437067a40eda3f5209f79029786f.