### PR TITLE
fix: preserve trailing newline when saving Markdown without front matter (#254)

### DIFF
--- a/extensions/ritemark/src/editorSync/state.test.ts
+++ b/extensions/ritemark/src/editorSync/state.test.ts
@@ -6,6 +6,7 @@ import {
   classifyAcceptedModelEdit,
   classifyStaleViewEdit,
   classifyThreeWay,
+  ensureTrailingNewline,
   observeLocalSaveReceipts,
   initializeThreeWayState,
   normalizeLogicalText,
@@ -78,6 +79,18 @@ test('an unmatched disk observation retires only receipts it can order after', (
 
 test('logical normalization ignores one BOM and EOL representation', () => {
   assert.equal(normalizeLogicalText('\uFEFFa\r\nb\r'), 'a\nb\n');
+});
+
+test('ensureTrailingNewline appends exactly one newline when the body lacks one', () => {
+  assert.equal(ensureTrailingNewline('- [ ] plain bullet'), '- [ ] plain bullet\n');
+});
+
+test('ensureTrailingNewline is a no-op when the body already ends in a newline', () => {
+  assert.equal(ensureTrailingNewline('# Canary\n\njust a paragraph\n'), '# Canary\n\njust a paragraph\n');
+});
+
+test('ensureTrailingNewline never turns an empty body into a bare newline', () => {
+  assert.equal(ensureTrailingNewline(''), '');
 });
 
 test('canonical JSON sorts nested object keys without reordering arrays', () => {

--- a/extensions/ritemark/src/editorSync/state.ts
+++ b/extensions/ritemark/src/editorSync/state.ts
@@ -90,6 +90,17 @@ export function normalizeLogicalText(content: string): string {
   return content.replace(/^\uFEFF/, '').replace(/\r\n?/g, '\n');
 }
 
+/**
+ * A saved Markdown body always ends in exactly one trailing newline, matching
+ * POSIX/Git conventions. `gray-matter`'s `stringify` already guarantees this
+ * when front matter is present; documents without front matter bypass it and
+ * are written as the editor's Markdown projection verbatim, which never ends
+ * in a newline (Turndown trims all trailing whitespace from its output).
+ */
+export function ensureTrailingNewline(content: string): string {
+  return content.length === 0 || content.endsWith('\n') ? content : `${content}\n`;
+}
+
 export function classifyThreeWay(snapshot: ThreeWaySnapshot): ThreeWaySyncState {
   const diskChanged = snapshot.diskHash !== snapshot.baseDiskHash;
   const modelChanged = snapshot.modelHash !== snapshot.baseModelHash;

--- a/extensions/ritemark/src/ritemarkEditor.ts
+++ b/extensions/ritemark/src/ritemarkEditor.ts
@@ -23,6 +23,7 @@ import {
 } from './workspaceFileLinks';
 import { DocumentSyncCoordinator } from './editorSync/DocumentSyncCoordinator';
 import type { DocumentEditPayload, DocumentRenderPayload, DocumentSyncBootstrap } from './editorSync/protocol';
+import { ensureTrailingNewline } from './editorSync/state';
 import { versionedWebviewAssetUri } from './views/webviewAssetUri';
 
 // Properties type for front-matter
@@ -940,7 +941,7 @@ export class RitemarkEditorProvider implements vscode.CustomTextEditorProvider {
   ): string {
     // If no properties or empty properties, return content only
     if (!properties || Object.keys(properties).length === 0) {
-      return content;
+      return ensureTrailingNewline(content);
     }
 
     // Use gray-matter to stringify with YAML front-matter


### PR DESCRIPTION
## What

`serializeFrontMatter`'s no-properties branch returned the editor's Markdown projection verbatim instead of ensuring it ends in a newline. Adds `ensureTrailingNewline` (in `extensions/ritemark/src/editorSync/state.ts`) and applies it on that path in `ritemarkEditor.ts`.

## Why

Closes #254.

Turndown (the webview's HTML→Markdown serializer) always trims trailing whitespace from its output, so its result never ends in `\n`. When a document has YAML front matter, `gray-matter`'s `stringify()` already re-adds a trailing newline unconditionally — but when a document has no front matter (the common case), `serializeFrontMatter` returned that Turndown output as-is, so any edit-triggered save wrote the file without a final newline.

The issue's repro (toggling a checkbox in a list-ending document) is the case that surfaces it, but the root cause isn't list-specific — it's any front-matter-less document, on any real edit. I confirmed this by reconstructing the exact TipTap→Turndown pipeline (via a headless TipTap editor + the project's actual `turndownService.ts`/`taskListRoundTrip.ts`) and found the produced Markdown lacks a trailing newline regardless of whether the document ends in a list or a plain paragraph. The fix is therefore at the single write boundary (`serializeFrontMatter`) rather than in the list-serialization rules.

## Lifecycle

- **Release:** none
- **Sprint:** none (triage-workflow agent fix)
- **Issues:** closes #254
- **User-facing change:** yes (cosmetic — no more spurious `\ No newline at end of file` git diff on first Ritemark save)
- **Release notes needed:** no (cosmetic fix, consistent with how #254 was scoped)
- **Architecture doc touched/needed:** no

## How to Test

1. Create a `.md` file with no YAML front matter ending in a list, e.g.:
   ```
   # Canary

   - [ ] alpha
   - [x] beta

   - [ ] gamma
     - [ ] nested
   - plain bullet
   ```
2. Open it in Ritemark, toggle any checkbox, save.
3. `tail -c 1 tasks.md | xxd -p` → now `0a` (previously `74`).
4. Regression check: a file *with* front matter properties still round-trips correctly (unchanged behavior, already exercised via `gray-matter`'s `stringify`).

Automated coverage: `extensions/ritemark/src/editorSync/state.test.ts` adds three cases for `ensureTrailingNewline` (appends when missing, no-op when already present, never turns an empty body into a bare newline). Ran via `npm run test:editor-sync` in `extensions/ritemark/` — all passing. Also ran `npx tsc --noEmit -p ./` in `extensions/ritemark/` and `.claude/hooks/pre-commit-validator.sh` — both clean.

## Checklist

- [ ] Release plan tracker updated, if release-bound — n/a, not release-bound
- [x] Linked issues updated/closed/deferred — will close via merge
- [ ] Sprint docs updated — n/a
- [x] Release notes/changelog updated or explicitly not needed — not needed (cosmetic)
- [x] `npx tsc --noEmit` passes in `extensions/ritemark/` when code changed
- [ ] `./scripts/apply-patches.sh --dry-run` shows every patch as "OK (can apply)" when patches changed — n/a, no patch changes
- [x] Changes are in `extensions/ritemark/` (not direct `vscode/` edits) unless patch work is explicit
- [x] No telemetry, tracking, or cloud dependencies added without release-plan approval
- [ ] Commit(s) are signed off (`git commit -s`) per DCO — not signed off; flagging for maintainer awareness

## Screenshots

N/A — no UI change.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012kHBZttVxWCdXGzHWFUf28

---
_Generated by [Claude Code](https://claude.ai/code/session_012kHBZttVxWCdXGzHWFUf28)_